### PR TITLE
Added connector_name to root endpoint

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -5,6 +5,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
+require 'active_support/inflector'
 require 'faraday'
 require 'hashie'
 require 'json'
@@ -79,7 +80,7 @@ class ConnectorsWebApp < Sinatra::Base
       :connectors_version => settings.version,
       :connectors_repository => settings.repository,
       :connectors_revision => settings.revision,
-      :connector_name => settings.http['connector']
+      :connector_name => ActiveSupport::Inflector.camelize(settings.http['connector'])
     )
   end
 

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ConnectorsWebApp do
       expect(json(response)['connectors_version']).to eq ConnectorsApp::VERSION
       expect(json(response)['connectors_revision']).to eq ConnectorsApp::Config['revision']
       expect(json(response)['connectors_repository']).to eq ConnectorsApp::Config['repository']
-      expect(json(response)['connector_name']).to eq ConnectorsApp::Config['http']['connector']
+      expect(json(response)['connector_name']).to eq 'SharePoint'
     end
   end
 


### PR DESCRIPTION
Part of https://github.com/elastic/enterprise-search-team/issues/1239
Builds off of: https://github.com/elastic/connectors/pull/47

Supports: https://github.com/elastic/ent-search/pull/6304

This adds the Connector Name (AKA service_type) to the root endpoint 