### PR TITLE
Remove analyzer settings for content index

### DIFF
--- a/config/connectors.yml.example
+++ b/config/connectors.yml.example
@@ -13,10 +13,3 @@ service_type: "CHANGEME"
 log_level: info
 
 idle_timeout: 60
-
-# ICU Analysis Plugin is used (false by default)
-# turn this on if the ICU plugin - International Components for Unicode - is installed in your Elasticsearch instance
-# see https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html
-use_analysis_icu: false
-# language code to use for the content indices
-content_language_code: en

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -53,11 +53,7 @@ module App
 
       Core::ElasticConnectorActions.ensure_connectors_index_exists
       config_settings = Core::ConnectorSettings.fetch(connector_id)
-      Core::ElasticConnectorActions.ensure_content_index_exists(
-        config_settings[:index_name],
-        App::Config[:use_analysis_icu],
-        App::Config[:content_language_code]
-      )
+      Core::ElasticConnectorActions.ensure_content_index_exists(config_settings[:index_name])
       Core::SyncJobRunner.new(config_settings, App::Config[:service_type]).execute
     end
 

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -34,11 +34,7 @@ module App
         Core::ElasticConnectorActions.ensure_connectors_index_exists
         Core::ElasticConnectorActions.ensure_job_index_exists
         connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
-        Core::ElasticConnectorActions.ensure_content_index_exists(
-          connector_settings.index_name,
-          App::Config[:use_analysis_icu],
-          App::Config[:content_language_code]
-        )
+        Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
       end
 
       def start_heartbeat_task


### PR DESCRIPTION
Remove the analyzer settings for the content index from the connector service, which should be set by Kibana when the index is created.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally