### PR TITLE
Refactor Core::ConnectorSettings for more consistency

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -46,6 +46,7 @@ module Core
       end
 
       def native_connectors
+        globals = connectors_meta
         result = []
         offset = 0
         loop do
@@ -64,7 +65,7 @@ module Core
           hits = response['hits']['hits']
           total = response['hits']['total']['value']
           result += hits.map do |hit|
-            Core::ConnectorSettings.new(hit)
+            Core::ConnectorSettings.new(hit, connectors_meta)
           end
           break if result.size >= total
           offset += DEFAULT_PAGE_SIZE

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -65,7 +65,7 @@ module Core
           hits = response['hits']['hits']
           total = response['hits']['total']['value']
           result += hits.map do |hit|
-            Core::ConnectorSettings.new(hit, connectors_meta)
+            Core::ConnectorSettings.new(hit, globals)
           end
           break if result.size >= total
           offset += DEFAULT_PAGE_SIZE

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -11,11 +11,7 @@ require 'core'
 describe Core::ConnectorSettings do
   let(:elasticsearch_response) { {} }
   let(:connectors_meta) { {} }
-  subject { described_class.send(:new, elasticsearch_response) }
-
-  before(:each) do
-    allow(Core::ElasticConnectorActions).to receive(:connectors_meta).and_return(connectors_meta)
-  end
+  subject { described_class.send(:new, elasticsearch_response, connectors_meta) }
 
   context 'pipeline settings' do
     it 'has defaults' do

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -11,11 +11,12 @@ describe Core::NativeScheduler do
   let(:connector_id2) { '456' }
   let(:poll_interval) { 999 }
 
+  let(:globals) { {} }
   let(:native_connector1) { { :_id => connector_id1 } }
   let(:native_connector2) { { :_id => connector_id2 } }
 
-  let(:connector_settings1) { Core::ConnectorSettings.new(native_connector1) }
-  let(:connector_settings2) { Core::ConnectorSettings.new(native_connector2) }
+  let(:connector_settings1) { Core::ConnectorSettings.new(native_connector1, globals) }
+  let(:connector_settings2) { Core::ConnectorSettings.new(native_connector2, globals) }
 
   let(:last_synced) { Time.now - 1.day }
   let(:sync_now) { false }


### PR DESCRIPTION
This PR just does a minor refactoring for `Core::ConnectorSettings` class.

Points addressed:

- Fixed overusage of `.with_indiffirent_access` when it's not actually needed -`ElasticConnectorActions.get_connector` already returns hash with indifferent access
- All data needed to initialise an instance of `Core::ConnectorSettings` is loaded in method caller instead of being loaded by the initializer.
- Removed `dig(*args*)` method as it's not used by anyone outside of class and replaced calls to it by explicit `@elasticsearch_response.dig` calls

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
