### PR TITLE
Add 100% spec coverage for Core::SyncJobRunner

### DIFF
--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -11,7 +11,7 @@ require 'elasticsearch'
 require 'app/config'
 
 module Utility
-  class EsClient < Elasticsearch::Client
+  class EsClient < ::Elasticsearch::Client
     class IndexingFailedError < StandardError
       def initialize(message, error = nil)
         super(message)

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -1,0 +1,186 @@
+require 'connectors/connector_status'
+require 'core/connector_settings'
+require 'core/elastic_connector_actions'
+require 'core/sync_job_runner'
+
+describe Core::SyncJobRunner do
+  let(:connector_id) { '123' }
+  let(:service_type) { 'foo' }
+  let(:connector_status) { Connectors::ConnectorStatus::CONNECTED }
+  let(:connector_stored_configuration) do # returned from Elasticsearch with values already specified by user
+        {
+          :lala => {
+            :label => 'Lala',
+            :value => 'hello'
+          }
+        }
+  end
+  let(:connector_default_configuration) do # returned from Connector class with default values
+        {
+          :lala => {
+            :label => 'Lala',
+            :value => nil
+          }
+        }
+  end
+
+  let(:connector_settings) { double }
+  let(:connector_class) { double }
+  let(:connector_instance) { double }
+  let(:sink) { double }
+
+  let(:source_status) { { :status => 'OK' } }
+  let(:output_index_name) { 'test-ingest-index' }
+  let(:existing_document_ids) { [] } # ids of documents that are already in the index
+  let(:extracted_documents) { [] } # documents returned from 3rd-party system
+
+  let(:job_id) { 'job-123' }
+
+  subject { described_class.new(connector_settings, service_type) }
+
+  before(:each) do
+    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
+
+    allow(Core::ElasticConnectorActions).to receive(:claim_job).and_return(job_id)
+    allow(Core::ElasticConnectorActions).to receive(:fetch_document_ids).and_return(existing_document_ids)
+    allow(Core::ElasticConnectorActions).to receive(:complete_sync)
+    allow(Core::ElasticConnectorActions).to receive(:update_connector_status)
+
+    allow(Connectors::REGISTRY).to receive(:connector_class).and_return(connector_class)
+    allow(Core::OutputSink::EsSink).to receive(:new).with(output_index_name).and_return(sink)
+    allow(sink).to receive(:ingest)
+    allow(sink).to receive(:delete)
+    allow(sink).to receive(:flush)
+
+    allow(connector_settings).to receive(:id).and_return(connector_id)
+    allow(connector_settings).to receive(:index_name).and_return(output_index_name)
+    allow(connector_settings).to receive(:configuration).and_return(connector_stored_configuration)
+
+    allow(connector_class).to receive(:configurable_fields).and_return(connector_default_configuration)
+    allow(connector_class).to receive(:service_type).and_return(service_type)
+    allow(connector_class).to receive(:new).and_return(connector_instance)
+
+    allow_statement = allow(connector_instance).to receive(:yield_documents)
+    extracted_documents.each { |document| allow_statement.and_yield(document) }
+  end
+
+  context '.execute' do
+    context 'when job_id is not present' do
+      let(:job_id) { nil }
+
+      it 'does not attempt to run the sync' do
+        expect(Core::ElasticConnectorActions).to_not receive(:complete_sync)
+        expect(Core::ElasticConnectorActions).to_not receive(:fetch_document_ids)
+
+        expect(sink).to_not receive(:ingest)
+        expect(sink).to_not receive(:delete)
+        expect(sink).to_not receive(:flush)
+
+        expect(connector_instance).to_not receive(:yield_documents)
+
+        subject.execute
+      end
+    end
+
+    context 'when connector was already configured with different configurable field set' do
+      let(:connector_stored_configuration) do
+        { 
+          :foo => {
+            :label => 'Foo',
+            :value => nil
+          }
+        }
+      end
+
+      let(:connector_default_configuration) do
+        {
+          :lala => {
+            :label => 'Lala',
+            :value => 'hello'
+          }
+        }
+      end
+
+      it 'raises an error' do
+        expect { subject.execute }.to raise_error(Core::IncompatibleConfigurableFieldsError)
+      end
+    end
+
+    it 'claims the job when starting the run' do
+      expect(Core::ElasticConnectorActions).to receive(:claim_job).with(connector_id)
+
+      subject.execute
+    end
+
+    it 'flushes the sink' do
+      # We don't ingest anything, but flush still happens just in case.
+      # This is done so that the last batch of documents is always ingested into the sink
+      expect(sink).to receive(:flush)
+
+      subject.execute
+    end
+
+    context 'when a bunch of documents are returned from 3rd-party system' do
+      let(:doc1) do
+        {
+          :id => 1,
+          :title => 'Hello',
+          :body => 'World'
+        }
+      end
+
+      let(:doc2) do
+        {
+          :id => 2,
+          :title => 'thanks',
+          :body => 'for the fish'
+        }
+      end
+
+      let(:extracted_documents) { [ doc1, doc2 ] } # documents returned from 3rd-party system
+
+      it 'ingests returned documents into the sink' do
+        expect(sink).to receive(:ingest).with(doc1)
+        expect(sink).to receive(:ingest).with(doc2)
+
+        subject.execute
+      end 
+
+      context 'when some documents were present before' do
+        let(:existing_document_ids) { [ 3, 4, 'lala', 'some other id' ] }
+
+        it 'attempts to remove existing documents' do
+          existing_document_ids.each do |id|
+            expect(sink).to receive(:delete).with(id)
+          end
+
+          subject.execute
+        end
+
+        it 'marks the job as complete with job stats' do
+          expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, {:indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => nil})
+
+          subject.execute
+        end
+
+        context 'when an error happens during sync' do
+          before(:each) do
+            allow(sink).to receive(:flush).and_raise('whoops')
+          end
+
+          it 'changes connector status to error' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_status).with(connector_id, Connectors::ConnectorStatus::ERROR)
+            
+            subject.execute
+          end
+
+          it 'marks the job as complete with proper error' do
+            expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, {:indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => anything})
+
+            subject.execute
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -8,20 +8,20 @@ describe Core::SyncJobRunner do
   let(:service_type) { 'foo' }
   let(:connector_status) { Connectors::ConnectorStatus::CONNECTED }
   let(:connector_stored_configuration) do # returned from Elasticsearch with values already specified by user
-        {
-          :lala => {
-            :label => 'Lala',
-            :value => 'hello'
-          }
-        }
+    {
+      :lala => {
+        :label => 'Lala',
+        :value => 'hello'
+      }
+    }
   end
   let(:connector_default_configuration) do # returned from Connector class with default values
-        {
-          :lala => {
-            :label => 'Lala',
-            :value => nil
-          }
-        }
+    {
+      :lala => {
+        :label => 'Lala',
+        :value => nil
+      }
+    }
   end
 
   let(:connector_settings) { double }
@@ -84,7 +84,7 @@ describe Core::SyncJobRunner do
 
     context 'when connector was already configured with different configurable field set' do
       let(:connector_stored_configuration) do
-        { 
+        {
           :foo => {
             :label => 'Foo',
             :value => nil
@@ -137,17 +137,17 @@ describe Core::SyncJobRunner do
         }
       end
 
-      let(:extracted_documents) { [ doc1, doc2 ] } # documents returned from 3rd-party system
+      let(:extracted_documents) { [doc1, doc2] } # documents returned from 3rd-party system
 
       it 'ingests returned documents into the sink' do
         expect(sink).to receive(:ingest).with(doc1)
         expect(sink).to receive(:ingest).with(doc2)
 
         subject.execute
-      end 
+      end
 
       context 'when some documents were present before' do
-        let(:existing_document_ids) { [ 3, 4, 'lala', 'some other id' ] }
+        let(:existing_document_ids) { [3, 4, 'lala', 'some other id'] }
 
         it 'attempts to remove existing documents' do
           existing_document_ids.each do |id|
@@ -158,7 +158,7 @@ describe Core::SyncJobRunner do
         end
 
         it 'marks the job as complete with job stats' do
-          expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, {:indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => nil})
+          expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, { :indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => nil })
 
           subject.execute
         end
@@ -170,12 +170,12 @@ describe Core::SyncJobRunner do
 
           it 'changes connector status to error' do
             expect(Core::ElasticConnectorActions).to receive(:update_connector_status).with(connector_id, Connectors::ConnectorStatus::ERROR)
-            
+
             subject.execute
           end
 
           it 'marks the job as complete with proper error' do
-            expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, {:indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => anything})
+            expect(Core::ElasticConnectorActions).to receive(:complete_sync).with(connector_id, job_id, { :indexed_document_count => extracted_documents.length, :deleted_document_count => existing_document_ids.length, :error => anything })
 
             subject.execute
           end


### PR DESCRIPTION
This PR adds tests for Core::SyncJobRunner to reach full condition/code coverage.

One small change to the logic: now when connector is unable to claim the job, it will not even attempt to run the sync any more.