### PR TITLE
[8.4] Make connector CONFIGURED if all configurable fields have default values (#217)

### DIFF
--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -6,8 +6,10 @@
 
 # frozen_string_literal: true
 
+require 'core/elastic_connector_actions'
 require 'connectors/connector_status'
 require 'connectors/registry'
+require 'utility/logger'
 
 module Core
   class Heartbeat
@@ -21,8 +23,21 @@ module Core
 
         if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
           connector_class = Connectors::REGISTRY.connector_class(service_type)
-          doc[:configuration] = connector_class.configurable_fields
-          doc[:status] = Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+          configuration = connector_class.configurable_fields
+          doc[:configuration] = configuration
+
+          # We want to set connector to CONFIGURED status if all configurable fields have default values
+          new_connector_status = if configuration.values.all? { |setting| setting[:value] }
+                                   Utility::Logger.debug("All connector configurable fields provided default values for connector #{connector_id}.")
+                                   Connectors::ConnectorStatus::CONFIGURED
+                                 else
+                                   Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+                                 end
+
+          doc[:status] = new_connector_status
+
+          Utility::Logger.info("Heartbeat updated configuration for connector #{connector_id}.")
+          Utility::Logger.info("Changing connector status to #{new_connector_status}.")
         elsif connector_settings.connector_status_allows_sync?
           connector_instance = Connectors::REGISTRY.connector(service_type, connector_settings.configuration)
           doc[:status] = connector_instance.source_status[:status] == 'OK' ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Make connector CONFIGURED if all configurable fields have default values (#217)](https://github.com/elastic/connectors-ruby/pull/217)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)