### PR TITLE
add default crawler mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,13 @@ tag:
 
 build_gem:
 	mkdir -p .gems
-	gem build connectors_utility.gemspec
+	bundle _$(shell cat .bundler-version)_ exec gem build connectors_utility.gemspec
 	rm -f .gems/*
 	mv *.gem .gems/
 	echo "DO NOT FORGET TO UPDATE ENT-SEARCH"
 
 push_gem:
-	gem push .gems/*
+	bundle _$(shell cat .bundler-version)_ exec gem push .gems/*
 
 install:
 	rbenv install -s

--- a/lib/utility/elasticsearch/index/mappings.rb
+++ b/lib/utility/elasticsearch/index/mappings.rb
@@ -12,63 +12,91 @@ module Utility
       module Mappings
         ENUM_IGNORE_ABOVE = 2048
 
-        WORKPLACE_SEARCH_SUBEXTRACTION_STAMP_FIELD_MAPPINGS = {
-          _subextracted_as_of: {
-            type: 'date'
-          },
-          _subextracted_version: {
-            type: 'keyword'
+        DATE_FIELD_MAPPING = {
+          type: 'date'
+        }
+
+        KEYWORD_FIELD_MAPPING = {
+          type: 'keyword'
+        }
+
+        TEXT_FIELD_MAPPING = {
+          type: 'text',
+          analyzer: 'iq_text_base',
+          index_options: 'freqs',
+          fields: {
+            'stem': {
+              type: 'text',
+              analyzer: 'iq_text_stem'
+            },
+            'prefix' => {
+              type: 'text',
+              analyzer: 'i_prefix',
+              search_analyzer: 'q_prefix',
+              index_options: 'docs'
+            },
+            'delimiter' => {
+              type: 'text',
+              analyzer: 'iq_text_delimiter',
+              index_options: 'freqs'
+            },
+            'joined': {
+              type: 'text',
+              analyzer: 'i_text_bigram',
+              search_analyzer: 'q_text_bigram',
+              index_options: 'freqs'
+            },
+            'enum': {
+              type: 'keyword',
+              ignore_above: ENUM_IGNORE_ABOVE
+            }
           }
+        }
+
+        WORKPLACE_SEARCH_SUBEXTRACTION_STAMP_FIELD_MAPPINGS = {
+          _subextracted_as_of: DATE_FIELD_MAPPING,
+          _subextracted_version: KEYWORD_FIELD_MAPPING
         }.freeze
 
-        def self.default_text_fields_mappings(connectors_index:)
+        CRAWLER_FIELD_MAPPINGS = {
+          additional_urls: KEYWORD_FIELD_MAPPING,
+          body_content: TEXT_FIELD_MAPPING,
+          domains: KEYWORD_FIELD_MAPPING,
+          headings: TEXT_FIELD_MAPPING,
+          last_crawled_at: DATE_FIELD_MAPPING,
+          links: KEYWORD_FIELD_MAPPING,
+          meta_description: TEXT_FIELD_MAPPING,
+          meta_keywords: KEYWORD_FIELD_MAPPING,
+          title: TEXT_FIELD_MAPPING,
+          url: KEYWORD_FIELD_MAPPING,
+          url_host: KEYWORD_FIELD_MAPPING,
+          url_path: KEYWORD_FIELD_MAPPING,
+          url_path_dir1: KEYWORD_FIELD_MAPPING,
+          url_path_dir2: KEYWORD_FIELD_MAPPING,
+          url_path_dir3: KEYWORD_FIELD_MAPPING,
+          url_port: KEYWORD_FIELD_MAPPING,
+          url_scheme: KEYWORD_FIELD_MAPPING
+        }.freeze
+
+
+
+        def self.default_text_fields_mappings(connectors_index:, crawler_index: false)
           {
             dynamic: true,
             dynamic_templates: [
               {
                 data: {
                   match_mapping_type: 'string',
-                  mapping: {
-                    type: 'text',
-                    analyzer: 'iq_text_base',
-                    index_options: 'freqs',
-                    fields: {
-                      'stem': {
-                        type: 'text',
-                        analyzer: 'iq_text_stem'
-                      },
-                      'prefix' => {
-                        type: 'text',
-                        analyzer: 'i_prefix',
-                        search_analyzer: 'q_prefix',
-                        index_options: 'docs'
-                      },
-                      'delimiter' => {
-                        type: 'text',
-                        analyzer: 'iq_text_delimiter',
-                        index_options: 'freqs'
-                      },
-                      'joined': {
-                        type: 'text',
-                        analyzer: 'i_text_bigram',
-                        search_analyzer: 'q_text_bigram',
-                        index_options: 'freqs'
-                      },
-                      'enum': {
-                        type: 'keyword',
-                        ignore_above: ENUM_IGNORE_ABOVE
-                      }
-                    }
-                  }
+                  mapping: TEXT_FIELD_MAPPING
                 }
               }
             ],
             properties: {
-              id: {
-                type: 'keyword'
-              }
+              id: KEYWORD_FIELD_MAPPING
             }.tap do |properties|
               properties.merge!(WORKPLACE_SEARCH_SUBEXTRACTION_STAMP_FIELD_MAPPINGS) if connectors_index
+            end.tap do |properties|
+              properties.merge!(CRAWLER_FIELD_MAPPINGS) if crawler_index
             end
           }
         end

--- a/lib/utility/elasticsearch/index/mappings.rb
+++ b/lib/utility/elasticsearch/index/mappings.rb
@@ -78,8 +78,6 @@ module Utility
           url_scheme: KEYWORD_FIELD_MAPPING
         }.freeze
 
-
-
         def self.default_text_fields_mappings(connectors_index:, crawler_index: false)
           {
             dynamic: true,

--- a/spec/utility/elasticsearch/mappings_spec.rb
+++ b/spec/utility/elasticsearch/mappings_spec.rb
@@ -31,27 +31,32 @@ describe Utility::Elasticsearch::Index::Mappings do
 
       context 'when the index is a crawler index' do
         let(:crawler_index) { true }
+        let(:expected_props) do
+          {
+            properties: {
+              id: Hash,
+              additional_urls: Hash,
+              body_content: Hash,
+              domains: Hash,
+              headings: Hash,
+              last_crawled_at: Hash,
+              links: Hash,
+              meta_description: Hash,
+              meta_keywords: Hash,
+              title: Hash,
+              url: Hash,
+              url_host: Hash,
+              url_path: Hash,
+              url_path_dir1: Hash,
+              url_path_dir2: Hash,
+              url_path_dir3: Hash,
+              url_port: Hash,
+              url_scheme: Hash
+            }
+          }
+        end
 
-        it { is_expected.to include(properties: {
-          id: Hash,
-          additional_urls: Hash,
-          body_content: Hash,
-          domains: Hash,
-          headings: Hash,
-          last_crawled_at: Hash,
-          links: Hash,
-          meta_description: Hash,
-          meta_keywords: Hash ,
-          title: Hash,
-          url: Hash,
-          url_host: Hash,
-          url_path: Hash,
-          url_path_dir1: Hash,
-          url_path_dir2: Hash,
-          url_path_dir3: Hash,
-          url_port: Hash,
-          url_scheme: Hash
-        }) }
+        it { is_expected.to include(expected_props) }
       end
     end
   end

--- a/spec/utility/elasticsearch/mappings_spec.rb
+++ b/spec/utility/elasticsearch/mappings_spec.rb
@@ -11,9 +11,10 @@ require 'utility/elasticsearch/index/mappings'
 
 describe Utility::Elasticsearch::Index::Mappings do
   describe '#default_text_fields_mappings' do
-    subject { Utility::Elasticsearch::Index::Mappings.default_text_fields_mappings(connectors_index: connectors_index) }
+    let(:crawler_index) { false }
+    subject { Utility::Elasticsearch::Index::Mappings.default_text_fields_mappings(connectors_index: connectors_index, crawler_index: crawler_index) }
 
-    context 'when the index is a search index' do
+    context 'when the index is a connectors index' do
       let(:connectors_index) { true }
 
       it { is_expected.to be_kind_of(Hash) }
@@ -21,12 +22,37 @@ describe Utility::Elasticsearch::Index::Mappings do
       it { is_expected.to include(properties: { id: Hash, _subextracted_as_of: Hash, _subextracted_version: Hash }) }
     end
 
-    context 'when the index is not a search index' do
+    context 'when the index is not a connectors index' do
       let(:connectors_index) { false }
 
       it { is_expected.to be_kind_of(Hash) }
       it { is_expected.to include(dynamic: true, dynamic_templates: Array, properties: Hash) }
       it { is_expected.not_to include(properties: { id: Hash, _subextracted_as_of: Hash, _subextracted_version: Hash }) }
+
+      context 'when the index is a crawler index' do
+        let(:crawler_index) { true }
+
+        it { is_expected.to include(properties: {
+          id: Hash,
+          additional_urls: Hash,
+          body_content: Hash,
+          domains: Hash,
+          headings: Hash,
+          last_crawled_at: Hash,
+          links: Hash,
+          meta_description: Hash,
+          meta_keywords: Hash ,
+          title: Hash,
+          url: Hash,
+          url_host: Hash,
+          url_path: Hash,
+          url_path_dir1: Hash,
+          url_path_dir2: Hash,
+          url_path_dir3: Hash,
+          url_port: Hash,
+          url_scheme: Hash
+        }) }
+      end
     end
   end
 end


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/2379
## part of https://github.com/elastic/enterprise-search-team/issues/2391


our default mappings were not creating all the expected schema fields for crawler indices, which conflicted with [the default crawler deduplication fields](https://github.com/elastic/ent-search/blob/main/shared_togo/lib/shared_togo/config_parser/schemas/connector.rb#L4-L11)

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally



## Related Pull Requests

- https://github.com/elastic/ent-search/pull/6729



## For Elastic Internal Use Only
- [x] [Manual test steps](https://github.com/elastic/connectors-ruby/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
