### PR TITLE
Fix connector initialisation when connector settings are not set yet

### DIFF
--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -37,7 +37,7 @@ module Connectors
         super
 
         @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => remote_configuration[:base_url][:value],
+          :base_url => remote_configuration.dig(:base_url, :value),
           :api_token => local_configuration[:api_token]
         )
       end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -37,9 +37,9 @@ module Connectors
       def initialize(local_configuration: {}, remote_configuration: {})
         super
 
-        @host = remote_configuration[:host][:value]
-        @database = remote_configuration[:database][:value]
-        @collection = remote_configuration[:collection][:value]
+        @host = remote_configuration.dig(:host, :value)
+        @database = remote_configuration.dig(:database, :value)
+        @collection = remote_configuration.dig(:collection, :value)
       end
 
       def health_check(_params)


### PR DESCRIPTION
Problem: we create an instance of `Connector` even before connector was configured. We also have initialisation in the connectors, for example:

```ruby
        @extractor = Connectors::GitLab::Extractor.new(
          :base_url => remote_configuration[:base_url][:value],
          :api_token => local_configuration[:api_token]
        )
```

Since `remote_configuration` comes from Kibana, when user sets the values, it might not yet be available.

Thus this commit changes such initialisation to use `dig` to not raise errors if config is not fully supplied:

```ruby 
        @extractor = Connectors::GitLab::Extractor.new(
          :base_url => remote_configuration.dig(:base_url, :value),
          :api_token => local_configuration[:api_token]
        )
```