### PR TITLE
Make EsClient independent of App::Config

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -220,7 +220,7 @@ module Core
       private
 
       def client
-        @client ||= Utility::EsClient.new
+        @client ||= Utility::EsClient.new(App::Config[:elasticsearch])
       end
     end
   end

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -15,7 +15,7 @@ module Core::OutputSink
   class EsSink < Core::OutputSink::BaseSink
     def initialize(index_name, flush_threshold = 50)
       super()
-      @client = Utility::EsClient.new
+      @client = Utility::EsClient.new(App::Config[:elasticsearch])
       @index_name = index_name
       @operation_queue = []
       @flush_threshold = flush_threshold

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -8,7 +8,6 @@
 
 require 'logger'
 require 'elasticsearch'
-require 'app/config'
 
 module Utility
   class EsClient < ::Elasticsearch::Client
@@ -21,12 +20,11 @@ module Utility
       attr_reader :cause
     end
 
-    def initialize
-      super(connection_configs)
+    def initialize(es_config)
+      super(connection_configs(es_config))
     end
 
-    def connection_configs
-      es_config = App::Config[:elasticsearch]
+    def connection_configs(es_config)
       configs = { :api_key => es_config[:api_key] }
       if es_config[:cloud_id]
         configs[:cloud_id] = es_config[:cloud_id]

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -17,11 +17,9 @@ RSpec.describe Utility::EsClient do
     }
   end
 
-  let(:subject) { described_class.new }
+  let(:subject) { described_class.new(config[:elasticsearch]) }
 
   before(:each) do
-    stub_const('App::Config', config)
-
     stub_request(:get, "#{host}:9200/")
       .to_return(status: 403, body: '', headers: {})
     stub_request(:get, "#{host}:9200/_cluster/health")


### PR DESCRIPTION
## https://github.com/elastic/enterprise-search-team/issues/2543

To be able to use `Utility::EsClient` in ent-search we need to make it independent of `App::Config`. Ent-search doesn't have `connectors.yml` file that is being used in `App::Config`. 

## Checklists
#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
