### PR TITLE
Update system indices settings

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -195,7 +195,9 @@ module Core
         body = {
           :settings => {
             :index => {
-              :hidden => true
+              :hidden => true,
+              :number_of_replicas => 0,
+              :auto_expand_replicas => '0-5'
             }
           }
         }


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2199

Set the following settings for system indices `.elastic-connectors` and `.elastic-connectors-sync-jobs`

```
        "auto_expand_replicas": "0-3",
        "number_of_replicas": "0",
```

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally