### PR TITLE
Add tests for Core::Output_Sink::* + refactor sinks a bit

### DIFF
--- a/lib/core/output_sink/base_sink.rb
+++ b/lib/core/output_sink/base_sink.rb
@@ -18,7 +18,7 @@ module Core
       end
 
       def delete(_id)
-        raise 'not_implemented'
+        raise 'not implemented'
       end
 
       def delete_multiple(_ids)

--- a/lib/core/output_sink/console_sink.rb
+++ b/lib/core/output_sink/console_sink.rb
@@ -13,37 +13,38 @@ module Core::OutputSink
   class ConsoleSink < Core::OutputSink::BaseSink
     def ingest(document)
       print_header 'Got a single document:'
-      Utility::Logger.info document
+      puts document
     end
 
     def flush(size: nil)
       print_header 'Flushing'
+      puts "Flush size: #{size}"
     end
 
     def ingest_multiple(documents)
       print_header 'Got multiple documents:'
-      Utility::Logger.info documents
+      puts documents
     end
 
     def delete(id)
       print_header "Deleting single id: #{id}"
-      Utility::Logger.info id
+      puts id
     end
 
     def delete_multiple(ids)
       print_header "Deleting several ids: #{ids}"
-      Utility::Logger.info ids
+      puts ids
     end
 
     private
 
     def print_delim
-      Utility::Logger.info '----------------------------------------------------'
+      puts '----------------------------------------------------'
     end
 
     def print_header(header)
       print_delim
-      Utility::Logger.info header
+      puts header
       print_delim
     end
   end

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -13,8 +13,6 @@ require 'utility/logger'
 
 module Core::OutputSink
   class EsSink < Core::OutputSink::BaseSink
-    attr_accessor :index_name
-
     def initialize(index_name, flush_threshold = 50)
       super()
       @client = Utility::EsClient.new
@@ -57,6 +55,8 @@ module Core::OutputSink
     end
 
     private
+
+    attr_accessor :index_name
 
     def send_data(ops)
       return if ops.empty?

--- a/spec/core/output_sink/base_sink_spec.rb
+++ b/spec/core/output_sink/base_sink_spec.rb
@@ -1,20 +1,7 @@
 require 'core/output_sink'
 
-def get_class_specific_public_methods(klass)
-  (klass.public_methods - Object.public_methods).sort
-end
-
 describe Core::OutputSink::BaseSink do
   subject { described_class.new }
-  let(:specific_sink_classes) do
-    [
-      Core::OutputSink::ConsoleSink,
-      Core::OutputSink::CombinedSink,
-      Core::OutputSink::EsSink
-    ]
-  end
-
-  let(:base_sink_methods) { get_class_specific_public_methods(subject) }
 
   it 'base_sink methods raise an error when called' do
     expect { subject.ingest(nil) }.to raise_error('not implemented')
@@ -22,31 +9,5 @@ describe Core::OutputSink::BaseSink do
     expect { subject.delete(nil) }.to raise_error('not implemented')
     expect { subject.delete_multiple(nil) }.to raise_error('not implemented')
     expect { subject.flush(_size: nil) }.to raise_error('not implemented')
-  end
-
-  shared_examples 'implements all sink methods' do
-    it '' do
-      specific_class_public_methods = get_class_specific_public_methods(sink)
-
-      expect(specific_class_public_methods).to eq(base_sink_methods)
-    end
-  end
-
-  context 'Core::OutputSink::CombinedSink' do
-    let(:sink) { Core::OutputSink::CombinedSink.new }
-
-    it_behaves_like 'implements all sink methods'
-  end
-
-  context 'Core::OutputSink::ConsoleSink' do
-    let(:sink) { Core::OutputSink::ConsoleSink.new }
-
-    it_behaves_like 'implements all sink methods'
-  end
-
-  context 'Core::OutputSink::EsSink' do
-    let(:sink) { Core::OutputSink::EsSink.new('something') }
-
-    it_behaves_like 'implements all sink methods'
   end
 end

--- a/spec/core/output_sink/base_sink_spec.rb
+++ b/spec/core/output_sink/base_sink_spec.rb
@@ -1,0 +1,52 @@
+require 'core/output_sink'
+
+def get_class_specific_public_methods(klass)
+  (klass.public_methods - Object.public_methods).sort
+end
+
+describe Core::OutputSink::BaseSink do
+  subject { described_class.new }
+  let(:specific_sink_classes) do
+    [
+      Core::OutputSink::ConsoleSink,
+      Core::OutputSink::CombinedSink,
+      Core::OutputSink::EsSink
+    ]
+  end
+
+  let(:base_sink_methods) { get_class_specific_public_methods(subject) }
+
+  it 'base_sink methods raise an error when called' do
+    expect { subject.ingest(nil) }.to raise_error('not implemented')
+    expect { subject.ingest_multiple(nil) }.to raise_error('not implemented')
+    expect { subject.delete(nil) }.to raise_error('not implemented')
+    expect { subject.delete_multiple(nil) }.to raise_error('not implemented')
+    expect { subject.flush(_size: nil) }.to raise_error('not implemented')
+  end
+
+  shared_examples 'implements all sink methods' do
+    it '' do
+      specific_class_public_methods = get_class_specific_public_methods(sink)
+
+      expect(specific_class_public_methods).to eq(base_sink_methods)
+    end
+  end
+
+  context 'Core::OutputSink::CombinedSink' do
+    let(:sink) { Core::OutputSink::CombinedSink.new }
+
+    it_behaves_like 'implements all sink methods'
+  end
+
+  context 'Core::OutputSink::ConsoleSink' do
+    let(:sink) { Core::OutputSink::ConsoleSink.new }
+
+    it_behaves_like 'implements all sink methods'
+  end
+
+  context 'Core::OutputSink::EsSink' do
+    let(:sink) { Core::OutputSink::EsSink.new('something') }
+
+    it_behaves_like 'implements all sink methods'
+  end
+end

--- a/spec/core/output_sink/combined_sink_spec.rb
+++ b/spec/core/output_sink/combined_sink_spec.rb
@@ -1,0 +1,62 @@
+require 'core/output_sink/combined_sink'
+
+describe Core::OutputSink::CombinedSink do
+  let(:first_sink) { double }
+  let(:second_sink) { double }
+  subject { described_class.new([ first_sink, second_sink ]) }
+
+  context '.ingest' do
+    let(:doc) { { :id => 1, :something => :else } }
+
+    it 'calls ingest for each sink' do
+      expect(first_sink).to receive(:ingest).with(doc)
+      expect(second_sink).to receive(:ingest).with(doc)
+
+      subject.ingest(doc)
+    end
+  end
+
+  context '.ingest_multiple' do
+    let(:docs) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+
+    it 'calls ingest_multiple for each sink' do
+      expect(first_sink).to receive(:ingest_multiple).with(docs)
+      expect(second_sink).to receive(:ingest_multiple).with(docs)
+
+      subject.ingest_multiple(docs)
+    end
+  end
+
+  context '.delete' do
+    let(:id) { 15 }
+
+    it 'calls delete for each sink' do
+      expect(first_sink).to receive(:delete).with(id)
+      expect(second_sink).to receive(:delete).with(id)
+
+      subject.delete(id)
+    end
+  end
+
+  context '.delete_multiple' do
+    let(:ids) { [ 1, 2, 3, 15, 11, 17]}
+
+    it 'calls delete_multiple for each sink' do
+      expect(first_sink).to receive(:delete_multiple).with(ids)
+      expect(second_sink).to receive(:delete_multiple).with(ids)
+
+      subject.delete_multiple(ids)
+    end
+  end
+
+  context '.flush' do
+    let(:size) { 99 }
+
+    it 'calls flush for each sink' do
+      expect(first_sink).to receive(:flush).with(:size => size)
+      expect(second_sink).to receive(:flush).with(:size => size)
+
+      subject.flush(size: size)
+    end
+  end
+end

--- a/spec/core/output_sink/combined_sink_spec.rb
+++ b/spec/core/output_sink/combined_sink_spec.rb
@@ -3,7 +3,7 @@ require 'core/output_sink/combined_sink'
 describe Core::OutputSink::CombinedSink do
   let(:first_sink) { double }
   let(:second_sink) { double }
-  subject { described_class.new([ first_sink, second_sink ]) }
+  subject { described_class.new([first_sink, second_sink]) }
 
   context '.ingest' do
     let(:doc) { { :id => 1, :something => :else } }
@@ -17,7 +17,7 @@ describe Core::OutputSink::CombinedSink do
   end
 
   context '.ingest_multiple' do
-    let(:docs) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+    let(:docs) { [{ :id => 1, :something => :else }, { :id => 2, :another => :one }] }
 
     it 'calls ingest_multiple for each sink' do
       expect(first_sink).to receive(:ingest_multiple).with(docs)
@@ -39,7 +39,7 @@ describe Core::OutputSink::CombinedSink do
   end
 
   context '.delete_multiple' do
-    let(:ids) { [ 1, 2, 3, 15, 11, 17]}
+    let(:ids) { [1, 2, 3, 15, 11, 17] }
 
     it 'calls delete_multiple for each sink' do
       expect(first_sink).to receive(:delete_multiple).with(ids)

--- a/spec/core/output_sink/combined_sink_spec.rb
+++ b/spec/core/output_sink/combined_sink_spec.rb
@@ -1,9 +1,17 @@
+require 'core/output_sink/base_sink'
 require 'core/output_sink/combined_sink'
+
+require 'spec_helper'
 
 describe Core::OutputSink::CombinedSink do
   let(:first_sink) { double }
   let(:second_sink) { double }
   subject { described_class.new([first_sink, second_sink]) }
+
+  it_behaves_like 'implements all methods of base class' do
+    let(:concrete_class_instance) { subject }
+    let(:base_class_instance) { Core::OutputSink::BaseSink.new }
+  end
 
   context '.ingest' do
     let(:doc) { { :id => 1, :something => :else } }

--- a/spec/core/output_sink/console_sink_spec.rb
+++ b/spec/core/output_sink/console_sink_spec.rb
@@ -7,15 +7,15 @@ describe Core::OutputSink::ConsoleSink do
     let(:doc) { { :id => 1, :something => :else } }
 
     it 'outputs a doc into stdout' do
-      expect { subject.ingest(doc) }.to output(/#{doc.to_s}/).to_stdout
+      expect { subject.ingest(doc) }.to output(/#{doc}/).to_stdout
     end
   end
 
   context '.ingest_multiple' do
-    let(:docs) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+    let(:docs) { [{ :id => 1, :something => :else }, { :id => 2, :another => :one }] }
 
     it 'outputs docs into stdout' do
-      expect { subject.ingest_multiple(docs) }.to output(/#{docs.to_s}/).to_stdout
+      expect { subject.ingest_multiple(docs) }.to output(/#{docs}/).to_stdout
     end
   end
 
@@ -28,10 +28,10 @@ describe Core::OutputSink::ConsoleSink do
   end
 
   context '.delete_multiple' do
-    let(:ids) { [ 1, 2, 3, 15, 11, 17]}
+    let(:ids) { [1, 2, 3, 15, 11, 17] }
 
     it 'outputs deleted ids into stdout' do
-      expect { subject.delete_multiple(ids) }.to output(/#{ids.to_s}/).to_stdout
+      expect { subject.delete_multiple(ids) }.to output(/#{ids}/).to_stdout
     end
   end
 

--- a/spec/core/output_sink/console_sink_spec.rb
+++ b/spec/core/output_sink/console_sink_spec.rb
@@ -1,0 +1,45 @@
+require 'core/output_sink/console_sink'
+
+describe Core::OutputSink::ConsoleSink do
+  subject { described_class.new }
+
+  context '.ingest' do
+    let(:doc) { { :id => 1, :something => :else } }
+
+    it 'outputs a doc into stdout' do
+      expect { subject.ingest(doc) }.to output(/#{doc.to_s}/).to_stdout
+    end
+  end
+
+  context '.ingest_multiple' do
+    let(:docs) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+
+    it 'outputs docs into stdout' do
+      expect { subject.ingest_multiple(docs) }.to output(/#{docs.to_s}/).to_stdout
+    end
+  end
+
+  context '.delete' do
+    let(:id) { 15 }
+
+    it 'outputs deleted id into stdout' do
+      expect { subject.delete(id) }.to output(/#{id}/).to_stdout
+    end
+  end
+
+  context '.delete_multiple' do
+    let(:ids) { [ 1, 2, 3, 15, 11, 17]}
+
+    it 'outputs deleted ids into stdout' do
+      expect { subject.delete_multiple(ids) }.to output(/#{ids.to_s}/).to_stdout
+    end
+  end
+
+  context '.flush' do
+    let(:size) { 99 }
+
+    it 'outputs flush size into stdout' do
+      expect { subject.flush(size: size) }.to output(/#{size}/).to_stdout
+    end
+  end
+end

--- a/spec/core/output_sink/console_sink_spec.rb
+++ b/spec/core/output_sink/console_sink_spec.rb
@@ -1,7 +1,14 @@
 require 'core/output_sink/console_sink'
 
+require 'spec_helper'
+
 describe Core::OutputSink::ConsoleSink do
   subject { described_class.new }
+
+  it_behaves_like 'implements all methods of base class' do
+    let(:concrete_class_instance) { subject }
+    let(:base_class_instance) { Core::OutputSink::BaseSink.new }
+  end
 
   context '.ingest' do
     let(:doc) { { :id => 1, :something => :else } }

--- a/spec/core/output_sink/es_sink_spec.rb
+++ b/spec/core/output_sink/es_sink_spec.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :array_of_size do |x|
 end
 
 describe Core::OutputSink::EsSink do
-  subject { described_class.new(index_name, flush_threshold)}
+  subject { described_class.new(index_name, flush_threshold) }
   let(:index_name) { 'some-index-name' }
   let(:es_client) { double }
   let(:flush_threshold) { 1000 }
@@ -32,7 +32,7 @@ describe Core::OutputSink::EsSink do
       let(:doc_count) { 55 }
 
       it 'sends out one batch of documents' do
-        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+        expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(flush_threshold) })
 
         (1..doc_count).each do |id|
           doc = { :id => id, :data => 'same data' }
@@ -47,7 +47,7 @@ describe Core::OutputSink::EsSink do
             subject.ingest(doc)
           end
 
-          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+          expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(doc_count - flush_threshold) })
 
           subject.flush
         end
@@ -57,7 +57,7 @@ describe Core::OutputSink::EsSink do
 
   context '.ingest_multiple' do
     context('when flush threshold is not reached') do
-      let(:documents) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+      let(:documents) { [{ :id => 1, :something => :else }, { :id => 2, :another => :one }] }
 
       it 'does not immediately send the document into elasticsearch' do
         expect(es_client).to_not receive(:bulk)
@@ -71,7 +71,7 @@ describe Core::OutputSink::EsSink do
       let(:doc_count) { 55 }
 
       it 'sends out one batch of documents' do
-        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+        expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(flush_threshold) })
 
         documents = (1..doc_count).map do |id|
           { :id => id, :data => 'same data' }
@@ -88,7 +88,7 @@ describe Core::OutputSink::EsSink do
 
           subject.ingest_multiple(documents)
 
-          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+          expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(doc_count - flush_threshold) })
 
           subject.flush
         end
@@ -112,7 +112,7 @@ describe Core::OutputSink::EsSink do
       let(:doc_count) { 55 }
 
       it 'sends out one batch of changes' do
-        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+        expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(flush_threshold) })
 
         (1..doc_count).each do |id|
           subject.delete(id)
@@ -125,7 +125,7 @@ describe Core::OutputSink::EsSink do
             subject.delete(id)
           end
 
-          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+          expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(doc_count - flush_threshold) })
 
           subject.flush
         end
@@ -135,7 +135,7 @@ describe Core::OutputSink::EsSink do
 
   context '.delete_multiple' do
     context('when flush threshold is not reached') do
-      let(:ids) { [ 15, 12, 11 ] }
+      let(:ids) { [15, 12, 11] }
 
       it 'does not immediately send the document into elasticsearch' do
         expect(es_client).to_not receive(:bulk)
@@ -149,7 +149,7 @@ describe Core::OutputSink::EsSink do
       let(:doc_count) { 55 }
 
       it 'sends out one batch of documents' do
-        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+        expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(flush_threshold) })
 
         subject.delete_multiple((1..doc_count).to_a)
       end
@@ -158,7 +158,7 @@ describe Core::OutputSink::EsSink do
         it 'second flush sends out the rest of the documents' do
           subject.delete_multiple((1..doc_count).to_a)
 
-          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+          expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(doc_count - flush_threshold) })
 
           subject.flush
         end
@@ -171,7 +171,7 @@ describe Core::OutputSink::EsSink do
     let(:doc_count) { 5 }
 
     it 'sends the documents once flush is triggered' do
-      expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count) })
+      expect(es_client).to receive(:bulk).once.with({ :body => array_of_size(doc_count) })
 
       (1..doc_count).each do |id|
         doc = { :id => id, :data => 'same data' }

--- a/spec/core/output_sink/es_sink_spec.rb
+++ b/spec/core/output_sink/es_sink_spec.rb
@@ -1,6 +1,8 @@
 require 'core/output_sink/es_sink'
 require 'utility/es_client'
 
+require 'spec_helper'
+
 RSpec::Matchers.define :array_of_size do |x|
   match { |actual| actual.size == x }
 end
@@ -14,6 +16,11 @@ describe Core::OutputSink::EsSink do
   before(:each) do
     allow(Utility::EsClient).to receive(:new).and_return(es_client)
     allow(es_client).to receive(:bulk)
+  end
+
+  it_behaves_like 'implements all methods of base class' do
+    let(:concrete_class_instance) { subject }
+    let(:base_class_instance) { Core::OutputSink::BaseSink.new }
   end
 
   context '.ingest' do

--- a/spec/core/output_sink/es_sink_spec.rb
+++ b/spec/core/output_sink/es_sink_spec.rb
@@ -1,0 +1,184 @@
+require 'core/output_sink/es_sink'
+require 'utility/es_client'
+
+RSpec::Matchers.define :array_of_size do |x|
+  match { |actual| actual.size == x }
+end
+
+describe Core::OutputSink::EsSink do
+  subject { described_class.new(index_name, flush_threshold)}
+  let(:index_name) { 'some-index-name' }
+  let(:es_client) { double }
+  let(:flush_threshold) { 1000 }
+
+  before(:each) do
+    allow(Utility::EsClient).to receive(:new).and_return(es_client)
+    allow(es_client).to receive(:bulk)
+  end
+
+  context '.ingest' do
+    context('when flush threshold is not reached') do
+      let(:doc) { { :id => 1, :something => :else } }
+
+      it 'does not immediately send the document into elasticsearch' do
+        expect(es_client).to_not receive(:bulk)
+
+        subject.ingest(doc)
+      end
+    end
+
+    context 'when flush threshold is reached' do
+      let(:flush_threshold) { 50 }
+      let(:doc_count) { 55 }
+
+      it 'sends out one batch of documents' do
+        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+
+        (1..doc_count).each do |id|
+          doc = { :id => id, :data => 'same data' }
+          subject.ingest(doc)
+        end
+      end
+
+      context 'when flush is called afterwards' do
+        it 'second flush sends out the rest of the documents' do
+          (1..doc_count).each do |id|
+            doc = { :id => id, :data => 'same data' }
+            subject.ingest(doc)
+          end
+
+          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+
+          subject.flush
+        end
+      end
+    end
+  end
+
+  context '.ingest_multiple' do
+    context('when flush threshold is not reached') do
+      let(:documents) { [ { :id => 1, :something => :else }, { :id => 2, :another => :one } ] }
+
+      it 'does not immediately send the document into elasticsearch' do
+        expect(es_client).to_not receive(:bulk)
+
+        subject.ingest_multiple(documents)
+      end
+    end
+
+    context 'when flush threshold is reached' do
+      let(:flush_threshold) { 50 }
+      let(:doc_count) { 55 }
+
+      it 'sends out one batch of documents' do
+        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+
+        documents = (1..doc_count).map do |id|
+          { :id => id, :data => 'same data' }
+        end
+
+        subject.ingest_multiple(documents)
+      end
+
+      context 'when flush is called afterwards' do
+        it 'second flush sends out the rest of the documents' do
+          documents = (1..doc_count).map do |id|
+            { :id => id, :data => 'same data' }
+          end
+
+          subject.ingest_multiple(documents)
+
+          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+
+          subject.flush
+        end
+      end
+    end
+  end
+
+  context '.delete' do
+    context('when flush threshold is not reached') do
+      let(:id) { 15 }
+
+      it 'does not immediately send the document into elasticsearch' do
+        expect(es_client).to_not receive(:bulk)
+
+        subject.delete(id)
+      end
+    end
+
+    context 'when flush threshold is reached' do
+      let(:flush_threshold) { 50 }
+      let(:doc_count) { 55 }
+
+      it 'sends out one batch of changes' do
+        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+
+        (1..doc_count).each do |id|
+          subject.delete(id)
+        end
+      end
+
+      context 'when flush is called afterwards' do
+        it 'second flush sends out the rest of the documents' do
+          (1..doc_count).each do |id|
+            subject.delete(id)
+          end
+
+          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+
+          subject.flush
+        end
+      end
+    end
+  end
+
+  context '.delete_multiple' do
+    context('when flush threshold is not reached') do
+      let(:ids) { [ 15, 12, 11 ] }
+
+      it 'does not immediately send the document into elasticsearch' do
+        expect(es_client).to_not receive(:bulk)
+
+        subject.delete_multiple(ids)
+      end
+    end
+
+    context 'when flush threshold is reached' do
+      let(:flush_threshold) { 50 }
+      let(:doc_count) { 55 }
+
+      it 'sends out one batch of documents' do
+        expect(es_client).to receive(:bulk).once.with({:body => array_of_size(flush_threshold) })
+
+        subject.delete_multiple((1..doc_count).to_a)
+      end
+
+      context 'when flush is called afterwards' do
+        it 'second flush sends out the rest of the documents' do
+          subject.delete_multiple((1..doc_count).to_a)
+
+          expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count - flush_threshold) })
+
+          subject.flush
+        end
+      end
+    end
+  end
+
+  context '.flush' do
+    let(:flush_threshold) { 50 }
+    let(:doc_count) { 5 }
+
+    it 'sends the documents once flush is triggered' do
+      expect(es_client).to receive(:bulk).once.with({:body => array_of_size(doc_count) })
+
+      (1..doc_count).each do |id|
+        doc = { :id => id, :data => 'same data' }
+        subject.ingest(doc)
+      end
+
+      subject.flush
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require 'active_support/core_ext/time/zones'
 require 'simplecov'
 require 'simplecov-material'
 
-Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 # Eneable coverage report
 SimpleCov.add_filter('spec')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require 'active_support/core_ext/time/zones'
 require 'simplecov'
 require 'simplecov-material'
 
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 # Eneable coverage report
 SimpleCov.add_filter('spec')
 SimpleCov.formatter = SimpleCov::Formatter::MaterialFormatter
@@ -29,6 +31,10 @@ end
 
 def connectors_fixture_json(fixture_name)
   JSON.parse(connectors_fixture_raw(fixture_name))
+end
+
+def get_class_specific_public_methods(klass)
+  (klass.public_methods - Object.public_methods).sort
 end
 
 def random_string

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -6,6 +6,15 @@
 
 # frozen_string_literal: true
 
+shared_examples 'implements all methods of base class' do
+  it '' do
+    base_class_public_methods = get_class_specific_public_methods(base_class_instance)
+    specific_class_public_methods = get_class_specific_public_methods(concrete_class_instance)
+
+    expect(specific_class_public_methods).to eq(base_class_public_methods)
+  end
+end
+
 shared_examples 'does not populate updated_at' do
   it 'returns document that does not have updated_at field' do
     expect(document.with_indifferent_access).to_not include(have_key(:updated_at))


### PR DESCRIPTION
This PR adds tests for files under `lib/core/output_sink/` directory.

Minor changes to sinks:

- Standartize `not implemented` message for BaseSink
- Use `puts` instead of `Logger.info` in ConsoleSink - it seems like usage of logger here does not make sense, cause sink is expected to always output by design
- Move `attr_accessor :index_name` for EsSink to `private` region
