### PR TITLE
Simplify EsSink and flush manually

### DIFF
--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -7,7 +7,6 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/numeric/time'
-require 'concurrent-ruby'
 require 'core/output_sink/base_sink'
 require 'utility/es_client'
 require 'utility/logger'
@@ -16,17 +15,12 @@ module Core::OutputSink
   class EsSink < Core::OutputSink::BaseSink
     attr_accessor :index_name
 
-    def initialize(index_name, flush_threshold = 50, flush_interval = 10.seconds)
+    def initialize(index_name, flush_threshold = 50)
       super()
       @client = Utility::EsClient.new
       @index_name = index_name
       @queue = []
       @flush_threshold = flush_threshold
-      @last_flush = Time.now
-      @flush_task = Concurrent::TimerTask.new(execution_interval: flush_interval) do
-        flush(:size => @queue.size, :force => true)
-      end
-      @flush_task.execute
     end
 
     def ingest(document)
@@ -37,12 +31,12 @@ module Core::OutputSink
       flush if ready_to_flush?
     end
 
-    def flush(size: nil, force: false)
+    def flush(size: nil)
       flush_size = size || @flush_threshold
-      if force || ready_to_flush?
-        data_to_flush = @queue.pop(flush_size)
-        send_data(data_to_flush)
-      end
+
+      data_to_flush = @queue.pop(flush_size)
+
+      send_data(data_to_flush)
     end
 
     def ingest_multiple(documents)

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -34,9 +34,10 @@ module Core::OutputSink
     def flush(size: nil)
       flush_size = size || @flush_threshold
 
-      data_to_flush = @queue.pop(flush_size)
-
-      send_data(data_to_flush)
+      while @queue.any?
+        data_to_flush = @queue.pop(flush_size)
+        send_data(data_to_flush)
+      end
     end
 
     def ingest_multiple(documents)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -62,6 +62,8 @@ module Core
         @sink.ingest(document)
         @status[:indexed_document_count] += 1
       end
+
+      @sink.flush
     rescue StandardError => e
       @status[:error] = e.message
       Utility::ExceptionTracking.log_exception(e)


### PR DESCRIPTION
How EsSink works now:

Every N seconds it tries to automatically flush all the queue of requests into Elasticsearch. It was done to work around the problem, that the last batch of data was never sent to Elasticsearch - `@sink.flush` was never used in the end of sync.

Now with all the refactorings, it's trivial to just call `@sink.flush` in the end of sync in `SyncJobRunner.do_sync!`.

This simplifies the sink design + avoids potential awkward interactions when the timer task to flush is triggered in the middle of actual flush (rare case, nevertheless this is added complexity that can backfire).