### PR TITLE
Connector service refactor

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -32,6 +32,11 @@ module Core
       new(es_response, globals)
     end
 
+    def initialize(es_response, globals)
+      @elasticsearch_response = es_response.with_indifferent_access
+      @globals = globals.with_indifferent_access
+    end
+
     def id
       @elasticsearch_response[:_id]
     end
@@ -82,11 +87,6 @@ module Core
     end
 
     private
-
-    def initialize(es_response, globals)
-      @elasticsearch_response = es_response
-      @globals = globals
-    end
 
     def return_if_present(*args)
       args.each do |arg|

--- a/lib/core/native_scheduler.rb
+++ b/lib/core/native_scheduler.rb
@@ -18,6 +18,7 @@ module Core
       Core::ElasticConnectorActions.native_connectors || []
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, 'Could not retrieve native connectors due to unexpected error.')
+      []
     end
   end
 end

--- a/lib/core/single_scheduler.rb
+++ b/lib/core/single_scheduler.rb
@@ -21,6 +21,9 @@ module Core
     def connector_settings
       connector_settings = Core::ConnectorSettings.fetch(@connector_id)
       [connector_settings]
+    rescue StandardError => e
+      Utility::ExceptionTracking.log_exception(e, "Could not retrieve the connector by id #{@connector_id} due to unexpected error.")
+      []
     end
   end
 end


### PR DESCRIPTION
Some bug fixing and refactors:

1. changes to `connector_settings` method of `NativeScheduler` and `SingleScheduler`, to make sure they always return `[]` if something bad happens
2. Add `.with_indifferent_access` to `initialize` method of `Core::ConnectorSettings`. I remembered @artem-shelkovnikov made the change to remove it, but I think it's reasonable to keep it as we use symbolic keys in `Core::ConnectorSettings` and it does no harm to call `with_indifferent_access` twice (I actually encountered an issue because of this).
3. Move `initialize` method of `Core::ConnectorSettings` to public. I don't understand how it worked before, but we have method calls like below, and I think it's reasonable to make it public.

https://github.com/elastic/connectors-ruby/blob/2bc25637418b142cdfb2138c1201bd351aae49c6/lib/core/elastic_connector_actions.rb#L66

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
