### PR TITLE
[8.4] Move connector status update to heartbeat (#198)

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -39,11 +39,12 @@ module App
 
       def start_heartbeat_task
         connector_id = App::Config[:connector_id]
+        service_type = App::Config[:service_type]
         interval_seconds = 60 # seconds
         Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
         task = Concurrent::TimerTask.new(execution_interval: interval_seconds) do
           Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
-          Core::ElasticConnectorActions.heartbeat(connector_id)
+          Core::Heartbeat.send(connector_id, service_type)
         rescue StandardError => e
           Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
         end

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -9,3 +9,4 @@
 require 'core/connector_settings'
 require 'core/sync_job_runner'
 require 'core/elastic_connector_actions'
+require 'core/heartbeat'

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -57,20 +57,6 @@ module Core
       self[:scheduling]
     end
 
-    def configuration_initialized?
-      configuration.present?
-    end
-
-    def initialize_configuration(configuration)
-      # TODO: actually check it on the level lower, so that desync does not happen if configuration was updated elsewhere
-      raise 'Configuration is already initialized!' if configuration_initialized?
-
-      ElasticConnectorActions.update_connector_configuration(id, configuration) # TODO: I don't like that it's hidden here now
-      ElasticConnectorActions.update_connector_status(id, Connectors::ConnectorStatus::NEEDS_CONFIGURATION)
-
-      @elasticsearch_response[:_source][:configuration] = configuration
-    end
-
     private
 
     def initialize(es_response)

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -20,13 +20,7 @@ module Core
     class << self
 
       def force_sync(connector_id)
-        body = {
-          :doc => {
-            :scheduling => { :enabled => true },
-            :sync_now => true
-          }
-        }
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
+        update_connector_fields(connector_id, :scheduling => { :enabled => true }, :sync_now => true)
       end
 
       def create_connector(index_name, service_type)
@@ -44,34 +38,29 @@ module Core
       end
 
       def update_connector_configuration(connector_id, configuration)
-        update_connector_field(connector_id, :configuration, configuration)
+        update_connector_fields(connector_id, :configuration => configuration)
       end
 
       def enable_connector_scheduling(connector_id, cron_expression)
         payload = { :enabled => true, :interval => cron_expression }
-        update_connector_field(connector_id, :scheduling, payload)
+        update_connector_fields(connector_id, :scheduling => payload)
       end
 
       def disable_connector_scheduling(connector_id)
         payload = { :enabled => false }
-        update_connector_field(connector_id, :scheduling, payload)
+        update_connector_fields(connector_id, :scheduling => payload)
       end
 
       def set_configurable_field(connector_id, field_name, label, value)
         payload = { field_name => { :value => value, :label => label } }
-        update_connector_field(connector_id, :configuration, payload)
+        update_connector_fields(connector_id, :configuration => payload)
       end
 
       def claim_job(connector_id)
-        body = {
-          :doc => {
-            :sync_now => false,
-            :last_sync_status => Connectors::SyncStatus::IN_PROGRESS,
-            :last_synced => Time.now
-          }
-        }
-
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
+        update_connector_fields(connector_id,
+                                :sync_now => false,
+                                :last_sync_status => Connectors::SyncStatus::IN_PROGRESS,
+                                :last_synced => Time.now)
 
         body = {
           :connector_id => connector_id,
@@ -84,38 +73,17 @@ module Core
         job['_id']
       end
 
-      def heartbeat(connector_id)
-        body = {
-          :doc => {
-            :last_seen => Time.now
-          }
-        }
-
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
-      end
-
       def update_connector_status(connector_id, status)
-        body = {
-          :doc => {
-            :status => status
-          }
-        }
-
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
+        update_connector_fields(connector_id, :status => status)
       end
 
       def complete_sync(connector_id, job_id, status)
         sync_status = status[:error] ? Connectors::SyncStatus::FAILED : Connectors::SyncStatus::COMPLETED
 
-        body = {
-          :doc => {
-            :last_sync_status => sync_status,
-            :last_sync_error => status[:error],
-            :last_synced => Time.now
-          }
-        }
-
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
+        update_connector_fields(connector_id,
+                                :last_sync_status => sync_status,
+                                :last_sync_error => status[:error],
+                                :last_synced => Time.now)
 
         body = {
           :doc => {
@@ -242,13 +210,9 @@ module Core
         ensure_index_exists("#{JOB_INDEX}-v1", system_index_body(:alias_name => JOB_INDEX, :mappings => mappings))
       end
 
-      def update_connector_field(connector_id, field_name, value)
-        body = {
-          :doc => {
-            field_name => value
-          }
-        }
-        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => body)
+      def update_connector_fields(connector_id, doc = {})
+        return if doc.empty?
+        client.update(:index => CONNECTORS_INDEX, :id => connector_id, :body => { :doc => doc })
       end
 
       def client

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -1,0 +1,35 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'connectors/connector_status'
+require 'connectors/registry'
+
+module Core
+  class Heartbeat
+    class << self
+      def send(connector_id, service_type)
+        connector_settings = Core::ConnectorSettings.fetch(connector_id)
+
+        doc = {
+          :last_seen => Time.now
+        }
+
+        if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
+          connector_class = Connectors::REGISTRY.connector_class(service_type)
+          doc[:configuration] = connector_class.configurable_fields
+          doc[:status] = Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+        elsif connector_settings.connector_status_allows_sync?
+          connector_instance = Connectors::REGISTRY.connector(service_type, connector_settings.configuration)
+          doc[:status] = connector_instance.source_status[:status] == 'OK' ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR
+        end
+
+        ElasticConnectorActions.update_connector_fields(connector_id, doc)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Move connector status update to heartbeat (#198)