### PR TITLE
Improve and refactor health checks; add healthcheck before a sync

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -9,6 +9,7 @@
 require 'bson'
 require 'core/output_sink'
 require 'utility/exception_tracking'
+require 'utility/errors'
 require 'app/config'
 
 module Connectors
@@ -35,6 +36,13 @@ module Connectors
 
       def do_health_check(params)
         raise 'Not implemented for this connector'
+      end
+
+      def do_health_check!(params)
+        do_health_check(params)
+      rescue StandardError => e
+        Utility::ExceptionTracking.log_exception(e, "Connector for service #{self.class.service_type} failed the health check for 3rd-party service.")
+        raise Utility::Errors::HealthCheckFailedError.new
       end
 
       def is_healthy?(params = {})

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -33,6 +33,10 @@ module Connectors
 
       def yield_documents; end
 
+      def do_health_check(params)
+        raise 'Not implemented for this connector'
+      end
+
       def is_healthy?(params = {})
         do_health_check(params)
 

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -8,7 +8,7 @@
 
 require 'bson'
 require 'core/output_sink'
-require 'utility/logger'
+require 'utility/exception_tracking'
 require 'app/config'
 
 module Connectors
@@ -33,11 +33,13 @@ module Connectors
 
       def yield_documents; end
 
-      def source_status(params = {})
-        health_check(params)
-        { :status => 'OK', :statusCode => 200, :message => "Connected to #{self.class.display_name}" }
+      def is_healthy?(params = {})
+        do_health_check(params)
+
+        true
       rescue StandardError => e
-        { :status => 'FAILURE', :statusCode => 500, :message => e.message }
+        Utility::ExceptionTracking.log_exception(e, "Connector for service #{self.class.service_type} failed the health check for 3rd-party service.")
+        false
       end
     end
   end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -34,7 +34,7 @@ module Connectors
 
       def yield_documents; end
 
-      def do_health_check(params)
+      def do_health_check(_params)
         raise 'Not implemented for this connector'
       end
 

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -33,8 +33,11 @@ module Connectors
         super
       end
 
-      def health_check(_params)
-        true
+      def do_health_check(_params)
+        # Do nothing.
+        #
+        # To emulate unhealthy 3rd-party system situation, uncomment the following line:
+        # raise 'something went wrong'
       end
 
       def yield_documents

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -34,7 +34,7 @@ module Connectors
       end
 
       def do_health_check(_params)
-        # Do nothing.
+        # Do the health check by trying to access 3rd-party system just to verify that everything is set up properly.
         #
         # To emulate unhealthy 3rd-party system situation, uncomment the following line:
         # raise 'something went wrong'

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -60,7 +60,7 @@ module Connectors
 
       private
 
-      def health_check(_params)
+      def do_health_check(_params)
         @extractor.health_check
       end
     end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -56,7 +56,7 @@ module Connectors
 
       private
 
-      def health_check(_params)
+      def do_health_check(_params)
         create_client(@host, @database)
       end
 

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -58,7 +58,7 @@ module Core
           Utility::Logger.info("Changing connector status to #{new_connector_status}.")
         elsif connector_settings.connector_status_allows_sync?
           connector_instance = Connectors::REGISTRY.connector(service_type, connector_settings.configuration)
-          doc[:status] = connector_instance.source_status[:status] == 'OK' ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR
+          doc[:status] = connector_instance.is_healthy? ? Connectors::ConnectorStatus::CONNECTED : Connectors::ConnectorStatus::ERROR
         end
 
         Core::ElasticConnectorActions.update_connector_fields(connector_id, doc)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -20,6 +20,12 @@ module Core
     end
   end
 
+  class HealthCheckFailedError < StandardError
+    def initialize
+      super('Health check failed for 3rd-party service.')
+    end
+  end
+
   class SyncJobRunner
     def initialize(connector_settings, service_type)
       @connector_settings = connector_settings
@@ -52,6 +58,8 @@ module Core
 
       begin
         Utility::Logger.debug("Successfully claimed job for connector #{@connector_settings.id}.")
+
+        raise HealthCheckFailedError unless @connector_instance.is_healthy?
 
         incoming_ids = []
         existing_ids = ElasticConnectorActions.fetch_document_ids(@connector_settings.index_name)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -20,12 +20,6 @@ module Core
     end
   end
 
-  class HealthCheckFailedError < StandardError
-    def initialize
-      super('Health check failed for 3rd-party service.')
-    end
-  end
-
   class SyncJobRunner
     def initialize(connector_settings, service_type)
       @connector_settings = connector_settings
@@ -59,7 +53,7 @@ module Core
       begin
         Utility::Logger.debug("Successfully claimed job for connector #{@connector_settings.id}.")
 
-        raise HealthCheckFailedError unless @connector_instance.is_healthy?
+        @connector_instance.do_health_check!
 
         incoming_ids = []
         existing_ids = ElasticConnectorActions.fetch_document_ids(@connector_settings.index_name)

--- a/lib/utility/errors.rb
+++ b/lib/utility/errors.rb
@@ -118,6 +118,12 @@ module Utility
     end
   end
 
+  class HealthCheckFailedError < StandardError
+    def initialize
+      super('Health check failed for 3rd-party service.')
+    end
+  end
+
   INTERNAL_SERVER_ERROR = Utility::Error.new(500, 'INTERNAL_SERVER_ERROR', 'Internal server error')
   INVALID_API_KEY = Utility::Error.new(401, 'INVALID_API_KEY', 'Invalid API key')
   UNSUPPORTED_AUTH_SCHEME = Utility::Error.new(401, 'UNSUPPORTED_AUTH_SCHEME', 'Unsupported authorization scheme')

--- a/spec/connectors/example/connector_spec.rb
+++ b/spec/connectors/example/connector_spec.rb
@@ -17,9 +17,9 @@ describe Connectors::Example::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#source_status' do
+  context '#is_healthy?' do
     it 'returns ok' do
-      expect(subject.source_status({})).to include(:status => 'OK')
+      expect(subject.is_healthy?({})).to eq(true)
     end
   end
 

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -25,32 +25,29 @@ describe Connectors::GitLab::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#source_status' do
+  context '#is_healthy?' do
     it 'correctly returns true on 200' do
       stub_request(:get, "#{base_url}/user")
         .to_return(:status => 200, :body => user_json)
-      result = subject.source_status
+      result = subject.is_healthy?
 
-      expect(result).to_not be_nil
-      expect(result[:status]).to eq('OK')
+      expect(result).to eq(true)
     end
 
     it 'correctly returns false on 401' do
       stub_request(:get, "#{base_url}/user")
         .to_return(:status => 401, :body => '{ "error": "wrong token" }')
-      result = subject.source_status
+      result = subject.is_healthy?
 
-      expect(result).to_not be_nil
-      expect(result[:status]).to eq('FAILURE')
+      expect(result).to eq(false)
     end
 
     it 'correctly returns false on 400' do
       stub_request(:get, "#{base_url}/user")
         .to_return(:status => 401, :body => '{ "error": "wrong token" }')
-      result = subject.source_status
+      result = subject.is_healthy?
 
-      expect(result).to_not be_nil
-      expect(result[:status]).to eq('FAILURE')
+      expect(result).to eq(false)
     end
   end
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -45,11 +45,11 @@ describe Connectors::MongoDB::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#source_status' do
+  context '#is_healthy?' do
     it 'instantiates a mongodb client' do
       expect(Mongo::Client).to receive(:new).with([mongodb_host], hash_including(:database => mongodb_database))
 
-      subject.source_status({})
+      subject.is_healthy?({})
     end
   end
 

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -12,7 +12,7 @@ describe Core::Heartbeat do
   let(:connector_class) { double }
   let(:connector_instance) { double }
 
-  let(:source_status) { { :status => 'OK' } }
+  let(:is_healthy) { true }
 
   before(:each) do
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
@@ -28,7 +28,7 @@ describe Core::Heartbeat do
     allow(connector_class).to receive(:configurable_fields).and_return(connector_default_configuration)
     allow(connector_class).to receive(:new).and_return(connector_instance)
 
-    allow(connector_instance).to receive(:source_status).and_return(source_status)
+    allow(connector_instance).to receive(:is_healthy?).and_return(is_healthy)
   end
 
   describe '.start_task' do

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -30,7 +30,6 @@ describe Core::SyncJobRunner do
   let(:connector_instance) { double }
   let(:sink) { double }
 
-  let(:source_status) { { :status => 'OK' } }
   let(:output_index_name) { 'test-ingest-index' }
   let(:existing_document_ids) { [] } # ids of documents that are already in the index
   let(:extracted_documents) { [] } # documents returned from 3rd-party system
@@ -69,6 +68,7 @@ describe Core::SyncJobRunner do
     allow(connector_class).to receive(:service_type).and_return(service_type)
     allow(connector_class).to receive(:new).and_return(connector_instance)
 
+    allow(connector_instance).to receive(:do_health_check!)
     allow_statement = allow(connector_instance).to receive(:yield_documents)
     extracted_documents.each { |document| allow_statement.and_yield(document) }
   end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2570
## Closes https://github.com/elastic/enterprise-search-team/issues/2667

Several very related changes bundled in one:

- Changed `Connectors::Base::Connector` method signature from `source_status` to `is_healthy?`. The method now always returns just a true or false.
- Changed base `Connectors::Base::Connector` method `health_check` to `do_health_check` - I think that this method method gives a better hint that this method is not supposed to return anything, but just "do something and raise an error"
- Added `Connectors::Base::Connector#do_health_check!` that raises `HealthCheckFailedError`if health check fails. 
- To improve on the previous point, I changed `Example::Connector.do_health_check` to include a comment that explains it and sample `raise` statement that user can uncomment and see what happens.
- Now when connector tries to run a sync, it always attempts to also do a health check - this can also help surface the problems with how `health_check` function is written. I think eventually health_check will be removed from heartbeat as heartbeat will only update `last_seen` for the connector.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally