### PR TITLE
Fix a typo in variable name

### DIFF
--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -40,7 +40,7 @@ module Core::OutputSink
     def flush(size: nil)
       flush_size = size || @flush_threshold
 
-      while @queue.any?
+      while @operation_queue.any?
         data_to_flush = @operation_queue.pop(flush_size)
         send_data(data_to_flush)
       end


### PR DESCRIPTION
Problem that happened with a rebase:

EsSink class contains an `@operation_queue`, but in `def flush` code attempts to use `@queue`. It's a typo. 