### PR TITLE
Fix make run

### DIFF
--- a/lib/app/connector.rb
+++ b/lib/app/connector.rb
@@ -47,7 +47,7 @@ module App
       def create_sync_job_runner
         connector_settings = Framework::ConnectorSettings.fetch(App::Config['connector_package_id'])
 
-        Framework::SyncJobRunner.new(connector_settings)
+        Framework::SyncJobRunner.new(connector_settings, App::Config['service_type'])
       end
     end
   end

--- a/lib/framework/sync_job_runner.rb
+++ b/lib/framework/sync_job_runner.rb
@@ -18,9 +18,9 @@ module Framework
   end
 
   class SyncJobRunner
-    def initialize(connector_settings)
+    def initialize(connector_settings, service_type)
       @connector_settings = connector_settings
-      @connector_instance = Connectors::REGISTRY.connector(@connector_settings.service_type)
+      @connector_instance = Connectors::REGISTRY.connector(service_type)
     end
 
     def execute


### PR DESCRIPTION
Fixing `make run`

Ad-hoc/trivial change and does not have a corresponding
issue.

Reading from app config instead of kibana.

replaces https://github.com/elastic/connectors/pull/148/commits

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
