### PR TITLE
Adding NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+connectors
+Copyright 2022 Elasticsearch B.V.


### PR DESCRIPTION
NOTICE.txt will be required to make this repo public.

From discussion with @gtback I've understood, that interpreted languages do not bundle their dependencies, which makes `NOTICE.txt` file simple, not requiring to have notices or licenses of dependencies (see comment https://github.com/elastic/open-source/issues/278#issuecomment-1030174390).

This, our NOTICE.txt will be plain and straightforward.