### PR TITLE
[8.4] Add test coverage for lib/app/worker.rb + modify heartbeat logic for better separation of concerns (#236)

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -11,7 +11,6 @@ require 'connectors'
 require 'core'
 require 'utility'
 require 'app/config'
-require 'concurrent'
 
 module App
   module Worker
@@ -43,18 +42,8 @@ module App
       def start_heartbeat_task
         connector_id = App::Config[:connector_id]
         service_type = App::Config[:service_type]
-        interval_seconds = 60 # seconds
-        Utility::Logger.debug("Starting heartbeat timer task with interval #{interval_seconds} seconds.")
-        task = Concurrent::TimerTask.new(execution_interval: interval_seconds, run_now: true) do
-          Utility::Logger.debug("Sending heartbeat for the connector #{connector_id}")
-          Core::Heartbeat.send(connector_id, service_type)
-        rescue StandardError => e
-          Utility::ExceptionTracking.log_exception(e, 'Heartbeat timer encountered unexpected error.')
-        end
 
-        Utility::Logger.info('Successfully started heartbeat task.')
-
-        task.execute
+        Core::Heartbeat.start_task(connector_id, service_type)
       end
 
       def start_polling_jobs

--- a/lib/utility/environment.rb
+++ b/lib/utility/environment.rb
@@ -5,6 +5,7 @@
 #
 
 require 'logger'
+require 'utility/logger'
 require 'active_support/core_ext/module'
 
 module Utility

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -1,0 +1,117 @@
+require 'core/heartbeat'
+require 'connectors/connector_status'
+
+describe Core::Heartbeat do
+  let(:connector_id) { '123' }
+  let(:service_type) { 'foo' }
+  let(:connector_status) { Connectors::ConnectorStatus::CONNECTED }
+  let(:connector_stored_configuration) { {} } # returned from Elasticsearch with values already specified by user
+  let(:connector_default_configuration) { {} } # returned from Connector class with default values
+
+  let(:connector_settings) { double }
+  let(:connector_class) { double }
+  let(:connector_instance) { double }
+
+  let(:source_status) { { :status => 'OK' } }
+
+  before(:each) do
+    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
+
+    allow(Core::ElasticConnectorActions).to receive(:update_connector_fields)
+
+    allow(Connectors::REGISTRY).to receive(:connector_class).and_return(connector_class)
+
+    allow(connector_settings).to receive(:connector_status).and_return(connector_status)
+    allow(connector_settings).to receive(:connector_status_allows_sync?).and_return(true)
+    allow(connector_settings).to receive(:configuration).and_return(connector_stored_configuration)
+
+    allow(connector_class).to receive(:configurable_fields).and_return(connector_default_configuration)
+    allow(connector_class).to receive(:new).and_return(connector_instance)
+
+    allow(connector_instance).to receive(:source_status).and_return(source_status)
+  end
+
+  describe '.start_task' do
+    # Just replacing threaded timer task with immediate execution to find problems immediately,
+    # otherwise timer task just swallows errors
+    context 'when running code synchronously just one time' do
+      before(:each) do
+        allow(Concurrent::TimerTask).to receive(:execute).and_yield
+      end
+
+      context 'when connector has just been created' do
+        let(:connector_status) { Connectors::ConnectorStatus::CREATED }
+
+        context 'when connector has no configurable fields' do
+          it 'updates connector status to CONFIGURED' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+
+        context 'when connector has some configurable fields without default values' do
+          let(:connector_default_configuration) do
+            {
+              :foo => {
+                :label => 'Foo',
+                :value => nil
+              },
+              :lala => {
+                :label => 'Lala',
+                :value => 'hello'
+              }
+            }
+          end
+
+          it 'updates connector status to NEEDS_CONFIGURATION' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+
+        context 'when connector has all configurable fields with default values' do
+          let(:connector_default_configuration) do
+            {
+              :foo => {
+                :label => 'Foo',
+                :value => 'FF'
+              },
+              :lala => {
+                :label => 'Lala',
+                :value => 'hello'
+              }
+            }
+          end
+
+          it 'updates connector status to CONFIGURED' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+
+            described_class.start_task(connector_id, service_type)
+          end
+        end
+      end
+
+      context 'when connector is already connected' do
+        it 'updates connector last_seen and status only' do
+          expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :status => Connectors::ConnectorStatus::CONNECTED })
+
+          described_class.start_task(connector_id, service_type)
+        end
+      end
+
+      context 'when connector settings were not found' do
+        let(:error) { 'something really bad happened' }
+
+        before(:each) do
+          allow(Core::ConnectorSettings).to receive(:fetch).and_raise(error)
+        end
+
+        it 'does not raise an error' do
+          expect { described_class.start_task(connector_id, service_type) }.to_not raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -1,0 +1,55 @@
+require 'elasticsearch'
+require 'utility/es_client'
+require 'utility/environment'
+
+RSpec.describe Utility::EsClient do
+  let(:host) { 'http://notreallyaserver' }
+  let(:config) do
+    {
+      :service_type => 'stub_connector',
+      :log_level => 'INFO',
+      :connector_id => '1',
+      :elasticsearch => {
+        :api_key => 'key',
+        :hosts => host,
+        :disable_warnings => disable_warnings
+      }
+    }
+  end
+
+  let(:subject) { described_class.new }
+
+  before(:each) do
+    stub_const('App::Config', config)
+
+    stub_request(:get, "#{host}:9200/")
+      .to_return(status: 403, body: '', headers: {})
+    stub_request(:get, "#{host}:9200/_cluster/health")
+  end
+
+  context 'when wrapped in Utility::Environment.set_execution_environment' do
+    around(:each) do |example|
+      Utility::Environment.set_execution_environment(config) do
+        example.run
+      end
+    end
+
+    context 'when disable_warnings=false' do
+      let(:disable_warnings) { false }
+      it 'receives warnings from elasticsearch client' do
+        expect {
+          subject.cluster.health
+        }.to output(/#{Elasticsearch::SECURITY_PRIVILEGES_VALIDATION_WARNING}/).to_stderr
+      end
+    end
+
+    context 'when disable_warnings=true' do
+      let(:disable_warnings) { true }
+      it 'receives no warnings from elasticsearch client' do
+        expect {
+          subject.cluster.health
+        }.to_not output.to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Add test coverage for lib/app/worker.rb + modify heartbeat logic for better separation of concerns (#236)](https://github.com/elastic/connectors-ruby/pull/236)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)