### PR TITLE
Add retry_on_failure and request_timeout to ES client

### DIFF
--- a/config/connectors.yml.example
+++ b/config/connectors.yml.example
@@ -7,6 +7,8 @@ elasticsearch:
 #  cloud_id: CHANGEME
   hosts: http://localhost:9200
   api_key: "CHANGEME"
+  retry_on_failure: 3
+  request_timeout: 120
   disable_warnings: true
   trace: false
   log: false

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -30,6 +30,11 @@ puts "Parsing #{CONFIG_FILE} configuration file."
       optional(:cloud_id).value(:string)
       optional(:hosts).value(:string)
       required(:api_key).value(:string)
+      optional(:retry_on_failure).value(:integer)
+      optional(:request_timeout).value(:integer)
+      optional(:disable_warnings).value(:bool?)
+      optional(:trace).value(:bool?)
+      optional(:log).value(:bool?)
     end
 
     required(:connector_id).value(:string)

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -111,7 +111,11 @@ module App
   Config = ::Settings.tap do |config|
     if ent_search_config = ent_search_es_config
       Utility::Logger.error('Overriding elasticsearch config with ent-search config')
-      config[:elasticsearch] = ent_search_config
+      original_es_config = config[:elasticsearch].to_h
+      original_es_config.delete(:cloud_id)
+      original_es_config.delete(:hosts)
+      original_es_config.delete(:api_key)
+      config[:elasticsearch] = original_es_config.merge(ent_search_config)
     end
   end
 end

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -34,6 +34,8 @@ module Utility
       else
         raise 'Either elasticsearch.cloud_id or elasticsearch.hosts should be configured.'
       end
+      configs[:retry_on_failure] = es_config[:retry_on_failure] || false
+      configs[:request_timeout] = es_config[:request_timeout] || nil
       configs[:log] = es_config[:log] || false
       configs[:trace] = es_config[:trace] || false
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2666

Changes made in this PR:

1. When it's on Cloud, only override elasticsearch connection configs (e.g. `cloud_id`, `hosts`, `api_key`), and preserve the rest (e.g. `trace`, `log`)
2. Add new elasticsearch config `retry_on_failure`, in case there is network split.
3. Add new elasticsearch config `request_timeout`, in case the default timeout is too low.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally