### PR TITLE
add ingest fields to byoc definition

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -90,7 +90,6 @@ This is our main communication index, used to communicate the connector's config
   };                    -> Definition and values of configurable
                            fields
   error: string;        -> Optional error message
-  extract_binary_content: boolean; -> Whether or not the `request_pipeline` should handle binary data
   index_name: string;   -> The index data will be written to
   language: string;     -> the language used for the analyzer
   last_seen: date;      -> Connector writes check-in date-time
@@ -100,9 +99,13 @@ This is our main communication index, used to communicate the connector's config
   last_indexed_count: number;    -> How many documents were inserted into the index
   last_deleted_count: number;    -> How many documents were deleted from the index
   last_sync_status: string;  -> last sync Enum, see below
-  request_pipeline: string; -> Ingest pipeline to utilize on indexing data to Elasticsearch
-  reduce_whitespace: boolean; -> Whether or not the `request_pipeline` should squish redundant whitespace
-  run_ml_inference: boolean; -> Whether or not the `request_pipeline` should run the ML Inference pipeline
+  name: string; -> the name to use for the connector
+  pipeline: {
+    extract_binary_content: boolean; -> Whether or not the `request_pipeline` should handle binary data
+    name: string; ->  Ingest pipeline to utilize on indexing data to Elasticsearch
+    reduce_whitespace: boolean; -> Whether or not the `request_pipeline` should squish redundant whitespace
+    run_ml_inference: boolean; -> Whether or not the `request_pipeline` should run the ML Inference pipeline
+  }
   scheduling: {
     enabled: boolean; -> Is sync schedule enabled?
     interval: string; -> Quartz Cron syntax
@@ -132,16 +135,21 @@ This is our main communication index, used to communicate the connector's config
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
     "error" : { "type" : "text" },
-    "extract_binary_content": { "type" : "boolean" },
     "index_name" : { "type" : "keyword" },
     "language" : { "type" : "keyword" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "text" },
     "last_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
-    "request_pipeline" : { "type" : "keyword" },
-    "reduce_whitespace" : { "type" : "boolean" },
-    "run_ml_inference" : { "type" : "boolean" },
+    "name" : { "type" : "keyword" },
+    "pipeline" : {
+      "properties" : {
+        "extract_binary_content": { "type" : "boolean" },
+        "name" : { "type" : "keyword" },
+        "reduce_whitespace" : { "type" : "boolean" },
+        "run_ml_inference" : { "type" : "boolean" },
+      }
+    }
     "scheduling" : {
       "properties" : {
         "enabled" : { "type" : "boolean" },

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -90,6 +90,7 @@ This is our main communication index, used to communicate the connector's config
   };                    -> Definition and values of configurable
                            fields
   error: string;        -> Optional error message
+  extract_binary_content: boolean; -> Whether or not the `request_pipeline` should handle binary data
   index_name: string;   -> The index data will be written to
   language: string;     -> the language used for the analyzer
   last_seen: date;      -> Connector writes check-in date-time
@@ -99,6 +100,9 @@ This is our main communication index, used to communicate the connector's config
   last_indexed_count: number;    -> How many documents were inserted into the index
   last_deleted_count: number;    -> How many documents were deleted from the index
   last_sync_status: string;  -> last sync Enum, see below
+  request_pipeline: string; -> Ingest pipeline to utilize on indexing data to Elasticsearch
+  reduce_whitespace: boolean; -> Whether or not the `request_pipeline` should squish redundant whitespace
+  run_ml_inference: boolean; -> Whether or not the `request_pipeline` should run the ML Inference pipeline
   scheduling: {
     enabled: boolean; -> Is sync schedule enabled?
     interval: string; -> Quartz Cron syntax
@@ -128,12 +132,16 @@ This is our main communication index, used to communicate the connector's config
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
     "error" : { "type" : "text" },
+    "extract_binary_content": { "type" : "boolean" },
     "index_name" : { "type" : "keyword" },
     "language" : { "type" : "keyword" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "text" },
-    "last_sync_status" : { "type" : "keyword" }
+    "last_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
+    "request_pipeline" : { "type" : "keyword" },
+    "reduce_whitespace" : { "type" : "boolean" },
+    "run_ml_inference" : { "type" : "boolean" },
     "scheduling" : {
       "properties" : {
         "enabled" : { "type" : "boolean" },

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -84,7 +84,7 @@ module Core
 
     def initialize(es_response)
       @elasticsearch_response = es_response.with_indifferent_access
-      @globals = ElasticConnectorActions.get_connectors_meta
+      @globals = ElasticConnectorActions.connectors_meta
     end
   end
 end

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -14,6 +14,12 @@ require 'utility/logger'
 
 module Core
   class ConnectorSettings
+
+    DEFAULT_REQUEST_PIPELINE = 'ent-search-generic-ingestion'
+    DEFAULT_EXTRACT_BINARY_CONTENT = true
+    DEFAULT_REDUCE_WHITESPACE = true
+    DEFAULT_RUN_ML_INFERENCE = false
+
     # Error Classes
     class ConnectorNotFoundError < StandardError; end
 
@@ -56,6 +62,22 @@ module Core
 
     def scheduling_settings
       self[:scheduling]
+    end
+
+    def request_pipeline
+      self[:request_pipeline] || DEFAULT_REQUEST_PIPELINE
+    end
+
+    def extract_binary_content?
+      self[:extract_binary_content] || DEFAULT_EXTRACT_BINARY_CONTENT
+    end
+
+    def reduce_whitespace?
+      self[:reduce_whitespace] || DEFAULT_REDUCE_WHITESPACE
+    end
+
+    def run_ml_inference?
+      self[:run_ml_inference] || DEFAULT_RUN_ML_INFERENCE
     end
 
     private

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -65,19 +65,19 @@ module Core
     end
 
     def request_pipeline
-      self[:request_pipeline] || @globals[:default_request_pipeline] || DEFAULT_REQUEST_PIPELINE
+      self[:pipeline][:name] || @globals[:pipeline][:default_name] || DEFAULT_REQUEST_PIPELINE
     end
 
     def extract_binary_content?
-      self[:extract_binary_content] || @globals[:default_extract_binary_content] || DEFAULT_EXTRACT_BINARY_CONTENT
+      self[:pipeline][:extract_binary_content] || @globals[:pipeline][:default_extract_binary_content] || DEFAULT_EXTRACT_BINARY_CONTENT
     end
 
     def reduce_whitespace?
-      self[:reduce_whitespace] || @globals[:default_reduce_whitespace] || DEFAULT_REDUCE_WHITESPACE
+      self[:pipeline][:reduce_whitespace] || @globals[:pipeline][:default_reduce_whitespace] || DEFAULT_REDUCE_WHITESPACE
     end
 
     def run_ml_inference?
-      self[:run_ml_inference] || @globals[:default_run_ml_inference] || DEFAULT_RUN_ML_INFERENCE
+      self[:pipeline][:run_ml_inference] || @globals[:pipeline][:default_run_ml_inference] || DEFAULT_RUN_ML_INFERENCE
     end
 
     private

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -65,25 +65,26 @@ module Core
     end
 
     def request_pipeline
-      self[:request_pipeline] || DEFAULT_REQUEST_PIPELINE
+      self[:request_pipeline] || @globals[:default_request_pipeline] || DEFAULT_REQUEST_PIPELINE
     end
 
     def extract_binary_content?
-      self[:extract_binary_content] || DEFAULT_EXTRACT_BINARY_CONTENT
+      self[:extract_binary_content] || @globals[:default_extract_binary_content] || DEFAULT_EXTRACT_BINARY_CONTENT
     end
 
     def reduce_whitespace?
-      self[:reduce_whitespace] || DEFAULT_REDUCE_WHITESPACE
+      self[:reduce_whitespace] || @globals[:default_reduce_whitespace] || DEFAULT_REDUCE_WHITESPACE
     end
 
     def run_ml_inference?
-      self[:run_ml_inference] || DEFAULT_RUN_ML_INFERENCE
+      self[:run_ml_inference] || @globals[:default_run_ml_inference] || DEFAULT_RUN_ML_INFERENCE
     end
 
     private
 
     def initialize(es_response)
       @elasticsearch_response = es_response.with_indifferent_access
+      @globals = ElasticConnectorActions.get_connectors_meta
     end
   end
 end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -40,7 +40,7 @@ module Core
         client.get(:index => CONNECTORS_INDEX, :id => connector_id, :ignore => 404).with_indifferent_access
       end
 
-      def get_connectors_meta
+      def connectors_meta
         alias_mappings = client.indices.get_mapping(:index => CONNECTORS_INDEX).with_indifferent_access
         index = get_latest_index_in_alias(CONNECTORS_INDEX, alias_mappings.keys)
         alias_mappings.dig(index, 'mappings', '_meta')
@@ -274,8 +274,8 @@ module Core
       end
 
       def get_latest_index_in_alias(alias_name, indicies)
-        index_versions = indicies.map{ |index| (index.gsub("#{alias_name}-v", '')).to_i }
-        index_version = index_versions.sort[-1] # gets the largest suffix number
+        index_versions = indicies.map { |index| index.gsub("#{alias_name}-v", '').to_i }
+        index_version = index_versions.max # gets the largest suffix number
         "#{alias_name}-v#{index_version}"
       end
     end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -12,7 +12,6 @@ require 'connectors/connector_status'
 require 'connectors/sync_status'
 require 'utility'
 require 'core/connector_settings'
-require 'app/config'
 
 module Core
   class ElasticConnectorActions

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -144,6 +144,16 @@ describe Core::ElasticConnectorActions do
     end
   end
 
+  context '#get_connectors_meta' do
+    before(:each) do
+      allow(es_client_indices_api).to receive(:get_mapping).and_return({ '.elastic-connectors-v1'=>{ 'mappings'=>{ '_meta'=>{ 'version'=>'1'}, 'properties'=>{ 'api_key_id'=>{ 'type'=>'keyword'}, 'configuration'=>{ 'type'=>'object'}, 'error'=>{ 'type'=>'keyword'}, 'index_name'=>{ 'type'=>'keyword'}, 'language'=>{ 'type'=>'keyword'}, 'last_seen'=>{ 'type'=>'date'}, 'last_sync_error'=>{ 'type'=>'keyword'}, 'last_sync_status'=>{ 'type'=>'keyword'}, 'last_synced'=>{ 'type'=>'date'}, 'name'=>{ 'type'=>'keyword'}, 'scheduling'=>{ 'properties'=>{ 'enabled'=>{ 'type'=>'boolean'}, 'interval'=>{ 'type'=>'text'}}}, 'service_type'=>{ 'type'=>'keyword'}, 'status'=>{ 'type'=>'keyword'}, 'sync_now'=>{ 'type'=>'boolean'}}}}})
+    end
+
+    it 'gets the meta' do
+      expect(described_class.get_connectors_meta).to eq({ 'version' => '1' })
+    end
+  end
+
   context '#get_native_connectors' do
     let(:connector_one) { { '_id' => '123', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
     let(:connector_two) { { '_id' => '456', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
@@ -623,6 +633,15 @@ describe Core::ElasticConnectorActions do
 
         described_class.update_connector_fields(connector_id, doc)
       end
+    end
+  end
+
+  context 'get latest index in alias' do
+    let(:alias_name) { '.ent-search-connectors' }
+    let(:indices) { 11.times.collect { |i| ".ent-search-connectors-v#{i}" }.to_a }
+
+    it 'finds the latest numeric version' do
+      expect(described_class.send(:get_latest_index_in_alias, alias_name, indices)).to eq('.ent-search-connectors-v10')
     end
   end
 end

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -144,13 +144,13 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#get_connectors_meta' do
+  context '#connectors_meta' do
     before(:each) do
-      allow(es_client_indices_api).to receive(:get_mapping).and_return({ '.elastic-connectors-v1'=>{ 'mappings'=>{ '_meta'=>{ 'version'=>'1'}, 'properties'=>{ 'api_key_id'=>{ 'type'=>'keyword'}, 'configuration'=>{ 'type'=>'object'}, 'error'=>{ 'type'=>'keyword'}, 'index_name'=>{ 'type'=>'keyword'}, 'language'=>{ 'type'=>'keyword'}, 'last_seen'=>{ 'type'=>'date'}, 'last_sync_error'=>{ 'type'=>'keyword'}, 'last_sync_status'=>{ 'type'=>'keyword'}, 'last_synced'=>{ 'type'=>'date'}, 'name'=>{ 'type'=>'keyword'}, 'scheduling'=>{ 'properties'=>{ 'enabled'=>{ 'type'=>'boolean'}, 'interval'=>{ 'type'=>'text'}}}, 'service_type'=>{ 'type'=>'keyword'}, 'status'=>{ 'type'=>'keyword'}, 'sync_now'=>{ 'type'=>'boolean'}}}}})
+      allow(es_client_indices_api).to receive(:get_mapping).and_return({ '.elastic-connectors-v1' => { 'mappings' => { '_meta' => { 'version' => '1' }, 'properties' => { 'api_key_id' => { 'type' => 'keyword' }, 'configuration' => { 'type' => 'object' }, 'error' => { 'type' => 'keyword' }, 'index_name' => { 'type' => 'keyword' }, 'language' => { 'type' => 'keyword' }, 'last_seen' => { 'type' => 'date' }, 'last_sync_error' => { 'type' => 'keyword' }, 'last_sync_status' => { 'type' => 'keyword' }, 'last_synced' => { 'type' => 'date' }, 'name' => { 'type' => 'keyword' }, 'scheduling' => { 'properties' => { 'enabled' => { 'type' => 'boolean' }, 'interval' => { 'type' => 'text' } } }, 'service_type' => { 'type' => 'keyword' }, 'status' => { 'type' => 'keyword' }, 'sync_now' => { 'type' => 'boolean' } } } } })
     end
 
     it 'gets the meta' do
-      expect(described_class.get_connectors_meta).to eq({ 'version' => '1' })
+      expect(described_class.connectors_meta).to eq({ 'version' => '1' })
     end
   end
 

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -28,6 +28,7 @@ describe Core::NativeScheduler do
   end
 
   before(:each) do
+    allow(Core::ElasticConnectorActions).to receive(:connectors_meta).and_return({})
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id1).and_return(connector_settings1)
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id2).and_return(connector_settings2)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2608
## Part of https://github.com/elastic/enterprise-search-team/issues/2607


This modifies the BYOC protocol (from the ruby connector client's side) to expect ingestion flags to be present in the `.elastic-connectors` document. If the settings are not there, they are looked up in the index's meta mappings. If that fails, it falls back to hardcoded default values.

These ingest settings impact which pipeline is used at request time to index documents, and what additional fields get set on the documents as they are sent to Elasticsearch.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally


## Related Pull Requests


* default pipeline definition: https://github.com/elastic/ent-search/pull/6805
* kibana PR to make these settings available: TODO

## Release Note

New fields were added to the definition of the `.elastic-connectors` index to represent ingest pipeline options.

## For Elastic Internal Use Only
- [x] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
  - will be handled in https://github.com/elastic/enterprise-search-team/issues/2614
