### PR TITLE
Add connectors_shared.gemspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ lint:
 build:
 	mkdir -p .gems
 	gem build connectors_shared.gemspec
+	gem build sharepoint_connector.gemspec
 	mv *.gem .gems/
 
 install:

--- a/connectors_shared.gemspec
+++ b/connectors_shared.gemspec
@@ -4,21 +4,14 @@ Gem::Specification.new do |s|
   s.name        = 'connectors_shared'
   s.version     = VERSION
   s.summary     = 'Connectors Gem containing shared implementation of apis used by Enterprise Search'
-  s.description = ''
+  s.description = "connectors_shared #{VERSION}"
   s.authors     = ['Elastic']
   s.email       = 'ent-search-dev@elastic.co'
-  s.files       = [
-    'lib/connectors_shared.rb',
-    'lib/connectors_shared/constants.rb',
-    'lib/connectors_shared/errors.rb',
-    'lib/connectors_shared/exception_tracking.rb',
-    'lib/connectors_shared/logger.rb',
-    'lib/connectors_shared/monitor.rb',
-    'LICENSE'
-  ]
-  s.homepage    =
-    'https://elastic.co'
-  s.license       = 'Elastic-2.0'
+  s.files       = Dir['lib/connectors_shared/**/*'].to_a +
+                  Dir['lib/connectors/base/**/*'].to_a <<
+                  'lib/connectors_shared.rb'
+  s.homepage    = 'https://elastic.co'
+  s.license     = 'Elastic-2.0'
 
   # TODO: figure out how to pin versions without harming ent-search repo
   s.add_dependency 'activesupport'

--- a/sharepoint_connector.gemspec
+++ b/sharepoint_connector.gemspec
@@ -1,0 +1,17 @@
+require_relative 'lib/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'sharepoint_connector'
+  s.version     = VERSION
+  s.summary     = 'Gem containing the Sharepoint Connector implementation'
+  s.description = "sharepoint_connector #{VERSION}"
+  s.authors     = ['Elastic']
+  s.email       = 'ent-search-dev@elastic.co'
+  s.files       = Dir['lib/connectors/office365/**/*'].to_a +
+                  Dir['lib/connectors/sharepoint/**/*'].to_a <<
+                  'LICENSE'
+  s.homepage    = 'https://elastic.co'
+  s.license     = 'Elastic-2.0'
+
+  s.add_dependency 'connectors_shared', VERSION
+end


### PR DESCRIPTION
Part of https://github.com/elastic/enterprise-search-team/issues/1237

This adds a new gemspec for `sharepoint_connector`