### PR TITLE
Improve PIT handling

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -137,28 +137,35 @@ module Core
       end
 
       def fetch_document_ids(index_name)
-        result = []
         page_size = 1000
-        pit_id = client.open_point_in_time(:index => index_name, :keep_alive => '1m', :expand_wildcards => 'all')['id']
-        body = {
-          :query => { :match_all => {} },
-          :sort => [{ :id => { :order => :asc } }],
-          :pit => {
-            :id => pit_id,
-            :keep_alive => '1m'
-          },
-          :size => page_size,
-          :_source => false
-        }
-        loop do
-          response = client.search(:body => body)
-          hits = response['hits']['hits']
-          ids = hits.map { |h| h['_id'] }
-          result += ids
-          break if hits.size < page_size
-          body[:search_after] = hits.last['sort']
+        result = []
+        begin
+          pit_id = client.open_point_in_time(:index => index_name, :keep_alive => '1m', :expand_wildcards => 'all')['id']
+          body = {
+            :query => { :match_all => {} },
+            :sort => [{ :id => { :order => :asc } }],
+            :pit => {
+              :id => pit_id,
+              :keep_alive => '1m'
+            },
+            :size => page_size,
+            :_source => false
+          }
+          loop do
+            response = client.search(:body => body)
+            hits = response['hits']['hits']
+
+            ids = hits.map { |h| h['_id'] }
+            result += ids
+            break if hits.size < page_size
+
+            body[:search_after] = hits.last['sort']
+            body[:pit] = response['pit_id']
+          end
+        ensure
+          client.close_point_in_time(:index => index_name, :body => { :id => pit_id })
         end
-        client.close_point_in_time(:index => index_name, :body => { :id => pit_id })
+
         result
       end
 

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -160,7 +160,7 @@ module Core
             break if hits.size < page_size
 
             body[:search_after] = hits.last['sort']
-            body[:pit] = response['pit_id']
+            body[:pit][:id] = response['pit_id']
           end
         ensure
           client.close_point_in_time(:index => index_name, :body => { :id => pit_id })


### PR DESCRIPTION
PR addressing comments in https://github.com/elastic/connectors-ruby/pull/174#pullrequestreview-1048305962:

1. Set `pit.id` to new `pit_id` that is returned with each query. Functionally it should not change anything, it's more of a safeguard in case Elasticsearch sends back new PIT Id.
2. Move `client.close_point_in_time(:index => index_name, :body => { :id => pit_id })` to `ensure` statement to attempt to close PIT once error happens in the method. This will help us clean up PIT before they expire.