### PR TITLE
[8.4] Fix connector protocol sequence diagram (#251)

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -44,16 +44,38 @@ Connectors should update the last_seen field with their current datetime in UTC 
 - Write a UTC date-time to the `last_seen` property as a heartbeat, at least every half hour. Kibana will show an error if the date in `last_seen` is more than half an hour ago.
 
 **Sequence diagram**:
-User->Kibana: Generates new API key & id
-Kibana->Elasticsearch: Saves API key & id
-User->Connector: Deploys with API key, id & Elasticsearch host
-Connector->Elasticsearch: Writes its connector definition to .elastic-connectors
-Elasticsearch->Kibana: Returns connector definition
-Kibana->User: Returns connector definition
-User->Kibana: Enters necessary configuration
-Kibana->Elasticsearch: Writes configuration
-Connector->Elasticsearch: Picks up configuration and starts syncing
-
+```mermaid
+sequenceDiagram
+    actor User
+    participant Kibana
+    participant Elasticsearch
+    participant Connector
+    participant Data source
+    User->>Kibana: Generates new API key & id
+    Kibana->>Elasticsearch: Saves API key & id
+    User->>Connector: Deploys with API key, id & Elasticsearch host
+    Connector->>Elasticsearch: Writes its connector definition to .elastic-connectors
+    Elasticsearch->>Kibana: Returns connector definition
+    Kibana->>User: Returns connector definition
+    User->>Kibana: Enters necessary configuration and synchronization schedule
+    Kibana->>Elasticsearch: Writes configuration and synchronization schedule
+    Connector->>Elasticsearch: Reads configuration and synchronization schedule
+    loop Every minute
+        Connector->>Elasticsearch: Reads sync_now flag and sync schedule
+        Connector->>Elasticsearch: Updates last_seen to current datetime
+        opt Sync_now is true or sync_schedule requires synchronization
+            Connector->>Elasticsearch: Sets sync_now to false and last_sync_status to in_progress
+            Connector->>Data source: Reads data
+            Connector->>Elasticsearch: Indexes data
+            alt Sync successfully completed
+                Connector->>Elasticsearch: Sets last_sync_status to success
+            else Sync error
+                Connector->>Elasticsearch: Sets status and last_sync_status to error
+                Connector->>Elasticsearch: Writes error message to error field
+            end
+        end
+    end
+```
 ### .elastic-connectors
 
 This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Fix connector protocol sequence diagram (#251)](https://github.com/elastic/connectors-ruby/pull/251)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)