### PR TITLE
Unspecified language_code fallbacks to English

### DIFF
--- a/lib/utility/elasticsearch/index/text_analysis_settings.rb
+++ b/lib/utility/elasticsearch/index/text_analysis_settings.rb
@@ -63,8 +63,8 @@ module Utility
           tokenizer_name: 'icu_tokenizer', folding_filters: %w(icu_folding)
         }.freeze
 
-        def initialize(language_code: DEFAULT_LANGUAGE, analysis_icu: false)
-          @language_code = language_code.to_sym
+        def initialize(language_code: nil, analysis_icu: false)
+          @language_code = (language_code || DEFAULT_LANGUAGE).to_sym
 
           raise UnsupportedLanguageCode unless language_data[@language_code]
 

--- a/spec/utility/elasticsearch/text_analysis_settings_spec.rb
+++ b/spec/utility/elasticsearch/text_analysis_settings_spec.rb
@@ -85,5 +85,16 @@ describe Utility::Elasticsearch::Index::TextAnalysisSettings do
       it { is_expected.to have_key(:"#{language_code}-stop-words-filter") }
       it { is_expected.to have_key(:"#{language_code}-elision") }
     end
+
+    context 'when language_code is nil' do
+      let(:language_code) { nil }
+      let(:analysis_icu) { false }
+      let(:subject) { described_class.new(language_code: language_code, analysis_icu: analysis_icu).to_h }
+
+      it 'fallbacks to english' do
+        english_settings = described_class.new(language_code: :en, analysis_icu: analysis_icu)
+        expect(subject).to eq(english_settings.to_h)
+      end
+    end
   end
 end


### PR DESCRIPTION
Make sure that `Utility::Elasticsearch::Index::TextAnalysisSettings.new(language_code: nil)` fallbacks to English settings
## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally