### PR TITLE
GitLab connector does not sync the files and folders properly #2461

### DIFF
--- a/lib/connectors/gitlab/extractor.rb
+++ b/lib/connectors/gitlab/extractor.rb
@@ -51,15 +51,6 @@ module Connectors
         response.headers['Link'] || nil
       end
 
-      def fetch_project_repository_files(project_id)
-        response = client.get("projects/#{project_id}/repository/tree")
-        if response.status != 200
-          puts "Received #{response.status} status when fetching repository files for project #{project_id}"
-          return []
-        end
-        JSON.parse(response.body)
-      end
-
       def health_check
         # let's do a simple call to get the current user
         response = client.get('user')


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2461

Cleaning up leftover code for GitLab files/folders sync that might have been confusing.

There is just one code block that needed to be removed - less than I thought. And this block was already unused. So this change should be pretty safe.