### PR TITLE
[Native Connectors] Heartbeat flow should be separate from sync flow

### DIFF
--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -48,9 +48,11 @@ module App
 
     def start_polling_jobs
       Utility::Logger.info("Polling Elasticsearch for synchronisation jobs to run on #{@connector_id} - #{@service_type}...")
-      Core::SingleScheduler.new(@connector_id, POLL_IDLING).when_triggered do |connector_settings|
-        job_runner = Core::SyncJobRunner.new(connector_settings, @service_type)
-        job_runner.execute
+      Core::SingleScheduler.new(@connector_id, POLL_IDLING).when_polling_jobs do |connector_settings, do_sync|
+        if do_sync
+          job_runner = Core::SyncJobRunner.new(connector_settings, @service_type)
+          job_runner.execute
+        end
       end
     end
   end

--- a/lib/core/heartbeat.rb
+++ b/lib/core/heartbeat.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-require 'concurrent'
+require 'concurrent-ruby'
 require 'connectors/connector_status'
 require 'connectors/registry'
 require 'core/connector_settings'

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -24,12 +24,10 @@ module Core
       raise 'Not implemented'
     end
 
-    def when_triggered
+    def when_polling_jobs
       loop do
         connector_settings.each do |cs|
-          if sync_triggered?(cs)
-            yield cs
-          end
+          yield cs, sync_triggered?(cs)
         end
         if @is_shutting_down
           break

--- a/spec/app/dispatcher_spec.rb
+++ b/spec/app/dispatcher_spec.rb
@@ -46,7 +46,7 @@ describe App::Dispatcher do
 
     context 'without native connectors' do
       before(:each) do
-        allow(scheduler).to receive(:when_triggered)
+        allow(scheduler).to receive(:when_polling_jobs)
       end
       it 'starts no sync jobs' do
         expect(Core::Heartbeat).to_not receive(:send)
@@ -66,7 +66,7 @@ describe App::Dispatcher do
         allow(connector_settings).to receive(:service_type).and_return(service_type)
         allow(connector_settings).to receive(:index_name).and_return(index_name)
 
-        allow(scheduler).to receive(:when_triggered).and_yield(connector_settings)
+        allow(scheduler).to receive(:when_polling_jobs).and_yield(connector_settings, true)
         allow(Connectors::REGISTRY).to receive(:registered?).with(service_type).and_return(true)
       end
 

--- a/spec/app/worker_spec.rb
+++ b/spec/app/worker_spec.rb
@@ -64,7 +64,7 @@ describe App::Worker do
     allow(Connectors::REGISTRY).to receive(:registered?).with(service_type).and_return(connector_class)
 
     allow(Core::Scheduler).to receive(:new).and_return(scheduler)
-    allow(scheduler).to receive(:when_triggered).and_yield(connector_settings)
+    allow(scheduler).to receive(:when_polling_jobs).and_yield(connector_settings, true)
 
     allow(Core::SyncJobRunner).to receive(:new).and_return(sync_job_runner)
     allow(sync_job_runner).to receive(:execute)
@@ -125,7 +125,7 @@ describe App::Worker do
 
     context 'when scheduler does not yield' do
       before(:each) do
-        allow(scheduler).to receive(:when_triggered)
+        allow(scheduler).to receive(:when_polling_jobs)
       end
 
       it 'does not trigger the connector' do

--- a/spec/connectors/crawler/crawler_scheduler_spec.rb
+++ b/spec/connectors/crawler/crawler_scheduler_spec.rb
@@ -54,13 +54,13 @@ describe Connectors::Crawler::Scheduler do
 
   shared_examples_for 'sync triggers' do
     it '' do
-      expect { |b| subject.when_triggered(&b) }.to yield_successive_args(*crawlers_settings)
+      expect { |b| subject.when_polling_jobs(&b) }.to yield_successive_args(*crawlers_settings.map { |cs| [cs, true] })
     end
   end
 
   shared_examples_for 'sync does not trigger' do
     it '' do
-      expect { |b| subject.when_triggered(&b) }.to_not yield_successive_args(anything)
+      expect { |b| subject.when_polling_jobs(&b) }.to_not yield_successive_args(anything)
     end
   end
 

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -51,14 +51,14 @@ describe Core::NativeScheduler do
   end
 
   shared_examples_for 'sync triggers' do
-    it '' do
-      expect { |b| subject.when_triggered(&b) }.to yield_successive_args(*native_connectors_settings)
+    it 'works as expected' do
+      expect { |b| subject.when_polling_jobs(&b) }.to yield_successive_args(*native_connectors_settings.map { |cs| [cs, true] })
     end
   end
 
   shared_examples_for 'sync does not trigger' do
-    it '' do
-      expect { |b| subject.when_triggered(&b) }.to_not yield_successive_args(anything)
+    it 'works as expected' do
+      expect { |b| subject.when_polling_jobs(&b) }.to_not yield_successive_args(anything)
     end
   end
 

--- a/spec/core/single_scheduler_spec.rb
+++ b/spec/core/single_scheduler_spec.rb
@@ -34,17 +34,17 @@ describe Core::SingleScheduler do
 
   shared_examples_for 'sync triggers' do
     it '' do
-      expect { |b| subject.when_triggered(&b) }.to yield_with_args(connector_settings)
+      expect { |b| subject.when_polling_jobs(&b) }.to yield_with_args(connector_settings, true)
     end
   end
 
   shared_examples_for 'sync does not trigger' do
     it '' do
-      expect { |b| subject.when_triggered(&b) }.to_not yield_with_args(anything)
+      expect { |b| subject.when_polling_jobs(&b) }.to_not yield_with_args(anything)
     end
   end
 
-  describe '.when_triggered' do
+  describe '.when_polling_jobs' do
     context 'when error is raised' do
       let(:error) { 'some error happened' }
 
@@ -55,7 +55,7 @@ describe Core::SingleScheduler do
       it_behaves_like 'sync does not trigger'
 
       it 'does not raise an error' do
-        expect { |b| subject.when_triggered(&b) }.to_not raise_error
+        expect { |b| subject.when_polling_jobs(&b) }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2716

Currently, the heartbeats don't start until the first sync, and this isn't a user-friendly experience on the UI because the user might sit and wait for a long time before the connector signifies that it's alive.

It's an oversight that should be fixed.

Bonus points: make one timer task per cycle, not one per connector (that would eat up threads doing very little).

## Steps to reproduce the behavior:

* Create an index for the connector
* Start the connector service dispatcher with a native connector and with sync disabled on it
* Heartbeats should start and show connector as available

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] [Manual test steps](https://github.com/elastic/connectors-ruby/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
