### PR TITLE
Add simple POC for asymmetric encryption

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -11,6 +11,7 @@ require 'active_support/core_ext/object/blank'
 require 'connectors/connector_status'
 require 'time'
 require 'utility/logger'
+require 'utility/encryption_helper'
 
 module Core
   class ConnectorSettings
@@ -51,7 +52,7 @@ module Core
     end
 
     def configuration
-      self[:configuration]
+      Utility::EncryptionHelper.decrypt(self[:encryption], self[:encrypted_configuration])
     end
 
     def scheduling_settings

--- a/lib/utility/encryption_helper.rb
+++ b/lib/utility/encryption_helper.rb
@@ -1,0 +1,63 @@
+require 'openssl'
+
+module Utility
+  module EncryptionHelper
+    ALGORITHM = 'prime256v1'
+    CERT_FILE_PATH = '/tmp/temp_cert.pem'
+
+    def self.local_pk_set?
+      res = File.exists?(CERT_FILE_PATH)
+      puts "EXISTS: #{res}"
+      res
+    end
+
+    def self.read_local_pk
+      OpenSSL::PKey::EC.new(File.read(CERT_FILE_PATH))
+    end
+
+    def self.generate_local_pk
+      key = OpenSSL::PKey::EC.generate(ALGORITHM)
+      puts "WRITING"
+
+      File.open(CERT_FILE_PATH, "w") do |f|
+        f.write(key.export)
+      end
+    end
+
+    def self.parse_public_key(pk)
+      puts "pk is: #{pk}"
+      bn = OpenSSL::BN.new(pk)
+      group = OpenSSL::PKey::EC::Group.new(ALGORITHM)
+
+      OpenSSL::PKey::EC::Point.new(group, bn)
+    end
+
+    def self.build_shared_encryption_key(encryption_settings)
+      puts "enc settings: #{encryption_settings}"
+      connector_key = read_local_pk
+      kibana_public_key = Utility::EncryptionHelper.parse_public_key(encryption_settings[:client_public_key])
+      connector_key.dh_compute_key(kibana_public_key)
+
+    def self.encrypt(encryption_settings, message)
+      encryption_key = build_shared_encryption_key(encryption_settings)
+
+      encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+      encrypted = encryptor.encrypt_and_sign(message)
+      puts "encrypted: #{encrypted}\n"
+
+      encrypted
+    end
+    end
+
+    def self.decrypt(encryption_settings, message)
+      encryption_key = build_shared_encryption_key(encryption_settings)
+
+      decryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+      decrypted = decryptor.decrypt_and_verify(message)
+
+      puts "decrypted: #{decrypted}\n"
+
+      decrypted
+    end
+  end
+end


### PR DESCRIPTION
Part of work to do asymmetric encryption on the side of the connectors.

Some rough things that were done:

1. Private key is automatically created once and put into `/tmp/temp_cert.pem` - you'll lose it if you restart the app. Also if you want different private key per connector, you can't have it yet, needs to be implemented
2. I'm writing and reading connector configuration from `:encrypted_configuration` field just for testing, when Kibana with Sander's POC is used, this can be changed to just `:configuration`
3. Curve that is used is `prime256v1` - it was a surprise to me, but `25519` is not available by default in Ruby OpenSSL package, there's a separate gem `x25519` - not sure how good it is. Need to discuss it and see if Python properly implements it, maybe we can choose a curve that's available everywhere, as long as it does not compromise security.
4. Encryption is just implemented to test things, it uses `ActiveSupport::MessageEncryptor` which uses unknown to me encryption algorithm and is definitely not a `AES-256-CBC` that we want, but can be easily changed.
5. Class structure is rudimentary - it's a PoC so I did not give a big thought to it.
6. Serialization/deserialization of the public key is arbitrary - I convert it to a number, but in reality it should be a PEM format.

To test that this code works you can add logging statements to `encrypt` and `decrypt` methods, and update connector record in `.elastic-connectors` to have the following object in `_source`:

```json
"encryption": {
  "client_public_key": "56824295195220096543251332234389801363768895710006339571233598387083553451534797619870711079289989347057382078386499248727730849166791941719712819299360377"
}
```

This way you'll see that connector is able to encrypt and decrypt data.