### PR TITLE
[8.4] Add example connector test coverage (#267)

### DIFF
--- a/spec/connectors/example/connector_spec.rb
+++ b/spec/connectors/example/connector_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'connectors/example/connector'
+require 'spec_helper'
+
+describe Connectors::Example::Connector do
+  subject { described_class.new(local_configuration: local_configuration, remote_configuration: remote_configuration) }
+  let(:local_configuration) { {} }
+  let(:remote_configuration) do
+    {
+       :foo => {
+         :label => 'Foo',
+         :value => 'something'
+       }
+    }
+  end
+
+  it_behaves_like 'a connector'
+
+  context '#source_status' do
+    it 'returns ok' do
+      expect(subject.source_status({})).to include(:status => 'OK')
+    end
+  end
+
+  context '#yield_documents' do
+    it 'returns some documents' do
+      documents = []
+
+      subject.yield_documents { |doc| documents << doc }
+
+      expect(documents.size).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Add example connector test coverage (#267)](https://github.com/elastic/connectors-ruby/pull/267)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)