### PR TITLE
Update App::Config key to symbol

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -2,14 +2,14 @@ require_relative 'lib/app/config'
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_utility'
-  s.version     = App::Config['version']
+  s.version     = App::Config[:version]
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing shared Connector Services libraries'
   s.description = ''
   s.authors     = ['Elastic']
   s.metadata    = {
-    "revision" => App::Config['revision'],
-    "repository" => App::Config['repository']
+    "revision" => App::Config[:revision],
+    "repository" => App::Config[:repository]
   }
   s.email       = 'ent-search-dev@elastic.co'
   s.files       = %w[

--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -16,7 +16,7 @@ module App
   # Set UTC as the timezone
   ENV['TZ'] = 'UTC'
 
-  Utility::Logger.level = App::Config['log_level']
+  Utility::Logger.level = App::Config[:log_level]
 
   App::Worker.start!
 end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -19,7 +19,7 @@ require 'cron_parser'
 
 module App
   ENV['TZ'] = 'UTC'
-  Utility::Logger.level = App::Config['log_level']
+  Utility::Logger.level = App::Config[:log_level]
 
   module ConsoleApp
     extend self
@@ -135,6 +135,7 @@ module App
       connector_settings = Core::ConnectorSettings.fetch(connector_id)
 
       if connector_settings.nil? || force
+        created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config[:service_type])
         created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config['service_type'])
         puts "Successfully registered connector #{index_name} with ID #{created_id}"
         connector_settings = Core::ConnectorSettings.fetch(created_id)
@@ -160,7 +161,7 @@ module App
 
     def current_connector
       connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
-      service_type = App::Config['service_type']
+      service_type = App::Config[:service_type]
       if service_type.present?
         return registry.connector(service_type, connector_settings.configuration)
       end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -136,7 +136,6 @@ module App
 
       if connector_settings.nil? || force
         created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config[:service_type])
-        created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config['service_type'])
         puts "Successfully registered connector #{index_name} with ID #{created_id}"
         connector_settings = Core::ConnectorSettings.fetch(created_id)
       end

--- a/lib/app/initializers/02_log_level.rb
+++ b/lib/app/initializers/02_log_level.rb
@@ -10,6 +10,6 @@ require 'app/config'
 require 'utility/logger'
 
 logger = AppConfig.connectors_logger
-logger.level = App::Config['log_level'] || 'info'
+logger.level = App::Config[:log_level] || 'info'
 
 Utility::Logger.setup!(logger)

--- a/lib/app/version.rb
+++ b/lib/app/version.rb
@@ -6,5 +6,5 @@
 require 'app/config'
 
 module App
-  VERSION = App::Config['version']
+  VERSION = App::Config[:version]
 end

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -15,7 +15,7 @@ require 'concurrent'
 
 module App
   module Worker
-    POLL_IDLING = (App::Config['idle_timeout'] || 60).to_i
+    POLL_IDLING = (App::Config[:idle_timeout] || 60).to_i
 
     class << self
       def start!
@@ -30,7 +30,7 @@ module App
       private
 
       def pre_flight_check
-        raise "#{App::Config['service_type']} is not a supported connector" unless Connectors::REGISTRY.registered?(App::Config['service_type'])
+        raise "#{App::Config[:service_type]} is not a supported connector" unless Connectors::REGISTRY.registered?(App::Config[:service_type])
         Core::ElasticConnectorActions.ensure_connectors_index_exists
         Core::ElasticConnectorActions.ensure_job_index_exists
         connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
@@ -75,7 +75,7 @@ module App
       def create_sync_job_runner
         connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
 
-        Core::SyncJobRunner.new(connector_settings, App::Config['service_type'])
+        Core::SyncJobRunner.new(connector_settings, App::Config[:service_type])
       end
     end
   end

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -25,12 +25,12 @@ module Utility
     end
 
     def connection_configs
-      es_config = App::Config['elasticsearch']
-      configs = { :api_key => es_config['api_key'] }
-      if es_config['cloud_id']
-        configs[:cloud_id] = es_config['cloud_id']
-      elsif es_config['hosts']
-        configs[:hosts] = es_config['hosts']
+      es_config = App::Config[:elasticsearch]
+      configs = { :api_key => es_config[:api_key] }
+      if es_config[:cloud_id]
+        configs[:cloud_id] = es_config[:cloud_id]
+      elsif es_config[:hosts]
+        configs[:hosts] = es_config[:hosts]
       else
         raise 'Either elasticsearch.cloud_id or elasticsearch.hosts should be configured.'
       end

--- a/spec/app/worker_spec.rb
+++ b/spec/app/worker_spec.rb
@@ -10,7 +10,7 @@ require 'app/worker'
 
 describe App::Worker do
   it 'should raise error for invalid service type' do
-    allow(App::Config).to receive(:[]).with('service_type').and_return('foobar')
+    allow(App::Config).to receive(:[]).with(:service_type).and_return('foobar')
     allow(Connectors::REGISTRY).to receive(:connector_class).and_return(nil)
     expect { described_class.start! }.to raise_error('foobar is not a supported connector')
   end


### PR DESCRIPTION
There are mixed uses of symbol and string for the key of `App::Config`. This PR makes it consistent to use symbol.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally