### PR TITLE
The cron is using the quartz syntax

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -77,7 +77,7 @@ This is our main communication index, used to communicate the connector's config
   last_sync_status: string;  -> last sync Enum, see below
   scheduling: {
     enabled: boolean; -> Is sync schedule enabled?
-    interval: string; -> cron syntax
+    interval: string; -> Quartz Cron syntax
   };
   service_type: string; -> Optional, used for UI sugar
   status: string;       -> Enum, see below


### PR DESCRIPTION
Follow up from https://github.com/elastic/connectors-ruby/pull/211

The BYOC uses Quartz Cron syntax