### PR TITLE
Start tracking :deleted_document_count

### DIFF
--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -83,7 +83,11 @@ module Core
 
       Utility::Logger.info("Deleting #{ids_to_delete.size} documents from index #{@connector_settings.index_name}.")
 
-      @sink.delete_multiple(ids_to_delete)
+      ids_to_delete.each do |id|
+        @sink.delete(id)
+        @status[:deleted_document_count] += 1
+      end
+
       @sink.flush
     rescue StandardError => e
       @status[:error] = e.message


### PR DESCRIPTION
As of now when a sync job runs we define `@status[:deleted_document_count] = 0` but never update it. 

This PR fixes it, allowing to track number of documents deleted by the sync job with every run 