### PR TITLE
Simplify gitlab connector - remove file extraction

### DIFF
--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -43,16 +43,14 @@ module Connectors
       end
 
       def yield_documents
-        yield_projects do |projects_chunk|
-          projects_chunk.each do |project|
-            yield Connectors::GitLab::Adapter.to_es_document(:project, project)
-
-            yield_project_files(projects_chunk) do |files|
-              files.each do |file|
-                yield Connectors::GitLab::Adapter.to_es_document(:file, file)
-              end
+        next_page_link = nil
+        loop do
+          next_page_link = @extractor.yield_projects_page(next_page_link) do |projects_chunk|
+            projects_chunk.each do |project|
+              yield Connectors::GitLab::Adapter.to_es_document(:project, project)
             end
           end
+          break unless next_page_link.present?
         end
       end
 
@@ -67,24 +65,6 @@ module Connectors
       end
 
       def yield_projects(&block)
-        next_page_link = nil
-        loop do
-          next_page_link = @extractor.yield_projects_page(next_page_link, &block)
-          break unless next_page_link.present?
-        end
-      end
-
-      def yield_project_files(projects_chunk)
-        projects_chunk.each_with_index do |project, idx|
-          project = project.with_indifferent_access
-
-          chunk_size = projects_chunk.size
-          Utility::Logger.info("Fetching files for project #{project[:id]} (#{idx + 1} out of #{chunk_size})...")
-
-          files = @extractor.fetch_project_repository_files(project[:id])
-
-          yield files
-        end
       end
     end
   end

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -63,9 +63,6 @@ module Connectors
       def custom_client_error
         Connectors::GitLab::CustomClient::ClientError
       end
-
-      def yield_projects(&block)
-      end
     end
   end
 end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2269

We're simplifying Gitlab connector by removing the file traversal for now - it's only picking up the root of the repository and does not sync file content.

It makes sense to approach this later when we start addressing the attachment/download functionality.