### PR TITLE
Resolve circular dependency between ElasticConnectorActions and ConnectorSettings

### DIFF
--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -47,7 +47,7 @@ module App
       Core::ElasticConnectorActions.force_sync(connector_id)
       puts "Successfully synced for connector #{connector_id}"
 
-      config_settings = Core::ConnectorSettings.fetch(connector_id)
+      config_settings = Core::ConnectorSettings.fetch_by_id(connector_id)
       Core::ElasticConnectorActions.ensure_content_index_exists(config_settings[:index_name])
       Core::SyncJobRunner.new(config_settings, App::Config[:service_type]).execute
     end
@@ -89,7 +89,7 @@ module App
     def enable_scheduling
       return unless connector_registered?
 
-      previous_schedule = Core::ConnectorSettings.fetch(connector_id)&.scheduling_settings&.fetch(:interval, nil)
+      previous_schedule = Core::ConnectorSettings.fetch_by_id(connector_id)&.scheduling_settings&.fetch(:interval, nil)
       if previous_schedule.present?
         puts "Please enter a valid crontab expression for scheduling. Previous schedule was: #{previous_schedule}."
       else
@@ -125,7 +125,7 @@ module App
       Core::ElasticConnectorActions.ensure_content_index_exists(index_name, use_analysis_icu, language_code)
       puts "Successfully registered connector #{index_name} with ID #{id}"
 
-      connector_settings = Core::ConnectorSettings.fetch(id)
+      connector_settings = Core::ConnectorSettings.fetch_by_id(id)
 
       connector_settings.id
     end
@@ -164,7 +164,7 @@ module App
     end
 
     def current_connector
-      connector_settings = Core::ConnectorSettings.fetch(App::Config[:connector_id])
+      connector_settings = Core::ConnectorSettings.fetch_by_id(App::Config[:connector_id])
       service_type = App::Config[:service_type]
       if service_type.present?
         return registry.connector(service_type, connector_settings.configuration)
@@ -190,7 +190,7 @@ module App
 
       connector = current_connector
       connector_class = connector.class
-      current_values = Core::ConnectorSettings.fetch(connector_id)&.configuration
+      current_values = Core::ConnectorSettings.fetch_by_id(connector_id)&.configuration
       return unless connector.present?
 
       puts 'Provided configurable fields:'
@@ -217,7 +217,7 @@ module App
       connector = current_connector
       connector_class = connector.class
 
-      current_values = Core::ConnectorSettings.fetch(connector_id)&.configuration
+      current_values = Core::ConnectorSettings.fetch_by_id(connector_id)&.configuration
       return unless connector.present?
 
       puts 'Persisted values of configurable fields:'

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -35,7 +35,7 @@ module App
     def pre_flight_check
       raise "#{@service_type} is not a supported connector" unless Connectors::REGISTRY.registered?(@service_type)
       begin
-        connector_settings = Core::ConnectorSettings.fetch(@connector_id)
+        connector_settings = Core::ConnectorSettings.fetch_by_id(@connector_id)
         Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
       rescue Elastic::Transport::Transport::Errors::Unauthorized => e
         raise "Elasticsearch is not authorizing access #{e}"

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -32,7 +32,7 @@ module Core
       end
 
       def send(connector_id, service_type)
-        connector_settings = Core::ConnectorSettings.fetch(connector_id)
+        connector_settings = Core::ConnectorSettings.fetch_by_id(connector_id)
 
         doc = {
           :last_seen => Time.now

--- a/lib/core/native_scheduler.rb
+++ b/lib/core/native_scheduler.rb
@@ -15,7 +15,7 @@ require 'utility/exception_tracking'
 module Core
   class NativeScheduler < Core::Scheduler
     def connector_settings
-      Core::ConnectorSettings.fetch_native || []
+      Core::ConnectorSettings.fetch_native_connectors || []
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, 'Could not retrieve native connectors due to unexpected error.')
       []

--- a/lib/core/native_scheduler.rb
+++ b/lib/core/native_scheduler.rb
@@ -15,7 +15,7 @@ require 'utility/exception_tracking'
 module Core
   class NativeScheduler < Core::Scheduler
     def connector_settings
-      Core::ElasticConnectorActions.native_connectors || []
+      Core::ConnectorSettings.fetch_native || []
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, 'Could not retrieve native connectors due to unexpected error.')
       []

--- a/lib/core/single_scheduler.rb
+++ b/lib/core/single_scheduler.rb
@@ -19,7 +19,7 @@ module Core
     end
 
     def connector_settings
-      connector_settings = Core::ConnectorSettings.fetch(@connector_id)
+      connector_settings = Core::ConnectorSettings.fetch_by_id(@connector_id)
       [connector_settings]
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, "Could not retrieve the connector by id #{@connector_id} due to unexpected error.")

--- a/spec/app/worker_spec.rb
+++ b/spec/app/worker_spec.rb
@@ -59,7 +59,7 @@ describe App::Worker do
 
     allow(Core::ElasticConnectorActions).to receive(:ensure_content_index_exists)
 
-    allow(Core::ConnectorSettings).to receive(:fetch).and_return(connector_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).and_return(connector_settings)
 
     allow(Connectors::REGISTRY).to receive(:registered?).with(service_type).and_return(connector_class)
 
@@ -90,7 +90,7 @@ describe App::Worker do
       let(:error) { 'oh no!' }
 
       before(:each) do
-        allow(Core::ConnectorSettings).to receive(:fetch).and_raise(error)
+        allow(Core::ConnectorSettings).to receive(:fetch_by_id).and_raise(error)
       end
 
       it 'crashes with the raised error' do

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -62,7 +62,7 @@ describe Core::ConnectorSettings do
     end
   end
 
-  context '.fetch_native' do
+  context '.fetch_native_connectors' do
     let(:connectors_meta) {
       {
         :pipeline => {
@@ -88,7 +88,7 @@ describe Core::ConnectorSettings do
 
     context 'when no paging is needed' do
       before(:each) do
-        allow(Core::ElasticConnectorActions).to receive(:get_native_connectors).and_return({
+        allow(Core::ElasticConnectorActions).to receive(:search_connectors).and_return({
           'hits' => {
             'hits' => connectors,
             'total' => {
@@ -99,7 +99,7 @@ describe Core::ConnectorSettings do
       end
 
       it 'returns three connector settings instances' do
-        results = described_class.fetch_native(connectors.size)
+        results = described_class.fetch_native_connectors(connectors.size)
 
         expected_connector_ids = results.map(&:id)
         actual_connector_ids = connectors.map { |c| c['_id'] }
@@ -111,7 +111,7 @@ describe Core::ConnectorSettings do
     context 'when paging is needed' do
       before(:each) do
         (0..2).each do |i|
-          allow(Core::ElasticConnectorActions).to receive(:get_native_connectors).with(anything, i).and_return({
+          allow(Core::ElasticConnectorActions).to receive(:search_connectors).with(anything, anything, i).and_return({
             'hits' => {
               'hits' => [connectors[i]],
               'total' => {
@@ -123,7 +123,7 @@ describe Core::ConnectorSettings do
       end
 
       it 'returns three connector settings instances' do
-        results = described_class.fetch_native(1)
+        results = described_class.fetch_native_connectors(1)
 
         expected_connector_ids = results.map(&:id)
         actual_connector_ids = connectors.map { |c| c['_id'] }
@@ -134,7 +134,7 @@ describe Core::ConnectorSettings do
       it 'fetches connectors meta only once' do
         expect(Core::ElasticConnectorActions).to receive(:connectors_meta).exactly(1).time
 
-        described_class.fetch_native(1)
+        described_class.fetch_native_connectors(1)
       end
     end
   end

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -99,9 +99,9 @@ describe Core::ConnectorSettings do
       end
 
       it 'returns three connector settings instances' do
-        results = described_class.fetch_native(page_size = connectors.size)
+        results = described_class.fetch_native(connectors.size)
 
-        expected_connector_ids = results.map { |c| c.id }
+        expected_connector_ids = results.map(&:id)
         actual_connector_ids = connectors.map { |c| c['_id'] }
 
         expect(expected_connector_ids).to eq(actual_connector_ids)
@@ -113,7 +113,7 @@ describe Core::ConnectorSettings do
         (0..2).each do |i|
           allow(Core::ElasticConnectorActions).to receive(:get_native_connectors).with(anything, i).and_return({
             'hits' => {
-              'hits' => [ connectors[i] ],
+              'hits' => [connectors[i]],
               'total' => {
                 'value' => connectors.size
               }
@@ -123,9 +123,9 @@ describe Core::ConnectorSettings do
       end
 
       it 'returns three connector settings instances' do
-        results = described_class.fetch_native(page_size = 1)
+        results = described_class.fetch_native(1)
 
-        expected_connector_ids = results.map { |c| c.id }
+        expected_connector_ids = results.map(&:id)
         actual_connector_ids = connectors.map { |c| c['_id'] }
 
         expect(expected_connector_ids).to eq(actual_connector_ids)
@@ -134,7 +134,7 @@ describe Core::ConnectorSettings do
       it 'fetches connectors meta only once' do
         expect(Core::ElasticConnectorActions).to receive(:connectors_meta).exactly(1).time
 
-        described_class.fetch_native(page_size = 1)
+        described_class.fetch_native(1)
       end
     end
   end

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -154,16 +154,17 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#get_native_connectors' do
+  context '#search_connectors' do
     let(:connector_one) { { '_id' => '123', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
     let(:connector_two) { { '_id' => '456', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
+    let(:query) { { :term => { :is_native => true } } }
     let(:offset) { 0 }
     let(:page_size) { 10 }
     before(:each) do
       allow(es_client).to receive(:search).and_return({ 'hits' => { 'hits' => [connector_one, connector_two], 'total' => { 'value' => 2 } } })
     end
     it 'returns all native connectors' do
-      connectors = described_class.get_native_connectors(page_size, offset)
+      connectors = described_class.search_connectors(query, page_size, offset)
       expect(connectors['hits']['hits'].size).to eq(2)
       expect(connectors['hits']['hits'][0]['_id']).to eq(connector_one['_id'])
       expect(connectors['hits']['hits'][1]['_id']).to eq(connector_two['_id'])

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -157,35 +157,16 @@ describe Core::ElasticConnectorActions do
   context '#get_native_connectors' do
     let(:connector_one) { { '_id' => '123', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
     let(:connector_two) { { '_id' => '456', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
+    let(:offset) { 0 }
+    let(:page_size) { 10 }
     before(:each) do
       allow(es_client).to receive(:search).and_return({ 'hits' => { 'hits' => [connector_one, connector_two], 'total' => { 'value' => 2 } } })
     end
     it 'returns all native connectors' do
-      connectors = described_class.native_connectors
-      expect(connectors.size).to eq(2)
-      expect(connectors[0].id).to eq(connector_one['_id'])
-      expect(connectors[1].id).to eq(connector_two['_id'])
-    end
-
-    context 'when pagination is needed' do
-      before(:each) do
-        described_class::DEFAULT_PAGE_SIZE = 1
-        allow(es_client)
-          .to receive(:search)
-          .with(hash_including(:from => 0), any_args)
-          .and_return({ 'hits' => { 'hits' => [connector_one], 'total' => 2 } })
-        allow(es_client)
-          .to receive(:search)
-          .with(hash_including(:from => 1), any_args)
-          .and_return({ 'hits' => { 'hits' => [connector_two], 'total' => 2 } })
-      end
-
-      it 'returns all native connectors with pagination' do
-        connectors = described_class.native_connectors
-        expect(connectors.size).to eq(2)
-        expect(connectors[0].id).to eq(connector_one['_id'])
-        expect(connectors[1].id).to eq(connector_two['_id'])
-      end
+      connectors = described_class.get_native_connectors(page_size, offset)
+      expect(connectors['hits']['hits'].size).to eq(2)
+      expect(connectors['hits']['hits'][0]['_id']).to eq(connector_one['_id'])
+      expect(connectors['hits']['hits'][1]['_id']).to eq(connector_two['_id'])
     end
   end
 

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -15,7 +15,7 @@ describe Core::Heartbeat do
   let(:is_healthy) { true }
 
   before(:each) do
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id).and_return(connector_settings)
 
     allow(Core::ElasticConnectorActions).to receive(:update_connector_fields)
 
@@ -123,7 +123,7 @@ describe Core::Heartbeat do
         let(:error) { 'something really bad happened' }
 
         before(:each) do
-          allow(Core::ConnectorSettings).to receive(:fetch).and_raise(error)
+          allow(Core::ConnectorSettings).to receive(:fetch_by_id).and_raise(error)
         end
 
         it 'does not raise an error' do

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -41,7 +41,7 @@ describe Core::NativeScheduler do
       allow(settings).to receive(:scheduling_settings).and_return(scheduling_settings)
     }
 
-    allow(Core::ConnectorSettings).to receive(:fetch_native).and_return(native_connectors_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_native_connectors).and_return(native_connectors_settings)
 
     # Also we don't really wanna sleep
     allow_any_instance_of(Object).to receive(:sleep)

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -29,9 +29,8 @@ describe Core::NativeScheduler do
   end
 
   before(:each) do
-    allow(Core::ElasticConnectorActions).to receive(:connectors_meta).and_return({})
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id1).and_return(connector_settings1)
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id2).and_return(connector_settings2)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id1).and_return(connector_settings1)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id2).and_return(connector_settings2)
 
     [connector_settings1, connector_settings2].each { |settings|
       allow(settings).to receive(:connector_status).and_return(connector_status)
@@ -42,7 +41,7 @@ describe Core::NativeScheduler do
       allow(settings).to receive(:scheduling_settings).and_return(scheduling_settings)
     }
 
-    allow(Core::ElasticConnectorActions).to receive(:native_connectors).and_return(native_connectors_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_native).and_return(native_connectors_settings)
 
     # Also we don't really wanna sleep
     allow_any_instance_of(Object).to receive(:sleep)

--- a/spec/core/single_scheduler_spec.rb
+++ b/spec/core/single_scheduler_spec.rb
@@ -16,7 +16,7 @@ describe Core::SingleScheduler do
   let(:scheduling_settings) { { :enabled => scheduling_enabled, :interval => scheduling_interval } }
 
   before(:each) do
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id).and_return(connector_settings)
 
     allow(connector_settings).to receive(:id).and_return(connector_id)
     allow(connector_settings).to receive(:connector_status).and_return(connector_status)

--- a/tests/ftest.rb
+++ b/tests/ftest.rb
@@ -115,7 +115,7 @@ def run_sync
   puts("Connector id #{connector_id}")
   puts('Syncing')
 
-  config_settings = Core::ConnectorSettings.fetch(connector_id)
+  config_settings = Core::ConnectorSettings.fetch_by_id(connector_id)
 
   # Creating the mapping for the index
   settings = Utility::Elasticsearch::Index::TextAnalysisSettings.new(:language_code => 'en', :analysis_icu => false).to_h


### PR DESCRIPTION
Found a problem that `ElasticConnectorActions` and `ConnectorSettings` classes have a circular dependency. 

It happens because `Core::ElasticConnectorActions.native_connectors` attempts to create instances of `Core::ConnectorSettings` inside of the method, while `Core::ConnectorSettings.fetch_by_id` instead just calls `Core::ElasticConnectorActions.get_connector` to get the connector and does creation on its side.

Resolution is - make `Core::ElasticConnectorActions.native_connectors` more primitive "query" method that does not attempt to stitch pages/join results and move the stitching/creation logic into a method in `Core::ConnectorSettings`, see `Core::ConnectorSettings.fetch_native` method.

As a side effect added a test that checks that when fetching native connectors we ask the server for `connectors_meta` only once.