### PR TITLE
Add a simple heartbeat task implementation

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -47,7 +47,7 @@ module App
           Utility::Logger.debug("Sending heartbeat for the connector")
           Core::ElasticConnectorActions.heartbeat(App::Config['connector_package_id'])
         rescue StandardError => e
-          Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer terminated due to unexpected error.')
+          Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end
 
         task.execute

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -41,7 +41,7 @@ module App
       end
 
       def start_heartbeat_task
-        interval_seconds = 5
+        interval_seconds = 60 # seconds
         Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
         task = Concurrent::TimerTask.new(execution_interval: interval_seconds) do
           Utility::Logger.debug("Sending heartbeat for the connector")

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -41,11 +41,12 @@ module App
       end
 
       def start_heartbeat_task
+        connector_package_id = App::Config['connector_package_id']
         interval_seconds = 60 # seconds
         Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
         task = Concurrent::TimerTask.new(execution_interval: interval_seconds) do
-          Utility::Logger.debug("Sending heartbeat for the connector")
-          Core::ElasticConnectorActions.heartbeat(App::Config['connector_package_id'])
+          Utility::Logger.debug("Sending heartbeat for the connector #{connector_package_id}")
+          Core::ElasticConnectorActions.heartbeat(connector_package_id)
         rescue StandardError => e
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -88,6 +88,16 @@ module Core
         job['_id']
       end
 
+      def heartbeat(connector_package_id)
+        body = {
+          :doc => {
+            :last_seen => Time.now
+          }
+        }
+
+        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
+      end
+
       def update_connector_status(connector_package_id, status)
         body = {
           :doc => {


### PR DESCRIPTION
PR adds a simple task that is started when `App::Worker` starts and sends a heartbeat into `.elastic-connectors` index, updating `last_seen` field to current time.

If something makes the thread crash, it's not restarted - is there a way to handle it better?