### PR TITLE
Add system indices retries and change exit code

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -24,5 +24,6 @@ module App
     worker.start!
   rescue App::PreflightCheck::CheckFailure => e
     Utility::Logger.error("Preflight check failed: #{e.message}")
+    exit(-1)
   end
 end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -266,6 +266,7 @@ module App
     end
   rescue App::PreflightCheck::CheckFailure => e
     Utility::Logger.error("Preflight check failed: #{e.message}")
+    exit(-1)
   rescue SystemExit
     puts 'Exiting.'
   rescue Interrupt

--- a/lib/app/dispatcher_app.rb
+++ b/lib/app/dispatcher_app.rb
@@ -20,5 +20,6 @@ module App
     App::Dispatcher.run_dispatcher!
   rescue App::PreflightCheck::CheckFailure => e
     Utility::Logger.error("Preflight check failed: #{e.message}")
+    exit(-1)
   end
 end


### PR DESCRIPTION
A follow-up on https://github.com/elastic/connectors-ruby/pull/284, as suggested by @tarekziade in https://github.com/elastic/connectors-ruby/pull/296#issue-1368091963:

>the service needs to try this in a loop, not exit. Also the exit status is 0, should be -1

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
