### PR TITLE
Add test coverage for lib/app/worker.rb + modify heartbeat logic for better separation of concerns

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -11,7 +11,6 @@ require 'connectors'
 require 'core'
 require 'utility'
 require 'app/config'
-require 'concurrent'
 
 module App
   module Worker
@@ -43,18 +42,8 @@ module App
       def start_heartbeat_task
         connector_id = App::Config[:connector_id]
         service_type = App::Config[:service_type]
-        interval_seconds = 60 # seconds
-        Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
-        task = Concurrent::TimerTask.new(execution_interval: interval_seconds, run_now: true) do
-          Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
-          Core::Heartbeat.send(connector_id, service_type)
-        rescue StandardError => e
-          Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
-        end
 
-        Utility::Logger.info('Successfully started heartbeat task.')
-
-        task.execute
+        Core::Heartbeat.start_task(connector_id, service_type)
       end
 
       def start_polling_jobs

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -9,16 +9,19 @@
 require 'concurrent'
 require 'connectors/connector_status'
 require 'connectors/registry'
+require 'core/connector_settings'
 require 'core/elastic_connector_actions'
 require 'utility/logger'
 
 module Core
   class Heartbeat
+    INTERVAL_SECONDS = 60
+
     class << self
       def start_task(connector_id, service_type)
-        interval_seconds = 60 # seconds
-        Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
-        task = Concurrent::TimerTask.new(execution_interval: interval_seconds, run_now: true) do
+        Utility::Logger.debug("Starting heartbeat timer task with interval #{INTERVAL_SECONDS} seconds.")
+
+        Concurrent::TimerTask.execute(execution_interval: INTERVAL_SECONDS, run_now: true) do
           Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
           send(connector_id, service_type)
         rescue StandardError => e
@@ -26,8 +29,6 @@ module Core
         end
 
         Utility::Logger.info('Successfully started heartbeat task.')
-
-        task.execute
       end
 
       private
@@ -45,7 +46,7 @@ module Core
           doc[:configuration] = configuration
 
           # We want to set connector to CONFIGURED status if all configurable fields have default values
-          new_connector_status = if configuration.values.all? { |setting| setting[:value] }
+          new_connector_status = if configuration.values.all? { |setting| setting[:value].present? }
                                    Utility::Logger.debug("All connector configurable fields provided default values for connector #{connector_id}.")
                                    Connectors::ConnectorStatus::CONFIGURED
                                  else
@@ -61,7 +62,7 @@ module Core
           doc[:status] = connector_instance.source_status[:status] == 'OK' ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR
         end
 
-        ElasticConnectorActions.update_connector_fields(connector_id, doc)
+        Core::ElasticConnectorActions.update_connector_fields(connector_id, doc)
       end
     end
   end

--- a/lib/utility/environment.rb
+++ b/lib/utility/environment.rb
@@ -5,6 +5,7 @@
 #
 
 require 'logger'
+require 'utility/logger'
 require 'active_support/core_ext/module'
 
 module Utility

--- a/spec/app/worker_spec.rb
+++ b/spec/app/worker_spec.rb
@@ -70,7 +70,7 @@ describe App::Worker do
     allow(Core::Heartbeat).to receive(:start_task)
   end
 
-  describe "#start" do
+  describe '#start' do
     context 'when valid setup is provided' do
       it 'ensures necessary indices are created' do
         expect(Core::ElasticConnectorActions).to receive(:ensure_connectors_index_exists)
@@ -111,7 +111,7 @@ describe App::Worker do
     end
 
     context 'when Core::ElasticConnectorActions raises elastic unauthorized error' do
-      let(:elastic_error_message) { "Something really bad happened" }
+      let(:elastic_error_message) { 'Something really bad happened' }
       before(:each) do
         allow(Core::ElasticConnectorActions).to receive(:ensure_content_index_exists).and_raise(Elastic::Transport::Transport::Errors::Unauthorized.new(elastic_error_message))
       end

--- a/spec/app/worker_spec.rb
+++ b/spec/app/worker_spec.rb
@@ -11,96 +11,128 @@ require 'app/worker'
 require 'utility/logger'
 require 'utility/environment'
 
-class FakeSettings
-  def index_name
-    'index'
-  end
-end
-
 describe App::Worker do
-  it 'should raise error for invalid service type' do
-    config = {
-      :service_type => 'foobar',
-      :connector_id => '1',
+  let(:connector_id) { '1' }
+  let(:service_type) { 'foobar' }
+  let(:content_index_name) { 'recent-data-ingestion-index' }
+  let(:config) do
+    {
+      :service_type => service_type,
+      :connector_id => connector_id,
       :log_level => 'INFO',
       :elasticsearch => {
         :api_key => 'key',
         :hosts => 'http://notreallyaserver'
       }
     }
-    allow(Connectors::REGISTRY).to receive(:connector_class).and_return(nil)
+  end
+
+  let(:connector_settings) do
+    double
+  end
+
+  let(:connector_class) do
+    double
+  end
+
+  let(:scheduler) do
+    double
+  end
+
+  let(:sync_job_runner) do
+    double
+  end
+
+  let(:timer_task) do
+    double
+  end
+
+  before(:each) do
     stub_const('App::Config', config)
 
-    expect {
-      Utility::Environment.set_execution_environment(config) do
+    allow(connector_settings).to receive(:id).and_return(connector_id)
+    allow(connector_settings).to receive(:index_name).and_return(content_index_name)
+
+    allow(Core::ElasticConnectorActions).to receive(:ensure_connectors_index_exists)
+    allow(Core::ElasticConnectorActions).to receive(:ensure_content_index_exists)
+    allow(Core::ElasticConnectorActions).to receive(:ensure_job_index_exists)
+
+    allow(Core::ConnectorSettings).to receive(:fetch).and_return(connector_settings)
+
+    allow(Connectors::REGISTRY).to receive(:registered?).with(service_type).and_return(connector_class)
+
+    allow(Core::Scheduler).to receive(:new).and_return(scheduler)
+    allow(scheduler).to receive(:when_triggered).and_yield(connector_settings)
+
+    allow(Core::SyncJobRunner).to receive(:new).and_return(sync_job_runner)
+    allow(sync_job_runner).to receive(:execute)
+
+    allow(Core::Heartbeat).to receive(:start_task)
+  end
+
+  describe "#start" do
+    context 'when valid setup is provided' do
+      it 'ensures necessary indices are created' do
+        expect(Core::ElasticConnectorActions).to receive(:ensure_connectors_index_exists)
+        expect(Core::ElasticConnectorActions).to receive(:ensure_job_index_exists)
+        expect(Core::ElasticConnectorActions).to receive(:ensure_content_index_exists).with(content_index_name)
+
         described_class.start!
       end
-    }.to raise_error('foobar is not a supported connector')
-  end
 
-  shared_examples 'handle_warnings' do |disable_warnings, stderr|
-    it "with disable_warnings=#{disable_warnings}" do
-      # This call will raise a 401 when the lib checks the server, and that will create a warning
-      expect_any_instance_of(Utility::EsClient).to receive(:elasticsearch_validation_request).and_raise(Elastic::Transport::Transport::Errors::Unauthorized)
+      it 'starts sync job runner' do
+        expect(sync_job_runner).to receive(:execute)
+        described_class.start!
+      end
+    end
 
-      config = if disable_warnings
-                 # This is the default behavior, so we don't pass
-                 # disable_warnings to make sure it is set to true by default
-                 {
-                   :service_type => 'stub_connector',
-                   :connector_id => '1',
-                   :log_level => 'INFO',
-                   :elasticsearch => {
-                     :api_key => 'key',
-                     :hosts => 'http://notreallyaserver'
-                   }
-                 }
-               else
-                 {
-                   :service_type => 'stub_connector',
-                   :log_level => 'INFO',
-                   :connector_id => '1',
-                   :elasticsearch => {
-                     :api_key => 'key',
-                     :hosts => 'http://notreallyaserver',
-                     :disable_warnings => false
-                   }
-                 }
-               end
+    context 'when connector settings could not be fetched' do
+      let(:error) { 'oh no!' }
 
-      # mocking the worker so start! returns immediatly after the initial checks
-      allow(App::Worker).to receive(:start_heartbeat_task)
-      allow(App::Worker).to receive(:start_polling_jobs)
-
-      # mocking some of the conversation between the worker and Elasticsearch
-      expect(Core::ConnectorSettings).to receive(:fetch).and_return(FakeSettings.new)
-
-      ['.elastic-connectors-sync-jobs-v1', 'index', '.elastic-connectors-v1'].each do |index|
-        stub_request(:head, "http://notreallyaserver:9200/#{index}")
-          .to_return(status: 404, body: YAML.dump({}), headers: {})
-        stub_request(:put, "http://notreallyaserver:9200/#{index}")
-          .to_return(status: 200, body: YAML.dump({}), headers: {})
+      before(:each) do
+        allow(Core::ConnectorSettings).to receive(:fetch).and_raise(error)
       end
 
-      stub_const('App::Config', config)
-
-      # make sure we start with a fresh ESClient for the duration of the test
-      expect(Core::ElasticConnectorActions).to receive(:client).at_least(:once).and_return(Utility::EsClient.new)
-
-      # now let's see what is displated in stderr
-      expect {
-        Utility::Environment.set_execution_environment(config) do
-          described_class.start!
-        end
-      }.to output(stderr).to_stderr
+      it 'crashes with the raised error' do
+        expect { described_class.start! }.to raise_error(error)
+      end
     end
-  end
 
-  context 'should display warnings from the Elasticsearch lib' do
-    include_examples 'handle_warnings', false, /#{Elasticsearch::SECURITY_PRIVILEGES_VALIDATION_WARNING}/
-  end
+    context 'when invalid service type is provided' do
+      before(:each) do
+        allow(Connectors::REGISTRY).to receive(:registered?).with(service_type).and_return(nil)
+      end
 
-  context 'should discard warnings from the Elasticsearch lib by default' do
-    include_examples 'handle_warnings', true, ''
+      it 'should raise error for invalid service type' do
+        expect {
+          described_class.start!
+        }.to raise_error("#{service_type} is not a supported connector")
+      end
+    end
+
+    context 'when Core::ElasticConnectorActions raises elastic unauthorized error' do
+      let(:elastic_error_message) { "Something really bad happened" }
+      before(:each) do
+        allow(Core::ElasticConnectorActions).to receive(:ensure_content_index_exists).and_raise(Elastic::Transport::Transport::Errors::Unauthorized.new(elastic_error_message))
+      end
+
+      it 'raises a new more user-friendly error' do
+        expect {
+          described_class.start!
+        }.to raise_error(/#{elastic_error_message}/)
+      end
+    end
+
+    context 'when scheduler does not yield' do
+      before(:each) do
+        allow(scheduler).to receive(:when_triggered)
+      end
+
+      it 'does not trigger the connector' do
+        expect(sync_job_runner).to_not receive(:execute)
+
+        described_class.start!
+      end
+    end
   end
 end

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -1,0 +1,118 @@
+require 'core/heartbeat'
+require 'connectors/connector_status'
+
+describe Core::Heartbeat do
+  let(:connector_id) { '123' }
+  let(:service_type) { 'foo' }
+  let(:connector_status) { Connectors::ConnectorStatus::CONNECTED }
+  let(:connector_stored_configuration) { {} } # returned from Elasticsearch with values already specified by user
+  let(:connector_default_configuration) { {} } # returned from Connector class with default values
+
+  let(:connector_settings) { double } 
+  let(:connector_class) { double }
+  let(:connector_instance) { double }
+
+  let(:source_status) { { :status => 'OK' } } 
+
+  before(:each) do
+    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
+
+    allow(Core::ElasticConnectorActions).to receive(:update_connector_fields)
+
+    allow(Connectors::REGISTRY).to receive(:connector_class).and_return(connector_class)
+
+    allow(connector_settings).to receive(:connector_status).and_return(connector_status)
+    allow(connector_settings).to receive(:connector_status_allows_sync?).and_return(true)
+    allow(connector_settings).to receive(:configuration).and_return(connector_stored_configuration)
+
+    allow(connector_class).to receive(:configurable_fields).and_return(connector_default_configuration)
+    allow(connector_class).to receive(:new).and_return(connector_instance)
+
+    allow(connector_instance).to receive(:source_status).and_return(source_status)
+  end
+
+  describe '.start_task' do
+    # Just replacing threaded timer task with immediate execution to find problems immediately,
+    # otherwise timer task just swallows errors
+    context 'when running code synchronously just one time' do
+      before(:each) do
+        allow(Concurrent::TimerTask).to receive(:execute).and_yield
+      end
+
+      context 'when connector has just been created' do
+        let(:connector_status) { Connectors::ConnectorStatus::CREATED }
+
+        context 'when connector has no configurable fields' do
+          it 'updates connector status to CONFIGURED' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+
+        context 'when connector has some configurable fields without default values' do
+          let(:connector_default_configuration) do
+            {
+              :foo => {
+                :label => 'Foo',
+                :value => nil
+              },
+              :lala => {
+                :label => 'Lala',
+                :value => 'hello'
+              }
+            }
+          end
+
+          it 'updates connector status to NEEDS_CONFIGURATION' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+
+        context 'when connector has all configurable fields with default values' do
+          let(:connector_default_configuration) do
+            {
+              :foo => {
+                :label => 'Foo',
+                :value => 'FF'
+              },
+              :lala => {
+                :label => 'Lala',
+                :value => 'hello'
+              }
+            }
+          end
+
+          it 'updates connector status to CONFIGURED' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+      end
+
+      context 'when connector is already connected' do
+        it 'updates connector last_seen and status only' do
+          expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :status => Connectors::ConnectorStatus::CONNECTED })
+
+          described_class.start_task(connector_id, service_type)
+        end
+      end
+
+      context 'when connector settings were not found' do
+        let(:error) { 'something really bad happened' }
+
+        before(:each) do
+          allow(Core::ConnectorSettings).to receive(:fetch).and_raise(error)
+        end
+
+        it 'does not raise an error' do
+          expect { described_class.start_task(connector_id, service_type) }.to_not raise_error
+        end
+      end
+    end
+  end
+end
+

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -8,11 +8,11 @@ describe Core::Heartbeat do
   let(:connector_stored_configuration) { {} } # returned from Elasticsearch with values already specified by user
   let(:connector_default_configuration) { {} } # returned from Connector class with default values
 
-  let(:connector_settings) { double } 
+  let(:connector_settings) { double }
   let(:connector_class) { double }
   let(:connector_instance) { double }
 
-  let(:source_status) { { :status => 'OK' } } 
+  let(:source_status) { { :status => 'OK' } }
 
   before(:each) do
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
@@ -115,4 +115,3 @@ describe Core::Heartbeat do
     end
   end
 end
-

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Utility::EsClient do
     stub_const('App::Config', config)
 
     stub_request(:get, "#{host}:9200/")
-      .to_return(status: 403, body: "", headers: {})
+      .to_return(status: 403, body: '', headers: {})
     stub_request(:get, "#{host}:9200/_cluster/health")
   end
 
@@ -42,7 +42,7 @@ RSpec.describe Utility::EsClient do
         }.to output(/#{Elasticsearch::SECURITY_PRIVILEGES_VALIDATION_WARNING}/).to_stderr
       end
     end
-    
+
     context 'when disable_warnings=true' do
       let(:disable_warnings) { true }
       it 'receives no warnings from elasticsearch client' do

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -1,0 +1,55 @@
+require 'elasticsearch'
+require 'utility/es_client'
+require 'utility/environment'
+
+RSpec.describe Utility::EsClient do
+  let(:host) { 'http://notreallyaserver' }
+  let(:config) do
+    {
+      :service_type => 'stub_connector',
+      :log_level => 'INFO',
+      :connector_id => '1',
+      :elasticsearch => {
+        :api_key => 'key',
+        :hosts => host,
+        :disable_warnings => disable_warnings
+      }
+    }
+  end
+
+  let(:subject) { described_class.new }
+
+  before(:each) do
+    stub_const('App::Config', config)
+
+    stub_request(:get, "#{host}:9200/")
+      .to_return(status: 403, body: "", headers: {})
+    stub_request(:get, "#{host}:9200/_cluster/health")
+  end
+
+  context 'when wrapped in Utility::Environment.set_execution_environment' do
+    around(:each) do |example|
+      Utility::Environment.set_execution_environment(config) do
+        example.run
+      end
+    end
+
+    context 'when disable_warnings=false' do
+      let(:disable_warnings) { false }
+      it 'receives warnings from elasticsearch client' do
+        expect {
+          subject.cluster.health
+        }.to output(/#{Elasticsearch::SECURITY_PRIVILEGES_VALIDATION_WARNING}/).to_stderr
+      end
+    end
+    
+    context 'when disable_warnings=true' do
+      let(:disable_warnings) { true }
+      it 'receives no warnings from elasticsearch client' do
+        expect {
+          subject.cluster.health
+        }.to_not output.to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds 100% test coverage for `lib/app/worker.rb` file.

- Additionally, the tests that were checking the warning handling were moved to `spec/utility/es_client_spec.rb` - they seem to belong there better.
- Moved the heartbeat timer start logic into `lib/core/heartbeat.rb` + added tests to it as well