### PR TITLE
Use ent-search elasticsearch config if it's on cloud

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -15,10 +15,12 @@ require 'utility/logger'
 
 module App
   Utility::Environment.set_execution_environment(App::Config) do
-    worker = App::Worker.new(
-      connector_id: App::Config['connector_id'],
-      service_type: App::Config['service_type']
-    )
-    worker.start!
+    Utility::Logger.info("App::Config['elasticsearch'] = #{App::Config['elasticsearch']}")
+
+    # worker = App::Worker.new(
+    #   connector_id: App::Config['connector_id'],
+    #   service_type: App::Config['service_type']
+    # )
+    # worker.start!
   end
 end

--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -15,12 +15,10 @@ require 'utility/logger'
 
 module App
   Utility::Environment.set_execution_environment(App::Config) do
-    Utility::Logger.info("App::Config['elasticsearch'] = #{App::Config['elasticsearch']}")
-
-    # worker = App::Worker.new(
-    #   connector_id: App::Config['connector_id'],
-    #   service_type: App::Config['service_type']
-    # )
-    # worker.start!
+    worker = App::Worker.new(
+      connector_id: App::Config['connector_id'],
+      service_type: App::Config['service_type']
+    )
+    worker.start!
   end
 end

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -4,8 +4,10 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
+# frozen_string_literal: true
+
 require 'config'
-require 'utility'
+require_relative '../utility/logger'
 
 # We look for places in this order:
 # - CONNECTORS_CONFIG environment variable

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -47,24 +47,66 @@ module App
   DEFAULT_PASSWORD = 'changeme'
 
   # If it's on cloud (i.e. EnvVar ENT_SEARCH_CONFIG_PATH is set), elasticsearch config in ent-search will be used.
-  Config = ::Settings.tap do |config|
-    if ENV['ENT_SEARCH_CONFIG_PATH']
-      Utility::Logger.info("Found ENT_SEARCH_CONFIG_PATH, loading ent-search config from #{ENV['ENT_SEARCH_CONFIG_PATH']}")
-      ent_search_config = YAML.safe_load(File.read(ENV['ENT_SEARCH_CONFIG_PATH']))
-      if ent_search_config && ent_search_config['elasticsearch.host'] && ent_search_config['elasticsearch.username'] && ent_search_config['elasticsearch.password']
-        url = URI(ent_search_config['elasticsearch.host'])
-        config[:elasticsearch] = {
-          :hosts => [
-            {
-              scheme: url.scheme,
-              user: ent_search_config['elasticsearch.username'],
-              password: ent_search_config['elasticsearch.password'],
-              host: url.host,
-              port: url.port
-            }
-          ]
-        }
-      end
+  def self.ent_search_es_config
+    ent_search_config_path = ENV['ENT_SEARCH_CONFIG_PATH']
+    unless ent_search_config_path
+      Utility::Logger.info('ENT_SEARCH_CONFIG_PATH is not found, use connector service config.')
+      return nil
     end
+
+    Utility::Logger.info("Found ENT_SEARCH_CONFIG_PATH, loading ent-search config from #{ent_search_config_path}")
+    ent_search_config = begin
+      YAML.load_file(ent_search_config_path)
+    rescue StandardError => e
+      Utility::Logger.error("Failed to load ent-search config #{ent_search_config_path}: #{e.message}")
+      return nil
+    end
+
+    unless ent_search_config&.is_a?(Hash)
+      Utility::Logger.error("Invalid ent-search config: #{ent_search_config.inspect}")
+      return nil
+    end
+
+    host = ent_search_config['elasticsearch.host'] || ent_search_config.dig('elasticsearch', 'host')
+    username = ent_search_config['elasticsearch.username'] || ent_search_config.dig('elasticsearch', 'username')
+    password = ent_search_config['elasticsearch.password'] || ent_search_config.dig('elasticsearch', 'password')
+
+    missing_fields = []
+    missing_fields << 'elasticsearch.host' unless host
+    missing_fields << 'elasticsearch.username' unless username
+    missing_fields << 'elasticsearch.password' unless password
+    if missing_fields.any?
+      Utility::Logger.error("Incomplete elasticsearch config, missing #{missing_fields.join(', ')}")
+      return nil
+    end
+
+    uri = begin
+      URI.parse(host)
+    rescue URI::InvalidURIError => e
+      Utility::Logger.error("Failed to parse elasticsearch host #{host}: #{e.message}")
+      return nil
+    end
+
+    unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+      Utility::Logger.error("Invalid elasticsearch host #{host}, it must be an http or https.")
+      return nil
+    end
+
+    {
+      :hosts => [
+        {
+          scheme: uri.scheme,
+          user: username,
+          password: password,
+          host: uri.host,
+          port: uri.port
+        }
+      ]
+    }
+  end
+
+  Config = ::Settings.tap do |config|
+    ent_search_config = ent_search_es_config
+    config[:elasticsearch] = ent_search_config if ent_search_config
   end
 end

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -107,7 +107,9 @@ module App
   end
 
   Config = ::Settings.tap do |config|
-    ent_search_config = ent_search_es_config
-    config[:elasticsearch] = ent_search_config if ent_search_config
+    if ent_search_config = ent_search_es_config
+      Utility::Logger.error('Overriding elasticsearch config with ent_search config')
+      config[:elasticsearch] = ent_search_config
+    end
   end
 end

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -108,7 +108,7 @@ module App
 
   Config = ::Settings.tap do |config|
     if ent_search_config = ent_search_es_config
-      Utility::Logger.error('Overriding elasticsearch config with ent_search config')
+      Utility::Logger.error('Overriding elasticsearch config with ent-search config')
       config[:elasticsearch] = ent_search_config
     end
   end

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -46,5 +46,24 @@ end
 module App
   DEFAULT_PASSWORD = 'changeme'
 
-  Config = ::Settings
+  # If it's on cloud (i.e. EnvVar ENT_SEARCH_CONFIG_PATH is set), elasticsearch config in ent-search will be used.
+  Config = ::Settings.tap do |config|
+    if ENV['ENT_SEARCH_CONFIG_PATH']
+      ent_search_config = YAML.safe_load(File.read(ENV['ENT_SEARCH_CONFIG_PATH']))
+      if ent_search_config && ent_search_config['elasticsearch.host'] && ent_search_config['elasticsearch.username'] && ent_search_config['elasticsearch.password']
+        url = URI(ent_search_config['elasticsearch.host'])
+        config[:elasticsearch] = {
+          :hosts => [
+            {
+              scheme: url.scheme,
+              user: ent_search_config['elasticsearch.username'],
+              password: ent_search_config['elasticsearch.password'],
+              host: url.host,
+              port: url.port
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -49,6 +49,7 @@ module App
   # If it's on cloud (i.e. EnvVar ENT_SEARCH_CONFIG_PATH is set), elasticsearch config in ent-search will be used.
   Config = ::Settings.tap do |config|
     if ENV['ENT_SEARCH_CONFIG_PATH']
+      Utility::Logger.info("Found ENT_SEARCH_CONFIG_PATH, loading ent-search config from #{ENV['ENT_SEARCH_CONFIG_PATH']}")
       ent_search_config = YAML.safe_load(File.read(ENV['ENT_SEARCH_CONFIG_PATH']))
       if ent_search_config && ent_search_config['elasticsearch.host'] && ent_search_config['elasticsearch.username'] && ent_search_config['elasticsearch.password']
         url = URI(ent_search_config['elasticsearch.host'])

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -5,6 +5,7 @@
 #
 
 require 'config'
+require 'utility'
 
 # We look for places in this order:
 # - CONNECTORS_CONFIG environment variable
@@ -62,7 +63,7 @@ module App
       return nil
     end
 
-    unless ent_search_config&.is_a?(Hash)
+    unless ent_search_config.is_a?(Hash)
       Utility::Logger.error("Invalid ent-search config: #{ent_search_config.inspect}")
       return nil
     end
@@ -88,7 +89,7 @@ module App
     end
 
     unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-      Utility::Logger.error("Invalid elasticsearch host #{host}, it must be an http or https.")
+      Utility::Logger.error("Invalid elasticsearch host #{host}, it must be a http or https URI.")
       return nil
     end
 

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -25,7 +25,8 @@ module Utility
     end
 
     def connection_configs(es_config)
-      configs = { :api_key => es_config[:api_key] }
+      configs = {}
+      configs[:api_key] = es_config[:api_key] if es_config[:api_key]
       if es_config[:cloud_id]
         configs[:cloud_id] = es_config[:cloud_id]
       elsif es_config[:hosts]

--- a/spec/app/config_spec.rb
+++ b/spec/app/config_spec.rb
@@ -1,0 +1,139 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+# frozen_string_literal: true
+
+require 'app/config'
+
+describe App do
+  describe '.ent_search_es_config' do
+    let(:ent_search_config_path) { 'path' }
+
+    before(:each) do
+      allow(ENV).to receive(:[]).with('ENT_SEARCH_CONFIG_PATH').and_return(ent_search_config_path)
+    end
+
+    context 'when ENT_SEARCH_CONFIG_PATH is not set' do
+      let(:ent_search_config_path) { nil }
+      it 'returns nil' do
+        expect(described_class.ent_search_es_config).to be_nil
+      end
+    end
+
+    context 'when loading of config file fails' do
+      before(:each) do
+        allow(YAML).to receive(:load_file).with(ent_search_config_path).and_raise(StandardError)
+      end
+
+      it 'returns nil' do
+        expect(described_class.ent_search_es_config).to be_nil
+      end
+    end
+
+    context 'when loading of config file succeeds' do
+      let(:config_hash) do
+        {
+          'elasticsearch.host' => 'http://localhost:9200',
+          'elasticsearch.username' => 'elastic',
+          'elasticsearch.password' => 'changeme'
+        }
+      end
+
+      let(:expected_es_config) do
+        {
+          :hosts => [
+            {
+              scheme: 'http',
+              user: 'elastic',
+              password: 'changeme',
+              host: 'localhost',
+              port: 9200
+            }
+          ]
+        }
+      end
+
+      before(:each) do
+        allow(YAML).to receive(:load_file).with(ent_search_config_path).and_return(config_hash)
+      end
+
+      context 'when config is an empty file' do
+        let(:config_hash) { false }
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when host is missing' do
+        let(:config_hash) { super().except('elasticsearch.host') }
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when username is missing' do
+        let(:config_hash) { super().except('elasticsearch.username') }
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when password is missing' do
+        let(:config_hash) { super().except('elasticsearch.password') }
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when host is an invalid uri' do
+        let(:config_hash) do
+          super().tap do |out|
+            out['elasticsearch.host'] = '%^^&'
+          end
+        end
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when host is not a HTTP or HTTPS URI' do
+        let(:config_hash) do
+          super().tap do |out|
+            out['elasticsearch.host'] = 'ftp://localhost:21'
+          end
+        end
+
+        it 'returns nil' do
+          expect(described_class.ent_search_es_config).to be_nil
+        end
+      end
+
+      context 'when YAML is nested' do
+        let(:config_hash) do
+          {
+            'elasticsearch' => {
+              'host' => 'http://localhost:9200',
+              'username' => 'elastic',
+              'password' => 'changeme'
+            }
+          }
+        end
+
+        it 'returns expected elasticsearch config' do
+          expect(described_class.ent_search_es_config).to eq(expected_es_config)
+        end
+      end
+
+      it 'returns expected elasticsearch config' do
+        expect(described_class.ent_search_es_config).to eq(expected_es_config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2666

Elasticsearch Client will use ent-search elasticsearch config if it's on Cloud.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally