### PR TITLE
Add Permissions endpoint

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -124,6 +124,13 @@ class ConnectorsWebApp < Sinatra::Base
     json :results => connector.deleted(params['ids'])
   end
 
+  post '/permissions' do
+    params = JSON.parse(request.body.read)
+    connector = ConnectorsSdk::SharePoint::HttpCallWrapper.new(params)
+
+    json :results => connector.permissions(params['user_id'])
+  end
+
   # XXX remove `oauth2` from the name
   post '/oauth2/init' do
     body = JSON.parse(request.body.read, symbolize_names: true)

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -48,6 +48,12 @@ module ConnectorsSdk
         end
         results
       end
+
+      def permissions(user_id)
+        @extractor.yield_permissions(user_id) do |permissions|
+          return permissions
+        end
+      end
     end
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe ConnectorsWebApp do
     end
   end
 
+  describe 'POST /permissions' do
+    let(:params) { { :user_id => 'id', :access_token => 'access token' } }
+
+    it 'returns deleted ids' do
+      allow_any_instance_of(ConnectorsSdk::SharePoint::HttpCallWrapper).to receive(:permissions).and_return(%w[permission1 permission2])
+
+      basic_authorize 'ent-search', api_key
+      response = post('/permissions', JSON.generate(params), { 'CONTENT_TYPE' => 'application/json' })
+      expect(response).to be_successful
+      expect(json(response)['results']).to_not be_empty
+    end
+  end
+
   describe 'POST /oauth2/init' do
     context 'with valid request' do
       let(:params) { { :client_id => 'client id' } }


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/1554
This PR adds `POST /permissions` endpoint to external connector service.