### PR TITLE
Add tests for mongo connector

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -6,8 +6,9 @@
 
 # frozen_string_literal: true
 
-require 'mongo'
+require 'active_support/core_ext/hash/indifferent_access'
 require 'connectors/base/connector'
+require 'mongo'
 
 module Connectors
   module MongoDB
@@ -42,10 +43,6 @@ module Connectors
         @collection = remote_configuration.dig(:collection, :value)
       end
 
-      def health_check(_params)
-        create_client(@host, @database)
-      end
-
       def yield_documents
         mongodb_client = create_client(@host, @database)
 
@@ -55,6 +52,12 @@ module Connectors
 
           yield doc
         end
+      end
+
+      private
+
+      def health_check(_params)
+        create_client(@host, @database)
       end
 
       def create_client(host, database)

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -23,6 +23,8 @@ describe Connectors::GitLab::Connector do
     Connectors::GitLab::Connector.new(local_configuration: app_config, remote_configuration: remote_config)
   end
 
+  it_behaves_like 'a connector'
+
   context '#source_status' do
     it 'correctly returns true on 200' do
       stub_request(:get, "#{base_url}/user")

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'connectors/mongodb/connector'
+require 'hashie/mash'
+require 'spec_helper'
+
+describe Connectors::MongoDB::Connector do
+  subject { described_class.new(local_configuration: local_configuration, remote_configuration: remote_configuration) }
+  let(:local_configuration) { {} }
+  let(:remote_configuration) do
+    {
+       :host => {
+         :label => 'MongoDB Server Hostname',
+         :value => mongodb_host
+       },
+       :database => {
+         :label => 'MongoDB Database',
+         :value => mongodb_database
+       },
+       :collection => {
+         :label => 'MongoDB Collection',
+         :value => mongodb_collection
+       }
+    }
+  end
+
+  let(:mongodb_host) { '127.0.0.1:27027' }
+  let(:mongodb_database) { 'sample-database' } 
+  let(:mongodb_collection) { 'some-collection' }
+
+  let(:mongo_client) { double }
+
+  let(:actual_collection) { double }
+  let(:actual_collection_data) { [] }
+
+  before(:each) do
+    allow(Mongo::Client).to receive(:new).and_return(mongo_client)
+
+    allow(mongo_client).to receive(:collections).and_return([ Hashie::Mash.new({ :name => mongodb_collection }) ])
+    allow(mongo_client).to receive(:database_names).and_return([ Hashie::Mash.new({ :name => mongodb_database }) ])
+    allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
+    
+    allow(actual_collection).to receive(:find).and_return(actual_collection_data)
+  end
+
+  it_behaves_like 'a connector'
+
+  context '#source_status' do
+    it 'instantiates a mongodb client' do
+      expect(Mongo::Client).to receive(:new).with([mongodb_host], hash_including(:database => mongodb_database))
+
+      subject.source_status({})
+    end
+  end
+  
+  context '#yield_documents' do
+    context 'when database is not found' do
+      xit 'no error is raised' do
+        # Leaving this here to describe the work of MongoDB client:
+        # When database is not found on the server, the client does not raise errors
+        # Instead, it acts as if a database exists on server, but has no collections
+        # So every call to .collection will return empty iterator.
+      end
+    end
+
+    context 'when collection is not found' do
+      # mongo client does not raise an error when collection is not found on the server, instead it just returns an empty collection
+      let(:actual_collection_data) { [ ] }
+
+      it 'does not raise' do
+        expect { |b| subject.yield_documents(&b) }.to_not raise_error(anything)
+      end
+
+      it 'does not yield' do
+        expect { |b| subject.yield_documents(&b) }.to_not yield_with_args(anything)
+      end
+    end
+
+    context 'when collection is found' do
+      let(:actual_collection_data) do
+        [
+          { '_id' => '1', 'some' => { 'nested' => 'data' } },
+          { '_id' => '2', 'more' => { 'nested' => 'data' } },
+          { '_id' => '167', 'nothing' => nil },
+          { '_id' => 'last' }
+        ]
+      end
+
+      it 'yields each document of the collection replacing _id with id' do
+        expected_ids = actual_collection_data.map {|d| d['_id'] }.to_a
+
+        yielded_documents = []
+        
+        subject.yield_documents { |doc| yielded_documents << doc }
+
+        expect(yielded_documents.size).to eq(actual_collection_data.size)
+        expected_ids.each do |id|
+          expect(yielded_documents).to include(a_hash_including('id' => id))
+        end
+      end
+    end
+  end
+end

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -25,7 +25,7 @@ describe Connectors::MongoDB::Connector do
   end
 
   let(:mongodb_host) { '127.0.0.1:27027' }
-  let(:mongodb_database) { 'sample-database' } 
+  let(:mongodb_database) { 'sample-database' }
   let(:mongodb_collection) { 'some-collection' }
 
   let(:mongo_client) { double }
@@ -36,10 +36,10 @@ describe Connectors::MongoDB::Connector do
   before(:each) do
     allow(Mongo::Client).to receive(:new).and_return(mongo_client)
 
-    allow(mongo_client).to receive(:collections).and_return([ Hashie::Mash.new({ :name => mongodb_collection }) ])
-    allow(mongo_client).to receive(:database_names).and_return([ Hashie::Mash.new({ :name => mongodb_database }) ])
+    allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
+    allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
     allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
-    
+
     allow(actual_collection).to receive(:find).and_return(actual_collection_data)
   end
 
@@ -52,7 +52,7 @@ describe Connectors::MongoDB::Connector do
       subject.source_status({})
     end
   end
-  
+
   context '#yield_documents' do
     context 'when database is not found' do
       xit 'no error is raised' do
@@ -65,7 +65,7 @@ describe Connectors::MongoDB::Connector do
 
     context 'when collection is not found' do
       # mongo client does not raise an error when collection is not found on the server, instead it just returns an empty collection
-      let(:actual_collection_data) { [ ] }
+      let(:actual_collection_data) { [] }
 
       it 'does not raise' do
         expect { |b| subject.yield_documents(&b) }.to_not raise_error(anything)
@@ -87,10 +87,10 @@ describe Connectors::MongoDB::Connector do
       end
 
       it 'yields each document of the collection replacing _id with id' do
-        expected_ids = actual_collection_data.map {|d| d['_id'] }.to_a
+        expected_ids = actual_collection_data.map { |d| d['_id'] }.to_a
 
         yielded_documents = []
-        
+
         subject.yield_documents { |doc| yielded_documents << doc }
 
         expect(yielded_documents.size).to eq(actual_collection_data.size)

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -47,7 +47,7 @@ shared_examples 'a connector' do
     expect(configurable_fields).to respond_to(:keys)
     expect(configurable_fields).to respond_to(:[])
 
-    configurable_fields.keys.each do |field_name|
+    configurable_fields.each_key do |field_name|
       field_definition = configurable_fields[field_name]
 
       # is a hash too

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -20,3 +20,44 @@ shared_examples 'does not populate updated_at' do
     expect(document.with_indifferent_access).to_not include(have_key(:updated_at))
   end
 end
+
+shared_examples 'a connector' do
+  it 'implements display_name class method' do
+    expect(described_class.display_name).to_not be_nil
+  end
+
+  it 'implements service_type class method' do
+    expect(described_class.service_type).to_not be_nil
+  end
+
+  it 'implements configurable_fields class method' do
+    expect(described_class.configurable_fields).to_not be_nil
+  end
+
+  it 'configurable_fields class method returns valid configuration' do
+    # expected configurable fields format:
+    # {
+    #   'key' => {
+    #     'label' => '',
+    #     'value' => ''
+    #   }
+    # }
+    configurable_fields = described_class.configurable_fields.with_indifferent_access
+
+    expect(configurable_fields).to respond_to(:keys)
+    expect(configurable_fields).to respond_to(:[])
+
+    configurable_fields.keys.each do |field_name|
+      field_definition = configurable_fields[field_name]
+
+      # is a hash too
+      expect(field_definition).to respond_to(:keys)
+      expect(field_definition).to respond_to(:[])
+
+      expect(field_definition['label']).to_not be_nil
+      if field_definition['value']
+        expect(field_definition['value']).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds test coverage for our sample MongoDB connector - the coverage is 100%, but covers only basic scenarios - no negative cases, special error handling or anything. They can be added once needed.