### PR TITLE
Make the sync account for files deleted from 3rd-party service between syncs

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -147,7 +147,8 @@ module Core
             :id => pit_id,
             :keep_alive => '1m'
           },
-          :size => page_size
+          :size => page_size,
+          :_source => false
         }
         loop do
           response = client.search(:body => body)

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -136,7 +136,29 @@ module Core
         end
       end
 
-      def fetch_existing_document_ids(index_name)
+      def fetch_document_ids(index_name)
+        result = []
+        page_size = 1000
+        pit_id = client.open_point_in_time(:index => index_name, :keep_alive => '1m', :expand_wildcards => 'all')['id']
+        body = {
+          :query => { :match_all => {} },
+          :sort => [{ :id => { :order => :asc } }],
+          :pit => {
+            :id => pit_id,
+            :keep_alive => '1m'
+          },
+          :size => page_size
+        }
+        loop do
+          response = client.search(:body => body)
+          hits = response['hits']['hits']
+          ids = hits.map { |h| h['_id'] }
+          result += ids
+          body[:search_after] = hits.last['sort']
+          break if hits.size < page_size
+        end
+        client.close_point_in_time(:index => index_name, :body => { :id => pit_id })
+        result
       end
 
       # should only be used in CLI

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -136,8 +136,7 @@ module Core
         end
       end
 
-      def client
-        @client ||= Utility::EsClient.new
+      def fetch_existing_document_ids(index_name)
       end
 
       # should only be used in CLI
@@ -234,6 +233,10 @@ module Core
         }
         client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
         Utility::Logger.info("Successfully updated field #{field_name} connector #{connector_package_id}")
+      end
+
+      def client
+        @client ||= Utility::EsClient.new
       end
     end
   end

--- a/lib/core/output_sink/base_sink.rb
+++ b/lib/core/output_sink/base_sink.rb
@@ -17,6 +17,10 @@ module Core
         raise 'not implemented'
       end
 
+      def delete(_id)
+        raise 'not_implemented'
+      end
+
       def delete_multiple(_ids)
         raise 'not implemented'
       end

--- a/lib/core/output_sink/combined_sink.rb
+++ b/lib/core/output_sink/combined_sink.rb
@@ -27,6 +27,10 @@ module Core::OutputSink
       @sinks.each { |sink| sink.ingest_multiple(documents) }
     end
 
+    def delete(id)
+      @sinks.each { |sink| sink.delete(id) }
+    end
+
     def delete_multiple(ids)
       @sinks.each { |sink| sink.delete_multiple(ids) }
     end

--- a/lib/core/output_sink/console_sink.rb
+++ b/lib/core/output_sink/console_sink.rb
@@ -26,7 +26,7 @@ module Core::OutputSink
     end
 
     def delete(id)
-      print_header 'Deleting single id'
+      print_header "Deleting single id: #{id}"
       Utility::Logger.info id
     end
 

--- a/lib/core/output_sink/console_sink.rb
+++ b/lib/core/output_sink/console_sink.rb
@@ -31,7 +31,7 @@ module Core::OutputSink
     end
 
     def delete_multiple(ids)
-      print_header 'Deleting several ids'
+      print_header "Deleting several ids: #{ids}"
       Utility::Logger.info ids
     end
 

--- a/lib/core/output_sink/console_sink.rb
+++ b/lib/core/output_sink/console_sink.rb
@@ -25,8 +25,13 @@ module Core::OutputSink
       Utility::Logger.info documents
     end
 
+    def delete(id)
+      print_header 'Deleting single id'
+      Utility::Logger.info id
+    end
+
     def delete_multiple(ids)
-      print_header 'Deleting some stuff too'
+      print_header 'Deleting several ids'
       Utility::Logger.info ids
     end
 

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -68,11 +68,6 @@ module Core::OutputSink
 
       @client.bulk(:body => ops)
       Utility::Logger.info "Sent #{ops.size} operations to the index #{index_name}"
-    rescue StandardError => e
-      Utility::Logger.error_with_backtrace(
-        message: "Failed to send operations to the index #{index_name}: #{e.message}",
-        exception: e
-      )
     end
 
     def ready_to_flush?

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -72,9 +72,7 @@ module Core
 
       Utility::Logger.info("Deleting #{ids_to_delete.size} documents from index #{@connector_settings.index_name}")
 
-      ids_to_delete.each do |id_to_delete|
-        @sink.delete(id_to_delete)
-      end
+      @sink.delete_multiple(ids_to_delete)
     rescue StandardError => e
       @status[:error] = e.message
       Utility::ExceptionTracking.log_exception(e)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -34,6 +34,7 @@ module Core
     end
 
     def execute
+      job_id = nil
       unless @connector_settings.configuration_initialized?
         @connector_settings.initialize_configuration(@connector_class.configurable_fields)
       end
@@ -59,7 +60,7 @@ module Core
       job_id = ElasticConnectorActions.claim_job(@connector_settings.id)
 
       incoming_ids = []
-      existing_ids = ElasticConnectorActions.fetch_document_ids(@connector.settings.index_name)
+      existing_ids = ElasticConnectorActions.fetch_document_ids(@connector_settings.index_name)
 
       @connector_instance.yield_documents(@connector_settings) do |document|
         @sink.ingest(document)
@@ -67,12 +68,14 @@ module Core
         @status[:indexed_document_count] += 1
       end
 
-      ids_to_delete = existing_ids.except(incoming_ids)
+      ids_to_delete = existing_ids - incoming_ids.uniq
+
+      Utility::Logger.info("Deleting #{ids_to_delete.size} documents from index #{@connector_settings.index_name}")
 
       ids_to_delete.each do |id_to_delete|
         @sink.delete(id_to_delete)
       end
-      
+
     rescue StandardError => e
       @status[:error] = e.message
       Utility::ExceptionTracking.log_exception(e)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -75,7 +75,6 @@ module Core
       ids_to_delete.each do |id_to_delete|
         @sink.delete(id_to_delete)
       end
-
     rescue StandardError => e
       @status[:error] = e.message
       Utility::ExceptionTracking.log_exception(e)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -34,7 +34,6 @@ module Core
     end
 
     def execute
-      job_id = nil
       unless @connector_settings.configuration_initialized?
         @connector_settings.initialize_configuration(@connector_class.configurable_fields)
       end


### PR DESCRIPTION
Co-authored with @mchernyavskaya 

For now following the simplest way to also account for deletions when syncing the documents from Gitlab and Mongodb.

1. The algorithm is straightforward: before sync, collect the ids of documents that are present in the ingestion index. 
2. When doing the syncs, collect the document ids from the documents that are ingested into the index
3. Compare ids from 1. and 2. and find out which ids are in 1, but not in 2 - these will be the ids to delete.
4. Bulk delete the ids from 3.

While this way is not a perfect one to move forward, it's probably good enough for now.

When we add new connector in future, that has a different model of deleting objects (Office365-related connectors are a good example) OR implement a streamed events sync for Mongo, we will reconsider the current logic.

A good suggested way to move forward was to allow connector return events from the sync, such as:

```
def get_sync_events
  yield :upsert, { :id => 1, :data => { :something => 'something' } }
  yield :delete, { :id => 2 }
end
```

This can be implemented when adding new connectors to the repository later.
