### PR TITLE
Use Core::ConnectorSettings in Crawler::Scheduler

### DIFF
--- a/lib/connectors/crawler/scheduler.rb
+++ b/lib/connectors/crawler/scheduler.rb
@@ -16,7 +16,7 @@ module Connectors
   module Crawler
     class Scheduler < Core::Scheduler
       def connector_settings
-        Core::ElasticConnectorActions.crawler_connectors || []
+        Core::ConnectorSettings.fetch_crawler_connectors || []
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, 'Could not retrieve Crawler connectors due to unexpected error.')
       end

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -44,7 +44,7 @@ module Core
       fetch_connectors_by_query(query, page_size)
     end
 
-    def self.fetch_crawler_connectors
+    def self.fetch_crawler_connectors(page_size = DEFAULT_PAGE_SIZE)
       query = { term: { service_type: Utility::Constants::CRAWLER_SERVICE_TYPE } }
       fetch_connectors_by_query(query, page_size)
     end

--- a/spec/connectors/crawler/crawler_scheduler_spec.rb
+++ b/spec/connectors/crawler/crawler_scheduler_spec.rb
@@ -31,8 +31,8 @@ describe Connectors::Crawler::Scheduler do
 
   before(:each) do
     allow(Core::ElasticConnectorActions).to receive(:connectors_meta).and_return({})
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id1).and_return(connector_settings1)
-    allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id2).and_return(connector_settings2)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id1).and_return(connector_settings1)
+    allow(Core::ConnectorSettings).to receive(:fetch_by_id).with(connector_id2).and_return(connector_settings2)
 
     [connector_settings1, connector_settings2].each { |settings|
       allow(settings).to receive(:connector_status).and_return(connector_status)
@@ -43,7 +43,7 @@ describe Connectors::Crawler::Scheduler do
       allow(settings).to receive(:scheduling_settings).and_return(scheduling_settings)
     }
 
-    allow(Core::ElasticConnectorActions).to receive(:crawler_connectors).and_return(crawlers_settings)
+    allow(Core::ConnectorSettings).to receive(:fetch_crawler_connectors).and_return(crawlers_settings)
 
     # Also we don't really wanna sleep
     allow_any_instance_of(Object).to receive(:sleep)


### PR DESCRIPTION
This will fix `Crawler::Scheduler` after `ElasticConnectorActions` [refactoring](https://github.com/elastic/connectors-ruby/pull/300)

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally