### PR TITLE
Add simple validation for gitlab configuration

### DIFF
--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -15,6 +15,8 @@ require 'core/output_sink'
 
 module Connectors
   module GitLab
+    class InvalidConfigurationError < StandardError; end
+
     class Connector < Connectors::Base::Connector
       def self.service_type
         'gitlab'
@@ -36,9 +38,11 @@ module Connectors
       def initialize(local_configuration: {}, remote_configuration: {})
         super
 
+        raise InvalidConfigurationError.new("Configuration section \"#{self.class.service_type}\" is required but not provided.") if !local_configuration
+
         @extractor = Connectors::GitLab::Extractor.new(
           :base_url => remote_configuration.dig(:base_url, :value),
-          :api_token => local_configuration[:api_token]
+          :api_token => local_configuration.dig(:api_token)
         )
       end
 

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -38,11 +38,11 @@ module Connectors
       def initialize(local_configuration: {}, remote_configuration: {})
         super
 
-        raise InvalidConfigurationError.new("Configuration section \"#{self.class.service_type}\" is required but not provided.") if !local_configuration
+        raise InvalidConfigurationError.new("Configuration section \"#{self.class.service_type}\" is required but not provided.") unless local_configuration
 
         @extractor = Connectors::GitLab::Extractor.new(
           :base_url => remote_configuration.dig(:base_url, :value),
-          :api_token => local_configuration.dig(:api_token)
+          :api_token => local_configuration[:api_token]
         )
       end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2360

Problem:

We have a configuration file validation that depends on itself when creating validation rules.

For instance, if connector is `gitlab`, we want to make sure that the following section is available in the configuration file:

```yaml
gitlab:
  api_token: <some_api_token>
```

We cannot do it now, because we also need to parse and validate `service_type` before actually adding this validator. It's a tough problem and we'll need to have a systematic approach for it. In future we'll probably not have any connector-specific configuration in config files any more, and all config will be available from Elasticsearch.

However for now, we want to indicate that configuration is required for `gitlab` connector to run (other connectors don't need it).

This PR is an attempt to provide a quick fix for the outlined problem, it's far from perfection and I'm not quite happy with it.