### PR TITLE
Remove params from do_health_check, do_health_check! and is_healthy?

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -34,19 +34,19 @@ module Connectors
 
       def yield_documents; end
 
-      def do_health_check(_params)
+      def do_health_check
         raise 'Not implemented for this connector'
       end
 
-      def do_health_check!(params)
-        do_health_check(params)
+      def do_health_check!
+        do_health_check
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, "Connector for service #{self.class.service_type} failed the health check for 3rd-party service.")
         raise Utility::Errors::HealthCheckFailedError.new
       end
 
-      def is_healthy?(params = {})
-        do_health_check(params)
+      def is_healthy?
+        do_health_check
 
         true
       rescue StandardError => e

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -33,7 +33,7 @@ module Connectors
         super
       end
 
-      def do_health_check(_params)
+      def do_health_check
         # Do the health check by trying to access 3rd-party system just to verify that everything is set up properly.
         #
         # To emulate unhealthy 3rd-party system situation, uncomment the following line:

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -60,7 +60,7 @@ module Connectors
 
       private
 
-      def do_health_check(_params)
+      def do_health_check
         @extractor.health_check
       end
     end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -56,7 +56,7 @@ module Connectors
 
       private
 
-      def do_health_check(_params)
+      def do_health_check
         create_client(@host, @database)
       end
 

--- a/spec/connectors/example/connector_spec.rb
+++ b/spec/connectors/example/connector_spec.rb
@@ -19,7 +19,7 @@ describe Connectors::Example::Connector do
 
   context '#is_healthy?' do
     it 'returns ok' do
-      expect(subject.is_healthy?({})).to eq(true)
+      expect(subject.is_healthy?).to eq(true)
     end
   end
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -49,7 +49,7 @@ describe Connectors::MongoDB::Connector do
     it 'instantiates a mongodb client' do
       expect(Mongo::Client).to receive(:new).with([mongodb_host], hash_including(:database => mongodb_database))
 
-      subject.is_healthy?({})
+      subject.is_healthy?
     end
   end
 


### PR DESCRIPTION
Simplifying the code - functions  `do_health_check`, `do_health_check!` and `is_healthy?` take one argument that is never used, therefore I'm deleting this argument in this PR.