### PR TITLE
Move connector status update to heartbeat

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -44,7 +44,7 @@ module App
         Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
         task = Concurrent::TimerTask.new(execution_interval: interval_seconds) do
           Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
-          Core::ElasticConnectorActions.heartbeat(connector_id, service_type)
+          Core::Heartbeat.send(connector_id, service_type)
         rescue StandardError => e
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -39,11 +39,12 @@ module App
 
       def start_heartbeat_task
         connector_id = App::Config[:connector_id]
+        service_type = App::Config[:service_type]
         interval_seconds = 60 # seconds
         Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
         task = Concurrent::TimerTask.new(execution_interval: interval_seconds) do
           Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
-          Core::ElasticConnectorActions.heartbeat(connector_id)
+          Core::ElasticConnectorActions.heartbeat(connector_id, service_type)
         rescue StandardError => e
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -9,3 +9,4 @@
 require 'core/connector_settings'
 require 'core/sync_job_runner'
 require 'core/elastic_connector_actions'
+require 'core/heartbeat'

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -57,20 +57,6 @@ module Core
       self[:scheduling]
     end
 
-    def configuration_initialized?
-      configuration.present?
-    end
-
-    def initialize_configuration(configuration)
-      # TODO: actually check it on the level lower, so that desync does not happen if configuration was updated elsewhere
-      raise 'Configuration is already initialized!' if configuration_initialized?
-
-      ElasticConnectorActions.update_connector_configuration(id, configuration) # TODO: I don't like that it's hidden here now
-      ElasticConnectorActions.update_connector_status(id, Connectors::ConnectorStatus::NEEDS_CONFIGURATION)
-
-      @elasticsearch_response[:_source][:configuration] = configuration
-    end
-
     private
 
     def initialize(es_response)

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -1,0 +1,35 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'connectors/connector_status'
+require 'connectors/registry'
+
+module Core
+  class Heartbeat
+    class << self
+      def send(connector_id, service_type)
+        connector_settings = Core::ConnectorSettings.fetch(connector_id)
+
+        doc = {
+          :last_seen => Time.now
+        }
+
+        if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
+          connector_class = Connectors::REGISTRY.connector_class(service_type)
+          doc[:configuration] = connector_class.configurable_fields
+          doc[:status] = Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+        elsif connector_settings.connector_status_allows_sync?
+          connector_instance = Connectors::REGISTRY.connector(service_type, connector_settings.configuration)
+          doc[:status] = connector_instance.source_status[:status] == 'OK' ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR
+        end
+
+        ElasticConnectorActions.update_connector_fields(connector_id, doc)
+      end
+    end
+  end
+end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -35,17 +35,13 @@ module Core
     end
 
     def execute
-      unless @connector_settings.configuration_initialized?
-        @connector_settings.initialize_configuration(@connector_class.configurable_fields)
-      end
-
-      validate_configuration!
-
       unless @connector_settings.connector_status_allows_sync?
         Utility::Logger.info("Connector #{@connector_settings.id} is in status \"#{@connector_settings.connector_status}\" and won't sync yet. Connector needs to be in one of the following statuses: #{Connectors::ConnectorStatus::STATUSES_ALLOWING_SYNC} to run.")
 
         return
       end
+
+      validate_configuration!
 
       do_sync! if should_sync?
     end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -58,7 +58,7 @@ module Core
       incoming_ids = []
       existing_ids = ElasticConnectorActions.fetch_document_ids(@connector_settings.index_name)
 
-      Utility::Logger.debug("#{existing_ids} documents are present in index #{@connector_settings.index_name}.")
+      Utility::Logger.debug("#{existing_ids.size} documents are present in index #{@connector_settings.index_name}.")
 
       @connector_instance.yield_documents do |document|
         @sink.ingest(document)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -47,15 +47,6 @@ module Core
         return
       end
 
-      if @connector_instance.source_status[:status] != 'OK'
-        Utility::Logger.error("Connector #{@connector_settings.id} was unable to reach out to the 3rd-party service. Make sure that it has been configured correctly and 3rd-party system is accessible.")
-        ElasticConnectorActions.update_connector_status(@connector_settings.id, Connectors::ConnectorStatus::ERROR)
-
-        return
-      end
-
-      ElasticConnectorActions.update_connector_status(@connector_settings.id, Connectors::ConnectorStatus::CONNECTED)
-
       do_sync! if should_sync?
     end
 


### PR DESCRIPTION
Several changes:
1. Move the connector status to heartbeat
2. ~Fix a bug in method `fetch_document_ids`~
3. ~Fix a name typo in `es_sink.rb`~
4. Move the configuration update to heartbeat

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally