### PR TITLE
Make display_name and configurable_fields a part of class instead of instance

### DIFF
--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -185,11 +185,12 @@ module App
       id = App::Config['connector_package_id']
 
       connector = current_connector
+      connector_class = connector.class
       current_values = Core::ConnectorSettings.fetch(id)&.configuration
       return unless connector.present?
 
       puts 'Provided configurable fields:'
-      configurable_fields = connector.configurable_fields
+      configurable_fields = connector_class.configurable_fields
       fields = configurable_fields.each_key.map do |key|
         field = configurable_fields[key].with_indifferent_access
         current_value = current_values&.fetch(key, nil)
@@ -210,12 +211,14 @@ module App
       id = App::Config['connector_package_id']
 
       connector = current_connector
+      connector_class = connector.class
+
       current_values = Core::ConnectorSettings.fetch(id)&.configuration
       return unless connector.present?
 
       puts 'Persisted values of configurable fields:'
-      connector.configurable_fields.each_key.each do |key|
-        field = connector.configurable_fields[key].with_indifferent_access
+      connector_class.configurable_fields.each_key.each do |key|
+        field = connector_class.configurable_fields[key].with_indifferent_access
         current_value = current_values&.fetch(key, nil)
         puts "* #{field[:label]} - current value: #{current_value}, default: #{field[:value]}"
       end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -21,8 +21,8 @@ module Connectors
         {}
       end
 
-      def service_type
-        self.class::SERVICE_TYPE
+      def self.service_type
+        raise 'Not implemented for this connector'
       end
 
       def yield_documents(connector_settings); end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -13,6 +13,18 @@ require 'utility/logger'
 module Connectors
   module Base
     class Connector
+      def self.display_name
+        raise 'Not implemented for this connector'
+      end
+
+      def self.configurable_fields
+        {}
+      end
+
+      def service_type
+        self.class::SERVICE_TYPE
+      end
+
       def yield_documents(connector_settings); end
 
       def source_status(params = {})
@@ -20,18 +32,6 @@ module Connectors
         { :status => 'OK', :statusCode => 200, :message => "Connected to #{display_name}" }
       rescue StandardError => e
         { :status => 'FAILURE', :statusCode => e.is_a?(custom_client_error) ? e.status_code : 500, :message => e.message }
-      end
-
-      def display_name
-        raise 'Not implemented for this connector'
-      end
-
-      def service_type
-        self.class::SERVICE_TYPE
-      end
-
-      def configurable_fields
-        {}
       end
     end
   end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -29,7 +29,7 @@ module Connectors
 
       def source_status(params = {})
         health_check(params)
-        { :status => 'OK', :statusCode => 200, :message => "Connected to #{display_name}" }
+        { :status => 'OK', :statusCode => 200, :message => "Connected to #{self.class.display_name}" }
       rescue StandardError => e
         { :status => 'FAILURE', :statusCode => e.is_a?(custom_client_error) ? e.status_code : 500, :message => e.message }
       end

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -17,7 +17,9 @@ require 'app/config'
 module Connectors
   module GitLab
     class Connector < Connectors::Base::Connector
-      SERVICE_TYPE = 'gitlab'
+      def self.service_type
+        'gitlab'
+      end
 
       def self.display_name
         'GitLab Connector'

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -19,20 +19,12 @@ module Connectors
     class Connector < Connectors::Base::Connector
       SERVICE_TYPE = 'gitlab'
 
-      def initialize
-        super()
-        @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => configurable_fields[:base_url][:value],
-          :api_token => configurable_fields[:api_token][:value]
-        )
-      end
-
-      def display_name
+      def self.display_name
         'GitLab Connector'
       end
 
-      def configurable_fields
-        @configurable_fields ||= {
+      def self.configurable_fields
+        {
           :api_token => {
             :label => 'API Token',
             :value => App::Config[:gitlab][:api_token]
@@ -42,6 +34,14 @@ module Connectors
             :value => App::Config[:gitlab][:api_base_url] || Connectors::GitLab::DEFAULT_BASE_URL
           }
         }
+      end
+
+      def initialize
+        super()
+        @extractor = Connectors::GitLab::Extractor.new(
+          :base_url => self.class.configurable_fields[:base_url][:value],
+          :api_token => self.class.configurable_fields[:api_token][:value]
+        )
       end
 
       def yield_documents(_connector_settings)

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -14,11 +14,11 @@ module Connectors
     class Connector < Connectors::Base::Connector
       SERVICE_TYPE = 'mongo'
 
-      def display_name
+      def self.display_name
         'MongoDB'
       end
 
-      def configurable_fields
+      def self.configurable_fields
         {
            :host => {
              :label => 'MongoDB Server Hostname'

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -12,7 +12,9 @@ require 'connectors/base/connector'
 module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
-      SERVICE_TYPE = 'mongo'
+      def self.service_type
+        'mongo'
+      end
 
       def self.display_name
         'MongoDB'

--- a/lib/connectors/registry.rb
+++ b/lib/connectors/registry.rb
@@ -40,13 +40,13 @@ module Connectors
   REGISTRY = Factory.new
 
   require_relative './stub_connector/connector'
-  REGISTRY.register(Connectors::StubConnector::Connector::SERVICE_TYPE, Connectors::StubConnector::Connector)
+  REGISTRY.register(Connectors::StubConnector::Connector.service_type, Connectors::StubConnector::Connector)
 
   # loading plugins (might replace this with a directory scan and conventions on names)
   require_relative './gitlab/connector'
 
-  REGISTRY.register(Connectors::GitLab::Connector::SERVICE_TYPE, Connectors::GitLab::Connector)
+  REGISTRY.register(Connectors::GitLab::Connector.service_type, Connectors::GitLab::Connector)
 
   require_relative 'mongodb/connector'
-  REGISTRY.register(Connectors::MongoDB::Connector::SERVICE_TYPE, Connectors::MongoDB::Connector)
+  REGISTRY.register(Connectors::MongoDB::Connector.service_type, Connectors::MongoDB::Connector)
 end

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -12,7 +12,9 @@ require 'utility'
 module Connectors
   module StubConnector
     class Connector < Connectors::Base::Connector
-      SERVICE_TYPE = 'stub_connector'
+      def self.service_type
+        'stub_connector'
+      end
 
       def self.display_name
         'Stub Connector'

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -14,11 +14,11 @@ module Connectors
     class Connector < Connectors::Base::Connector
       SERVICE_TYPE = 'stub_connector'
 
-      def display_name
+      def self.display_name
         'Stub Connector'
       end
 
-      def configurable_fields
+      def self.configurable_fields
         {
           'foo' => {
             'label' => 'Foo',


### PR DESCRIPTION
Both methods are used as instance methods, while in reality they don't need to have access to the instance of `Connector` class - moreover they can enforce mis-usage of these methods.

Therefore, moving `display_name` and `configurable_fields` to be methods on the instance of class.