### PR TITLE
added autobackport GA

### DIFF
--- a/.github/workflows/add-labels-main.yml
+++ b/.github/workflows/add-labels-main.yml
@@ -1,0 +1,23 @@
+name: Force backport labels for main
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: version
+        uses: juliangruber/read-file-action@ebfa650188272343fef925480eb4d18c5d49b925
+        with:
+          path: ./VERSION
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: |
+            auto-backport
+            v${{ steps.version.outputs.content }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,42 @@
+name: Backport PR
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - labeled
+      - closed
+
+jobs:
+  backport:
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        || (github.event.action == 'closed')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'swiftype/kibana-github-actions'
+          ref: main
+          path: ./actions
+
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Run Backport
+        uses: ./actions/backport
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          approver_token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          auto_approve: 'true'
+          commit_user: elastic
+          commit_email: ent-search-backport@users.noreply.github.com
+          auto_merge: 'true'
+          auto_merge_method: 'squash'
+          manual_backport_command_template: 'backport --pr %pullNumber% --autoMerge --autoMergeMethod squash'


### PR DESCRIPTION
Adding Github actions to auto-backport.

Behavior:
- any PR targeting main gets `auto-backport` and `v{VERSION}` where `VERSION` is the value in the root file
- when the PR is merged into `main` a backport issue is created

