### PR TITLE
Made keys on root more explicit

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -75,9 +75,9 @@ class ConnectorsWebApp < Sinatra::Base
 
   get '/' do
     json(
-      :version => settings.version,
-      :repository => settings.repository,
-      :revision => settings.revision
+      :connectors_version => settings.version,
+      :connectors_repository => settings.repository,
+      :connectors_revision => settings.revision
     )
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -96,7 +96,9 @@ RSpec.describe ConnectorsWebApp do
 
     it 'returns the connectors metadata' do
       expect(response.status).to eq 200
-      expect(json(response)['version']).to eq ConnectorsApp::VERSION
+      expect(json(response)['connectors_version']).to eq ConnectorsApp::VERSION
+      expect(json(response)['connectors_revision']).to eq ConnectorsApp::Config['revision']
+      expect(json(response)['connectors_repository']).to eq ConnectorsApp::Config['repository']
     end
   end
 


### PR DESCRIPTION
### Part of https://github.com/elastic/enterprise-search-team/issues/1239

supports: https://github.com/elastic/ent-search/pull/6304

This allows ent-search to more clearly differentiate between metadata coming back related to the connectors project vs something else