### PR TITLE
[8.4] Add test coverage for Gitlab Connector  (#266)

### DIFF
--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -63,10 +63,6 @@ module Connectors
       def health_check(_params)
         @extractor.health_check
       end
-
-      def custom_client_error
-        Connectors::GitLab::CustomClient::ClientError
-      end
     end
   end
 end

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'hashie/mash'
 require 'connectors/gitlab/connector'
 require 'connectors/gitlab/custom_client'
+require 'spec_helper'
 
 describe Connectors::GitLab::Connector do
   let(:user_json) { connectors_fixture_raw('gitlab/user.json') }
   let(:base_url) { Connectors::GitLab::DEFAULT_BASE_URL }
   let(:app_config) do
-    Hashie::Mash.new(
+    {
       :elasticsearch => { :api_key => 'hello-world', :hosts => 'localhost:9200' },
       :gitlab => { :api_token => 'some_token' }
-    )
+    }
   end
   let(:remote_config) do
     {
@@ -51,6 +51,61 @@ describe Connectors::GitLab::Connector do
 
       expect(result).to_not be_nil
       expect(result[:status]).to eq('FAILURE')
+    end
+  end
+
+  context '#yield_documents' do
+    let(:page_count) { 3 }
+    let(:page_size) { 100 }
+
+    let(:first_page_next_page_link) { 'https://next.page/1' }
+    let(:second_page_next_page_link) { 'https://next.page/2' }
+    let(:third_page_next_page_link) { 'https://next.page/3' }
+
+    let(:extractor) { double }
+
+    def create_data_page(ids)
+      ids.map do |id|
+        {
+          :id => id,
+          :something => "something-#{id}"
+        }
+      end
+    end
+
+    before(:each) do
+      allow(Connectors::GitLab::Extractor).to receive(:new).and_return(extractor)
+
+      allow(extractor)
+        .to receive(:yield_projects_page)
+        .with(nil)
+        .and_yield(create_data_page(1..page_size))
+        .and_return(first_page_next_page_link)
+
+      allow(extractor)
+        .to receive(:yield_projects_page)
+        .with(first_page_next_page_link)
+        .and_yield(create_data_page(page_size + 1..page_size * 2))
+        .and_return(second_page_next_page_link)
+
+      allow(extractor)
+        .to receive(:yield_projects_page)
+        .with(second_page_next_page_link)
+        .and_yield(create_data_page(page_size * 2 + 1..page_size * 3))
+        .and_return(third_page_next_page_link)
+
+      allow(extractor)
+        .to receive(:yield_projects_page)
+        .with(third_page_next_page_link)
+        .and_return(nil)
+    end
+
+    it 'extracts all documents' do
+      docs = []
+
+      subject.yield_documents { |doc| docs << doc }
+
+      expect(docs.size).to eq(page_count * page_size)
     end
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Add test coverage for Gitlab Connector  (#266)](https://github.com/elastic/connectors-ruby/pull/266)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)