### PR TITLE
Fix usage of cron parser for console_app.rb

### DIFF
--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -15,7 +15,7 @@ require 'app/worker'
 require 'utility/logger'
 require 'core/elastic_connector_actions'
 require 'core/connector_settings'
-require 'cron_parser'
+require 'fugit'
 
 module App
   ENV['TZ'] = 'UTC'
@@ -87,7 +87,7 @@ module App
     end
 
     def validate_cronline(cronline)
-      CronParser.new(cronline)
+      Fugit::Cron.do_parse(cronline)
       true
     rescue ArgumentError
       false

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -13,6 +13,7 @@ require 'connectors/registry'
 require 'app/menu'
 require 'app/worker'
 require 'utility/logger'
+require 'utility/cron'
 require 'core/elastic_connector_actions'
 require 'core/connector_settings'
 require 'fugit'
@@ -87,7 +88,7 @@ module App
     end
 
     def validate_cronline(cronline)
-      Fugit::Cron.do_parse(cronline)
+      Fugit::Cron.do_parse(Utility::Cron.quartz_to_crontab(cronline))
       true
     rescue ArgumentError
       false
@@ -104,7 +105,7 @@ module App
       end
       cron_expression = gets.chomp.strip.downcase
       unless validate_cronline(cron_expression)
-        puts "Cron expression #{cron_expression} isn't valid!"
+        puts "Quartz Cron expression #{cron_expression} isn't valid!"
         return
       end
       Core::ElasticConnectorActions.enable_connector_scheduling(connector_id, cron_expression)

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -88,10 +88,7 @@ module App
     end
 
     def validate_cronline(cronline)
-      Fugit::Cron.do_parse(Utility::Cron.quartz_to_crontab(cronline))
-      true
-    rescue ArgumentError
-      false
+      !!Fugit::Cron.parse(Utility::Cron.quartz_to_crontab(cronline))
     end
 
     def enable_scheduling


### PR DESCRIPTION
Fixes a problem with switching to `fugit` - `console_app.rb` was still using old `cron_parser` package to validate the cron statements.

Also make sure that the entered cron expression is a Quartz Cron one.