### PR TITLE
[8.4] Store service_type for connector in Kibana `.elastic-connectors` index. (#276)

### DIFF
--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -43,6 +43,7 @@ module Core
         if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
           connector_class = Connectors::REGISTRY.connector_class(service_type)
           configuration = connector_class.configurable_fields
+          doc[:service_type] = service_type
           doc[:configuration] = configuration
 
           # We want to set connector to CONFIGURED status if all configurable fields have default values

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -42,9 +42,15 @@ describe Core::Heartbeat do
       context 'when connector has just been created' do
         let(:connector_status) { Connectors::ConnectorStatus::CREATED }
 
+        it 'updates stored connector service_type' do
+          expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:service_type => service_type))
+
+          described_class.start_task(connector_id, service_type)
+        end
+
         context 'when connector has no configurable fields' do
           it 'updates connector status to CONFIGURED' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
             described_class.start_task(connector_id, service_type)
           end
@@ -64,8 +70,14 @@ describe Core::Heartbeat do
             }
           end
 
+          it 'updates connector configuration' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:configuration => connector_default_configuration))
+
+            described_class.start_task(connector_id, service_type)
+          end
+
           it 'updates connector status to NEEDS_CONFIGURATION' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
             described_class.start_task(connector_id, service_type)
           end
@@ -85,8 +97,14 @@ describe Core::Heartbeat do
             }
           end
 
+          it 'updates connector configuration' do
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:configuration => connector_default_configuration))
+
+            described_class.start_task(connector_id, service_type)
+          end
+
           it 'updates connector status to CONFIGURED' do
-            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, { :last_seen => anything, :configuration => connector_default_configuration, :status => Connectors::ConnectorStatus::CONFIGURED })
+            expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
             described_class.start_task(connector_id, service_type)
           end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Store service_type for connector in Kibana `.elastic-connectors` index. (#276)](https://github.com/elastic/connectors-ruby/pull/276)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)