### PR TITLE
Remove harmful rescue/raise for native_connectors method

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -70,9 +70,6 @@ module Core
           offset += DEFAULT_PAGE_SIZE
         end
         result
-      rescue StandardError => e
-        Utility::ExceptionTracking.log_exception(e, 'Error while getting native connectors')
-        raise Utility::ClientError.new(e)
       end
 
       def update_connector_configuration(connector_id, configuration)


### PR DESCRIPTION
Small fix for logic that makes debugging harder.

This rescue statement transforms `StandardError` to `Utility::ClientError` that is not handled by the caller differently than StandardError, but also it loses the call stack of original error, so that newly thrown error will always point to this rescue block, not to the place where original error happened.