### PR TITLE
Add Utility::EsClient to connectors_utility

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
                     LICENSE
                     NOTICE.txt
                     lib/connectors_utility.rb
+                    lib/utility/es_client.rb
+                    lib/utility/logger.rb
                     lib/utility/elasticsearch/index/text_analysis_settings.rb
                     lib/utility/elasticsearch/index/mappings.rb
                     lib/utility/elasticsearch/index/language_data.yml

--- a/lib/connectors_utility.rb
+++ b/lib/connectors_utility.rb
@@ -6,7 +6,6 @@
 
 # frozen_string_literal: true
 
-
 require_relative 'utility/es_client'
 require_relative 'utility/logger'
 require_relative 'utility/elasticsearch/index/text_analysis_settings'

--- a/lib/connectors_utility.rb
+++ b/lib/connectors_utility.rb
@@ -6,5 +6,8 @@
 
 # frozen_string_literal: true
 
+
+require_relative 'utility/es_client'
+require_relative 'utility/logger'
 require_relative 'utility/elasticsearch/index/text_analysis_settings'
 require_relative 'utility/elasticsearch/index/mappings'


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2543

This PR will add `Utility::EsClient` to connectors_utility which will be used in ent-search Crawler2 namespace. 

#### Pre-Review Checklist
- [x] Tested the changes locally

## Related Pull Requests
* https://github.com/elastic/ent-search/pull/6799
* https://github.com/elastic/connectors-ruby/pull/278