### PR TITLE
[Partial] Connectors recent syncs view #2487 - affected counts on backend

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -96,6 +96,8 @@ This is our main communication index, used to communicate the connector's config
                            regularly (UTC)
   last_sync_error: string;   -> Optional last sync error message
   last_synced: date;    -> Date/time of last completed sync (UTC)
+  last_indexed_count: number;    -> How many documents were inserted into the index
+  last_deleted_count: number;    -> How many documents were deleted from the index
   last_sync_status: string;  -> last sync Enum, see below
   scheduling: {
     enabled: boolean; -> Is sync schedule enabled?

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/hash'
 require 'connectors/connector_status'
 require 'connectors/sync_status'
 require 'utility'
+require 'app/config'
 
 module Core
   class ElasticConnectorActions
@@ -82,11 +83,16 @@ module Core
         update_connector_fields(connector_id,
                                 :last_sync_status => sync_status,
                                 :last_sync_error => status[:error],
-                                :last_synced => Time.now)
+                                :last_synced => Time.now,
+                                :last_indexed_count => status[:indexed_document_count],
+                                :last_deleted_count => status[:deleted_document_count]
+        )
 
         body = {
           :doc => {
             :status => sync_status,
+            :indexed_count => status[:indexed_document_count],
+            :deleted_count => status[:deleted_document_count],
             :completed_at => Time.now
           }.merge(status)
         }

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -85,14 +85,13 @@ module Core
                                 :last_sync_error => status[:error],
                                 :last_synced => Time.now,
                                 :last_indexed_count => status[:indexed_document_count],
-                                :last_deleted_count => status[:deleted_document_count]
-        )
+                                :last_deleted_count => status[:deleted_document_count])
 
         body = {
           :doc => {
             :status => sync_status,
-            :indexed_count => status[:indexed_document_count],
-            :deleted_count => status[:deleted_document_count],
+            :indexed_document_count => status[:indexed_document_count],
+            :deleted_document_count => status[:deleted_document_count],
             :completed_at => Time.now
           }.merge(status)
         }

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -320,8 +320,8 @@ describe Core::ElasticConnectorActions do
         :body => {
           :doc => hash_including(
             :completed_at,
-            :indexed_count,
-            :deleted_count,
+            :indexed_document_count,
+            :deleted_document_count,
             :status => Connectors::SyncStatus::COMPLETED
           )
         }

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -296,13 +296,15 @@ describe Core::ElasticConnectorActions do
     let(:job_id) { 'completed-job-1' }
     let(:status) { {} }
 
-    it 'updates last connector sync status and sync time' do
+    it 'updates last connector sync status, sync time and counts' do
       expect(es_client).to receive(:update).with(
         :index => connectors_index,
         :id => connector_id,
         :body => {
           :doc => hash_including(
             :last_synced,
+            :last_indexed_count,
+            :last_deleted_count,
             :last_sync_status => Connectors::SyncStatus::COMPLETED
           )
         }
@@ -318,6 +320,8 @@ describe Core::ElasticConnectorActions do
         :body => {
           :doc => hash_including(
             :completed_at,
+            :indexed_count,
+            :deleted_count,
             :status => Connectors::SyncStatus::COMPLETED
           )
         }
@@ -337,6 +341,8 @@ describe Core::ElasticConnectorActions do
           :body => {
             :doc => hash_including(
               :last_synced,
+              :last_indexed_count,
+              :last_deleted_count,
               :last_sync_status => Connectors::SyncStatus::FAILED,
               :last_sync_error => status[:error]
             )


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/2487

We're missing some information for the **Recent Syncs** view; namely, the affected counts. This PR adds indexed and deleted counts; together, they are what the job changes.

NOTE: it's not necessarily the same as current document count at the time. Since we assume that for 8.5, we always do the full sync, the job deletes all the old documents and creates the new. So in the end, the new documents count = indexed count, and the old documents count = deleted count, because all the old documents are deleted.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Added the changes to the protocol
- [ ] Tested the changes locally

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## For Elastic Internal Use Only
- [x] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] [Manual test steps](https://github.com/elastic/connectors-ruby/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
