### PR TITLE
Change logging a bit to log better and more versatile.

### DIFF
--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -49,7 +49,7 @@ module App
       return unless connector_registered?
       puts 'Initiating synchronization NOW...'
       Core::ElasticConnectorActions.force_sync(connector_id)
-      puts "Successfully scheduled an on-demand sync for connector #{connector_id}"
+      puts "Successfully synced for connector #{connector_id}"
 
       Core::ElasticConnectorActions.ensure_connectors_index_exists
       config_settings = Core::ConnectorSettings.fetch(connector_id)

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -49,6 +49,7 @@ module App
       return unless connector_registered?
       puts 'Initiating synchronization NOW...'
       Core::ElasticConnectorActions.force_sync(connector_id)
+      puts "Successfully scheduled an on-demand sync for connector #{connector_id}"
 
       Core::ElasticConnectorActions.ensure_connectors_index_exists
       config_settings = Core::ConnectorSettings.fetch(connector_id)
@@ -111,6 +112,7 @@ module App
         return
       end
       Core::ElasticConnectorActions.enable_connector_scheduling(connector_id, cron_expression)
+      puts "Enabled scheduling for connector #{connector_id} with cron expression #{cron_expression}"
     end
 
     def disable_scheduling
@@ -118,6 +120,7 @@ module App
       puts "Are you sure you want to disable scheduling for connector #{connector_id}? (y/n)"
       return unless gets.chomp.strip.casecmp('y').zero?
       Core::ElasticConnectorActions.disable_connector_scheduling(connector_id)
+      puts "Disabled scheduling for connector #{connector_id}"
     end
 
     def connector_registered?(warn_if_not: true)
@@ -133,6 +136,7 @@ module App
 
       if connector_settings.nil? || force
         created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config['service_type'])
+        puts "Successfully registered connector #{index_name} with ID #{created_id}"
         connector_settings = Core::ConnectorSettings.fetch(created_id)
       end
 
@@ -199,6 +203,7 @@ module App
       puts 'Please enter the new value:'
       new_value = gets.chomp.strip
       Core::ElasticConnectorActions.set_configurable_field(connector_id, field_name, field_label, new_value)
+      Utility::Logger.debug("Successfully updated field #{field_name} for connector #{connector_id} to #{new_value}")
     end
 
     def read_configurable_fields

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -52,13 +52,13 @@ module App
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end
 
-        Utility::Logger.info("Successfully started heartbeat task.")
+        Utility::Logger.info('Successfully started heartbeat task.')
 
         task.execute
       end
 
       def start_polling_jobs
-        Utility::Logger.info("Polling Elasticsearch for synchronisation jobs to run.")
+        Utility::Logger.info('Polling Elasticsearch for synchronisation jobs to run.')
         loop do
           job_runner = create_sync_job_runner
           job_runner.execute

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -19,9 +19,10 @@ module App
 
     class << self
       def start!
+        Utility::Logger.info('Running pre-flight check.')
         pre_flight_check
 
-        Utility::Logger.info('Starting to process jobs...')
+        Utility::Logger.info('Starting connector service workers.')
         start_heartbeat_task
         start_polling_jobs
       end
@@ -51,10 +52,13 @@ module App
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end
 
+        Utility::Logger.info("Successfully started heartbeat task.")
+
         task.execute
       end
 
       def start_polling_jobs
+        Utility::Logger.info("Polling Elasticsearch for synchronisation jobs to run.")
         loop do
           job_runner = create_sync_job_runner
           job_runner.execute
@@ -62,7 +66,7 @@ module App
           Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
         ensure
           if POLL_IDLING > 0
-            Utility::Logger.info("Sleeping for #{POLL_IDLING} seconds")
+            Utility::Logger.info("Sleeping for #{POLL_IDLING} seconds.")
             sleep(POLL_IDLING)
           end
         end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -36,8 +36,7 @@ module Core
           :service_type => service_type
         }
         response = client.index(:index => CONNECTORS_INDEX, :body => body)
-        created_id = response['_id']
-        created_id
+        response['_id']
       end
 
       def load_connector_settings(connector_id)

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -27,7 +27,6 @@ module Core
           }
         }
         client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
-        Utility::Logger.info("Successfully pushed sync_now flag for connector #{connector_id}")
       end
 
       def create_connector(index_name, service_type)
@@ -38,7 +37,6 @@ module Core
         }
         response = client.index(:index => CONNECTORS_INDEX, :body => body)
         created_id = response['_id']
-        Utility::Logger.info("Successfully registered connector #{index_name} with ID #{created_id}")
         created_id
       end
 
@@ -84,7 +82,6 @@ module Core
         }
         job = client.index(:index => JOB_INDEX, :body => body)
 
-        Utility::Logger.info("Successfully claimed job for connector #{connector_id}")
         job['_id']
       end
 
@@ -128,12 +125,6 @@ module Core
           }.merge(status)
         }
         client.update(:index => JOB_INDEX, :id => job_id, :body => body)
-
-        if status[:error]
-          Utility::Logger.info("Failed to sync for connector #{connector_id} with error #{status[:error]}")
-        else
-          Utility::Logger.info("Successfully synced for connector #{connector_id}")
-        end
       end
 
       def fetch_document_ids(index_name)
@@ -181,23 +172,23 @@ module Core
       # should only be used in CLI
       def ensure_index_exists(index_name, body = {})
         if client.indices.exists?(:index => index_name)
-          Utility::Logger.info("Index #{index_name} already exists. Checking mappings...")
+          Utility::Logger.debug("Index #{index_name} already exists. Checking mappings...")
           response = client.indices.get_mapping(:index => index_name)
           existing = response[index_name]['mappings']
-          Utility::Logger.info("New settings/mappings: #{body}")
+          Utility::Logger.debug("New settings/mappings: #{body}")
           if existing.empty?
-            Utility::Logger.info("Index #{index_name} has no mappings. Closing to create settings and mappings...")
+            Utility::Logger.debug("Index #{index_name} has no mappings. Closing to create settings and mappings...")
             client.indices.close(:index => index_name)
             client.indices.put_settings(:index => index_name, :body => body[:settings], :expand_wildcards => 'all')
             client.indices.put_mapping(:index => index_name, :body => body[:mappings], :expand_wildcards => 'all')
             client.indices.open(:index => index_name)
-            Utility::Logger.info("Index #{index_name} mappings added. Index reopened.")
+            Utility::Logger.debug("Index #{index_name} mappings added. Index reopened.")
           else
-            Utility::Logger.info("Index #{index_name} already has mappings: #{existing}. Skipping...")
+            Utility::Logger.debug("Index #{index_name} already has mappings: #{existing}. Skipping...")
           end
         else
           client.indices.create(:index => index_name, :body => body)
-          Utility::Logger.info("Created index #{index_name}")
+          Utility::Logger.debug("Created index #{index_name}")
         end
       end
 
@@ -262,7 +253,6 @@ module Core
           }
         }
         client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
-        Utility::Logger.info("Successfully updated field #{field_name} connector #{connector_id}")
       end
 
       def client

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -47,12 +47,12 @@ module Core::OutputSink
     end
 
     def ingest_multiple(documents)
-      Utility::Logger.info "Enqueueing #{documents&.size} documents to the index #{index_name}"
+      Utility::Logger.debug "Enqueueing #{documents&.size} documents to the index #{index_name}."
       documents.each { |doc| ingest(doc) }
     end
 
     def delete_multiple(ids)
-      Utility::Logger.info "Enqueueing #{ids&.size} ids to delete from the index #{index_name}"
+      Utility::Logger.debug "Enqueueing #{ids&.size} ids to delete from the index #{index_name}."
       ids.each { |id| delete(id) }
     end
 
@@ -62,7 +62,7 @@ module Core::OutputSink
       return if ops.empty?
 
       @client.bulk(:body => ops)
-      Utility::Logger.info "Sent #{ops.size} operations to the index #{index_name}"
+      Utility::Logger.info "Applied #{ops.size} upsert/delete operations to the index #{index_name}."
     end
 
     def ready_to_flush?

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -16,8 +16,8 @@ require 'utility'
 
 module Core
   class IncompatibleConfigurableFieldsError < StandardError
-    def initialize(expected_fields, actual_fields)
-      super("Connector expected configurable fields: #{expected_fields}, actual stored fields: #{actual_fields}")
+    def initialize(service_type, expected_fields, actual_fields)
+      super("Connector of service_type '#{service_type}' expected configurable fields: #{expected_fields}, actual stored fields: #{actual_fields}")
     end
   end
 
@@ -110,7 +110,7 @@ module Core
       expected_fields = @connector_class.configurable_fields.keys.map(&:to_s).sort
       actual_fields = @connector_settings.configuration.keys.map(&:to_s).sort
 
-      raise IncompatibleConfigurableFieldsError.new(expected_fields, actual_fields) if expected_fields != actual_fields
+      raise IncompatibleConfigurableFieldsError.new(@connector_class.service_type, expected_fields, actual_fields) if expected_fields != actual_fields
     end
 
     def cron_parser(cronline)


### PR DESCRIPTION
Various logging improvements:

1. ElasticConnectorActions do not do any `info` logs any more - only debug. Callers of ElasticConnectorActions now do logging instead in a way they need to.
2. Moved some messages from "info" to "debug"
3. Added summary logging lines in the end of sync that specify number of added/deleted docs.
4. Added a dot in the end of every log line I've found