### PR TITLE
Follow-up on PR-284

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -40,7 +40,7 @@ module Core
       def connectors_meta
         alias_mappings = client.indices.get_mapping(:index => Utility::Constants::CONNECTORS_INDEX).with_indifferent_access
         index = get_latest_index_in_alias(Utility::Constants::CONNECTORS_INDEX, alias_mappings.keys)
-        alias_mappings.dig(index, 'mappings', '_meta')
+        alias_mappings.dig(index, 'mappings', '_meta') || {}
       end
 
       def native_connectors
@@ -208,6 +208,8 @@ module Core
         body
       end
 
+      # DO NOT USE this method
+      # Creation of connector index should be handled by Kibana, this method is only used by ftest.rb
       def ensure_connectors_index_exists
         mappings = {
           :properties => {
@@ -235,6 +237,8 @@ module Core
         ensure_index_exists("#{Utility::Constants::CONNECTORS_INDEX}-v1", system_index_body(:alias_name => Utility::Constants::CONNECTORS_INDEX, :mappings => mappings))
       end
 
+      # DO NOT USE this method
+      # Creation of job index should be handled by Kibana, this method is only used by ftest.rb
       def ensure_job_index_exists
         mappings = {
           :properties => {

--- a/tests/ftest.rb
+++ b/tests/ftest.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 require 'yaml'
 require 'elasticsearch'
+require_relative '../lib/utility/constants'
 
 LIB_DIR = File.expand_path("#{File.dirname(__FILE__)}/../lib")
 
@@ -41,7 +42,7 @@ end
 
 def wipe_es
   puts('Wipe existing data')
-  ['mongo', '.elastic-connectors', '.elastic-connectors-sync-jobs'].each do |i|
+  ['mongo', Utility::Constants::CONNECTORS_INDEX, Utility::Constants::JOB_INDEX].each do |i|
     es_client.indices.delete(index: i, ignore: [400, 404])
   end
 end


### PR DESCRIPTION
1. Add comments to warn not to use methods `ensure_connectors_index_exists` and `ensure_job_index_exists`
2. Use default `{}` if meta is not set in connector index.
