### PR TITLE
Fix little bug with collecting existing document ids

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -155,8 +155,8 @@ module Core
           hits = response['hits']['hits']
           ids = hits.map { |h| h['_id'] }
           result += ids
-          body[:search_after] = hits.last['sort']
           break if hits.size < page_size
+          body[:search_after] = hits.last['sort']
         end
         client.close_point_in_time(:index => index_name, :body => { :id => pit_id })
         result


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2359

Problem happens when collecting ids of existing documents:

```
I, [2022-07-22T08:33:12.833639 #60375]  INFO -- : Starting to sync for connector 
I, [2022-07-22T08:33:12.950587 #60375]  INFO -- : Successfully claimed job for connector XXkIJYIBUQOC5cAY4OMF
E, [2022-07-22T08:33:12.953943 #60375] ERROR -- : Traceback (most recent call last):
        10: from app.rb:15:in `<main>'
         9: from app.rb:21:in `<module:App>'
         8: from /Users/sanderphilipse/development/elastic/connectors/lib/app/worker.rb:26:in `start!'
         7: from /Users/sanderphilipse/development/elastic/connectors/lib/app/worker.rb:58:in `start_polling_jobs'
         6: from /Users/sanderphilipse/development/elastic/connectors/lib/app/worker.rb:58:in `loop'
         5: from /Users/sanderphilipse/development/elastic/connectors/lib/app/worker.rb:60:in `block in start_polling_jobs'
         4: from /Users/sanderphilipse/development/elastic/connectors/lib/core/sync_job_runner.rb:59:in `execute'
         3: from /Users/sanderphilipse/development/elastic/connectors/lib/core/sync_job_runner.rb:70:in `do_sync!'
         2: from /Users/sanderphilipse/development/elastic/connectors/lib/core/elastic_connector_actions.rb:153:in `fetch_document_ids'
         1: from /Users/sanderphilipse/development/elastic/connectors/lib/core/elastic_connector_actions.rb:153:in `loop'
/Users/sanderphilipse/development/elastic/connectors/lib/core/elastic_connector_actions.rb:158:in `block in fetch_document_ids': undefined method `[]' for nil:NilClass (NoMethodError)
```

It happens because when the page with no results is returned, `hits.last` is null.