### PR TITLE
Add auth handling to MongoDB connector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'bundler', File.read(File.join(__dir__, '.bundler-version')).strip
 
 # Dependencies for connectors
 gem 'activesupport', '5.2.6'
-gem 'bson', '~> 4.2.2'
 gem 'mime-types', '= 3.1'
 gem 'tzinfo-data', '= 1.2022.1'
 gem 'tzinfo', '1.2.10'
@@ -52,4 +51,4 @@ gem 'elasticsearch'
 gem 'signet', '~> 0.16.0'
 
 # Dependency for mongo connector
-gem 'mongo', '~> 2.4.3'
+gem 'mongo', '~> 2.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     attr_extras (6.2.5)
-    bson (4.2.2)
-    bson (4.2.2-java)
+    bson (4.15.0)
+    bson (4.15.0-java)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     config (4.0.0)
@@ -108,8 +108,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     minitest (5.16.1)
-    mongo (2.4.3)
-      bson (>= 4.2.1, < 5.0.0)
+    mongo (2.18.1)
+      bson (>= 4.14.1, < 5.0.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nokogiri (1.13.7-arm64-darwin)
@@ -216,7 +216,6 @@ PLATFORMS
 DEPENDENCIES
   activesupport (= 5.2.6)
   attr_extras (~> 6.2.5)
-  bson (~> 4.2.2)
   bundler (= 2.3.15)
   concurrent-ruby (~> 1.1.9)
   config (~> 4.0.0)
@@ -229,7 +228,7 @@ DEPENDENCIES
   hashie (~> 5.0.0)
   httpclient (~> 2.8.3)
   mime-types (= 3.1)
-  mongo (~> 2.4.3)
+  mongo (~> 2.18)
   nokogiri (>= 1.13.7)
   pry-nav
   pry-remote

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -52,6 +52,10 @@ puts "Parsing #{CONFIG_FILE} configuration file."
     optional(:gitlab).hash do
       required(:api_token).value(:string)
     end
+
+    optional(:mongo).hash do
+      required(:direct_connection).value(:bool?)
+    end
   end
 end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -50,7 +50,7 @@ module Connectors
         @user = remote_configuration.dig(:user, :value)
         @password = remote_configuration.dig(:password, :value)
 
-        @direct_connection = local_configuration.present? && !!local_configuration.dig(:direct_connection)
+        @direct_connection = local_configuration.present? && !!local_configuration[:direct_connection]
       end
 
       def yield_documents
@@ -89,8 +89,6 @@ module Connectors
             user: @user,
             password: @password
           )
-        elsif @user.present? || @password.present?
-          raise 'Wrong configuration: both user and password should be present or missing at the same time'
         end
 
         begin

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -72,10 +72,10 @@ module Connectors
 
       def with_client
         uri = if @user.present? || @password.present?
-          "mongodb+srv://#{@user}:#{@password}@#{@host}/#{@database}"
-        else
-          "mongodb+srv://#{@host}/#{@database}"
-        end
+                "mongodb+srv://#{@user}:#{@password}@#{@host}/#{@database}"
+              else
+                "mongodb+srv://#{@host}/#{@database}"
+              end
 
         client = Mongo::Client.new(
           uri,

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -26,6 +26,12 @@ module Connectors
            :host => {
              :label => 'MongoDB Server Hostname'
            },
+           :user => {
+             :label => 'MongoDB User'
+           },
+           :password => {
+             :label => 'MongoDB Passwd'
+           },
            :database => {
              :label => 'MongoDB Database'
            },
@@ -41,10 +47,12 @@ module Connectors
         @host = remote_configuration.dig(:host, :value)
         @database = remote_configuration.dig(:database, :value)
         @collection = remote_configuration.dig(:collection, :value)
+        @user = remote_configuration.dig(:user, :value)
+        @password = remote_configuration.dig(:password, :value)
       end
 
       def yield_documents
-        with_client(@host, @database) do |client|
+        with_client do |client|
           client[@collection].find.each do |document|
             doc = document.with_indifferent_access
             transform!(doc)
@@ -57,15 +65,27 @@ module Connectors
       private
 
       def do_health_check
-        with_client(@host, @database) do |_client|
+        with_client do |_client|
           Utility::Logger.debug("Mongo at #{@host}/#{@database} looks healthy.")
         end
       end
 
-      def with_client(host, database)
-        client = Mongo::Client.new([host],
-                                   :connect => :direct,
-                                   :database => database)
+      def with_client
+        uri = if @user.present? || @password.present?
+          "mongodb+srv://#{@user}:#{@password}@#{@host}/#{@database}"
+        else
+          "mongodb+srv://#{@host}/#{@database}"
+        end
+
+        client = Mongo::Client.new(
+          uri,
+          app_name: 'Elastic Enterprise Search',
+          max_pool_size: 8,
+          socket_timeout: 60,
+          heartbeat_frequency: 120,
+          connect_timeout: 30,
+        )
+
         begin
           Utility::Logger.debug("Existing Databases #{client.database_names}")
           Utility::Logger.debug('Existing Collections:')

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -20,6 +20,14 @@ describe Connectors::MongoDB::Connector do
        :collection => {
          :label => 'MongoDB Collection',
          :value => mongodb_collection
+       },
+       :user => {
+         :label => 'Username',
+         :value => mongodb_username
+       },
+       :password => {
+         :label => 'Password',
+         :value => mongodb_password
        }
     }
   end
@@ -27,6 +35,8 @@ describe Connectors::MongoDB::Connector do
   let(:mongodb_host) { '127.0.0.1:27027' }
   let(:mongodb_database) { 'sample-database' }
   let(:mongodb_collection) { 'some-collection' }
+  let(:mongodb_username) { 'admin' }
+  let(:mongodb_password) { 'password' }
 
   let(:mongo_client) { double }
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -35,8 +35,8 @@ describe Connectors::MongoDB::Connector do
   let(:mongodb_host) { '127.0.0.1:27027' }
   let(:mongodb_database) { 'sample-database' }
   let(:mongodb_collection) { 'some-collection' }
-  let(:mongodb_username) { 'admin' }
-  let(:mongodb_password) { 'password' }
+  let(:mongodb_username) { nil }
+  let(:mongodb_password) { nil }
 
   let(:mongo_client) { double }
 
@@ -58,7 +58,7 @@ describe Connectors::MongoDB::Connector do
 
   context '#is_healthy?' do
     it 'instantiates a mongodb client' do
-      expect(Mongo::Client).to receive(:new).with([mongodb_host], hash_including(:database => mongodb_database))
+      expect(Mongo::Client).to receive(:new).with(mongodb_host, hash_including(:database => mongodb_database))
 
       subject.is_healthy?
     end

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -49,6 +49,7 @@ describe Connectors::MongoDB::Connector do
     allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
     allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
     allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
+    allow(mongo_client).to receive(:with).and_return(mongo_client)
     allow(mongo_client).to receive(:close)
 
     allow(actual_collection).to receive(:find).and_return(actual_collection_data)
@@ -56,25 +57,51 @@ describe Connectors::MongoDB::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#is_healthy?' do
-    it 'instantiates a mongodb client' do
-      expect(Mongo::Client).to receive(:new).with(mongodb_host, hash_including(:database => mongodb_database))
-
-      subject.is_healthy?
-    end
-
-    it 'closes a client in the end' do
+  shared_examples_for 'closes a client in the end' do
+    it '' do
       expect(mongo_client).to receive(:close)
 
       subject.is_healthy?
     end
   end
 
-  context '#yield_documents' do
-    it 'closes a client in the end' do
-      expect(mongo_client).to receive(:close)
+  shared_examples_for 'handles auth' do
+    context 'when username and password are provided' do
+      let(:mongodb_username) { 'admin' }
+      let(:mongodb_password) { 'some-password' }
+      it 'sets client to use basic auth' do
+        expect(mongo_client).to receive(:with).with(:user => mongodb_username, :password => mongodb_password)
 
-      subject.yield_documents { |doc| }
+        do_test
+      end
+    end
+
+    context 'when no username and password are provided' do
+      it 'does not set client to use basic auth' do
+        expect(mongo_client).to_not receive(:with).with(:user => mongodb_username, :password => mongodb_password)
+
+        do_test
+      end
+    end
+  end
+
+  context '#is_healthy?' do
+    it_behaves_like 'closes a client in the end'
+    it_behaves_like 'handles auth' do
+      let(:do_test) { subject.is_healthy? }
+    end
+
+    it 'instantiates a mongodb client' do
+      expect(Mongo::Client).to receive(:new).with(mongodb_host, hash_including(:database => mongodb_database))
+
+      subject.is_healthy?
+    end
+  end
+
+  context '#yield_documents' do
+    it_behaves_like 'closes a client in the end'
+    it_behaves_like 'handles auth' do
+      let(:do_test) { subject.yield_documents { |doc|; } }
     end
 
     context 'when database is not found' do


### PR DESCRIPTION
## Part of making MongoDB connector production-ready

This PR adds handling of auth for MongoDB connector + bumps MongoDB gem to support more mongodb installations.

Now it's possible to connect using different setups:

- Cloud version of MongoDB hosted by mongodb.net
This can be done setting `host` to for example: `mongodb+srv://some_cluster.mongodb.net`
- Locally hosted version of MongoDB without discovery enabled
This can be done with several steps - first setting `host` to for example: `host: mongodb://127.0.0.1:27021'. and then setting a configuration option in `config/connectors.yml`:
```
mongo:
  direct_connection: true
```

Both anonymous access and basic auth are supported!

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally