### PR TITLE
Store service_type for connector in Kibana `.elastic-connectors` index.

### DIFF
--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -43,6 +43,7 @@ module Core
         if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
           connector_class = Connectors::REGISTRY.connector_class(service_type)
           configuration = connector_class.configurable_fields
+          doc[:service_type] = service_type
           doc[:configuration] = configuration
 
           # We want to set connector to CONFIGURED status if all configurable fields have default values

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -43,9 +43,9 @@ describe Core::Heartbeat do
         let(:connector_status) { Connectors::ConnectorStatus::CREATED }
 
         it 'updates stored connector service_type' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:service_type => service_type))
+          expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:service_type => service_type))
 
-            described_class.start_task(connector_id, service_type)
+          described_class.start_task(connector_id, service_type)
         end
 
         context 'when connector has no configurable fields' do

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -42,9 +42,15 @@ describe Core::Heartbeat do
       context 'when connector has just been created' do
         let(:connector_status) { Connectors::ConnectorStatus::CREATED }
 
+        it 'updates stored connector service_type' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:service_type => service_type))
+
+            described_class.start_task(connector_id, service_type)
+        end
+
         context 'when connector has no configurable fields' do
           it 'updates connector status to CONFIGURED' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
             described_class.start_task(connector_id, service_type)
           end
@@ -64,8 +70,14 @@ describe Core::Heartbeat do
             }
           end
 
+          it 'updates connector configuration' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:configuration => connector_default_configuration))
+
+            described_class.start_task(connector_id, service_type)
+          end
+
           it 'updates connector status to NEEDS_CONFIGURATION' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
             described_class.start_task(connector_id, service_type)
           end
@@ -85,8 +97,14 @@ describe Core::Heartbeat do
             }
           end
 
+          it 'updates connector configuration' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:configuration => connector_default_configuration))
+
+            described_class.start_task(connector_id, service_type)
+          end
+
           it 'updates connector status to CONFIGURED' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
             described_class.start_task(connector_id, service_type)
           end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2419

When connector service starts up, now it will attempt to populate `service_type` for the record in Kibana `.elastic-connectors` index so that service type is now displayed in Kibana.

There is still something we can follow up on later, for example when connector tries to run a sync, it should check that it runs against expected service type.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally

## Screenshots

Before the fix:
![image](https://user-images.githubusercontent.com/12238374/185979227-26808a3d-ebb6-4606-82d6-23cf0cec73c3.png)

After the fix:
![image](https://user-images.githubusercontent.com/12238374/185979262-5a19000e-8638-4de4-b986-b6ef639ffdd9.png)
