### PR TITLE
Make the application actually respect the log level

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -16,9 +16,7 @@ module App
   # Set UTC as the timezone
   ENV['TZ'] = 'UTC'
 
-  logger = Logger.new(STDOUT)
-  logger.level = App::Config['log_level']
-  Utility::Logger.setup!(logger)
+  Utility::Logger.level = App::Config['log_level']
 
   App::Worker.start!
 end

--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -9,10 +9,16 @@
 $LOAD_PATH << '../'
 
 require 'app/worker'
+require 'app/config'
+require 'utility/logger'
 
 module App
   # Set UTC as the timezone
   ENV['TZ'] = 'UTC'
+
+  logger = Logger.new(STDOUT)
+  logger.level = App::Config['log_level']
+  Utility::Logger.setup!(logger)
 
   App::Worker.start!
 end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -19,6 +19,7 @@ require 'cron_parser'
 
 module App
   ENV['TZ'] = 'UTC'
+  Utility::Logger.level = App::Config['log_level']
 
   module ConsoleApp
     extend self

--- a/lib/utility/logger.rb
+++ b/lib/utility/logger.rb
@@ -15,8 +15,8 @@ module Utility
 
       delegate :formatter, :formatter=, :to => :logger
 
-      def setup!(logger)
-        @logger = logger
+      def level=(log_level)
+        logger.level = log_level
       end
 
       def logger


### PR DESCRIPTION
Currently connector app is started always with `log_level: debug` even if you specify different log level.

This PR makes app respect the `log_level` option from the configuration file!