### PR TITLE
Extract logic for scheduling to a separate class

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -59,23 +59,10 @@ module App
 
       def start_polling_jobs
         Utility::Logger.info('Polling Elasticsearch for synchronisation jobs to run.')
-        loop do
-          job_runner = create_sync_job_runner
+        Core::Scheduler.new(App::Config[:connector_id], POLL_IDLING).when_triggered do |connector_settings|
+          job_runner = Core::SyncJobRunner.new(connector_settings, App::Config[:service_type])
           job_runner.execute
-        rescue StandardError => e
-          Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
-        ensure
-          if POLL_IDLING > 0
-            Utility::Logger.info("Sleeping for #{POLL_IDLING} seconds.")
-            sleep(POLL_IDLING)
-          end
         end
-      end
-
-      def create_sync_job_runner
-        connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
-
-        Core::SyncJobRunner.new(connector_settings, App::Config[:service_type])
       end
     end
   end

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require 'core/connector_settings'
-require 'core/sync_job_runner'
 require 'core/elastic_connector_actions'
 require 'core/heartbeat'
+require 'core/scheduler'
+require 'core/sync_job_runner'

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -9,6 +9,7 @@
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/blank'
 require 'connectors/connector_status'
+require 'time'
 require 'utility/logger'
 
 module Core

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -1,0 +1,97 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'time'
+require 'fugit'
+require 'core/connector_settings'
+require 'utility/cron'
+require 'utility/logger'
+require 'utility/exception_tracking'
+
+module Core
+  class Scheduler
+    def initialize(connector_id, poll_interval)
+      @connector_id = connector_id
+      @poll_interval = poll_interval
+    end
+    
+    def when_triggered
+      loop do 
+        connector_settings = Core::ConnectorSettings.fetch(@connector_id)
+
+        if sync_triggered?(connector_settings)
+          yield connector_settings 
+        end
+      rescue StandardError => e
+        Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
+      ensure
+        if @poll_interval > 0
+          Utility::Logger.info("Sleeping for #{@poll_interval} seconds.")
+          sleep(@poll_interval)
+        end
+      end
+    end
+
+    private
+
+    def sync_triggered?(connector_settings)
+      unless connector_settings.connector_status_allows_sync?
+        Utility::Logger.info("Connector #{connector_settings.id} is in status \"#{connector_settings.connector_status}\" and won't sync yet. Connector needs to be in one of the following statuses: #{Connectors::ConnectorStatus::STATUSES_ALLOWING_SYNC} to run.")
+
+        return false
+      end
+
+      # We want to sync when sync never actually happened
+      last_synced = connector_settings[:last_synced]
+      if last_synced.nil? || last_synced.empty?
+        Utility::Logger.info("Connector #{connector_settings.id} has never synced yet, running initial sync.")
+        return true
+      end
+
+      # Sync when sync_now flag is true for the connector 
+      if connector_settings[:sync_now] == true
+        Utility::Logger.info("Connector #{connector_settings.id} is manually triggered to sync now.")
+        return true
+      end
+
+      # Don't sync if sync is explicitly disabled
+      scheduling_settings = connector_settings.scheduling_settings
+      unless scheduling_settings.present? && scheduling_settings[:enabled] == true
+        Utility::Logger.info("Connector #{connector_settings.id} scheduling is disabled.")
+        return false
+      end
+
+      current_schedule = scheduling_settings[:interval]
+
+      # Don't sync if there is no actual scheduling interval
+      if current_schedule.nil? || current_schedule.empty?
+        Utility::Logger.warn("No sync schedule configured for connector #{connector_settings.id}.")
+        return false
+      end
+
+      current_schedule = Utility::Cron.quartz_to_crontab(current_schedule)
+      cron_parser = Fugit::Cron.parse(current_schedule)
+
+      # Don't sync if the scheduling interval is non-parsable
+      unless cron_parser
+        Utility::Logger.error("Unable to parse sync schedule for connector #{connector_settings.id}: expression #{current_schedule} is not a valid Quartz Cron definition.")
+        return false
+      end
+
+      next_trigger_time = cron_parser.next_time(Time.parse(last_synced))
+
+      # Sync if next trigger for the connector is in past
+      if next_trigger_time < Time.now
+        Utility::Logger.info("Connector #{connector_settings.id} sync is triggered by cron schedule #{current_schedule}.")
+        return true
+      end
+
+      false
+    end
+  end
+end

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -19,13 +19,13 @@ module Core
       @connector_id = connector_id
       @poll_interval = poll_interval
     end
-    
+
     def when_triggered
-      loop do 
+      loop do
         connector_settings = Core::ConnectorSettings.fetch(@connector_id)
 
         if sync_triggered?(connector_settings)
-          yield connector_settings 
+          yield connector_settings
         end
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
@@ -53,7 +53,7 @@ module Core
         return true
       end
 
-      # Sync when sync_now flag is true for the connector 
+      # Sync when sync_now flag is true for the connector
       if connector_settings[:sync_now] == true
         Utility::Logger.info("Connector #{connector_settings.id} is manually triggered to sync now.")
         return true


### PR DESCRIPTION
A refactoring to move away the logic about the triggering of the sync to a different place.

This PR creates a `lib/core/scheduler.rb` file that got all the logic related to scheduling moved from the `lib/core/sync_job_runner.rb` file.

This will allow for simpler testing + easier feature implementation for scheduling (specifically, for the logic to notify user about the next time the job will run).