### PR TITLE
Remove AppConfig.connectors_logger method and everything connected to it

### DIFF
--- a/lib/stubs/app_config.rb
+++ b/lib/stubs/app_config.rb
@@ -4,8 +4,6 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-require 'logger'
-
 class AppConfig
   class << self
     def connectors

--- a/lib/stubs/app_config.rb
+++ b/lib/stubs/app_config.rb
@@ -8,10 +8,6 @@ require 'logger'
 
 class AppConfig
   class << self
-    def connectors_logger
-      Logger.new(STDOUT)
-    end
-
     def connectors
       {
         'transient_server_error_retry_delay_minutes' => 5

--- a/lib/utility/logger.rb
+++ b/lib/utility/logger.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-require 'stubs/app_config' unless defined?(Rails)
+require 'logger'
 require 'active_support/core_ext/module'
 
 module Utility
@@ -20,7 +20,7 @@ module Utility
       end
 
       def logger
-        @logger ||= AppConfig.connectors_logger
+        @logger ||= ::Logger.new(STDOUT)
       end
 
       SUPPORTED_LOG_LEVELS.each do |level|


### PR DESCRIPTION
Does not seem to be needed any more - inlined usage of `AppConfig.connectors_logger` to the only place that used it.