### PR TITLE
Change service_type: mongo -> mongodb

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -14,7 +14,7 @@ module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
       def self.service_type
-        'mongo'
+        'mongodb'
       end
 
       def self.display_name


### PR DESCRIPTION
Consistency change: let's make `mongo` connector service_type `mongodb` instead (Kibana creates native connectors with this service type now, and I find it better)