### PR TITLE
more cloud fixes

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -57,7 +57,6 @@ module Connectors
         with_client do |client|
           client[@collection].find.each do |document|
             doc = document.with_indifferent_access
-
             yield serialize(doc)
           end
         end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -94,6 +94,9 @@ module Core
     end
 
     def add_ingest_metadata(document)
+      # XXX
+      return document
+
       document.tap do |it|
         it['_extract_binary_content'] = @connector_settings.extract_binary_content? if @connector_settings.extract_binary_content?
         it['_reduce_whitespace'] = @connector_settings.reduce_whitespace? if @connector_settings.reduce_whitespace?


### PR DESCRIPTION
fixed the optional flag

now:

```
F, [2022-09-14T21:40:34.416285 #363] FATAL -- : [400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]"}],"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]"},"status":400}
E, [2022-09-14T21:40:34.424906 #363] ERROR -- : Traceback (most recent call last):
	28: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block in create_worker'
	27: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `catch'
	26: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `block (2 levels) in create_worker'
	25: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `loop'
	24: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `block (3 levels) in create_worker'
	23: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:363:in `run_task'
	22: from /usr/share/enterprise-search/connectors-ruby/lib/app/dispatcher.rb:87:in `block (2 levels) in start_polling_jobs!'
	21: from /usr/share/enterprise-search/connectors-ruby/lib/core/sync_job_runner.rb:38:in `execute'
	20: from /usr/share/enterprise-search/connectors-ruby/lib/core/sync_job_runner.rb:63:in `do_sync!'
	19: from /usr/share/enterprise-search/connectors-ruby/lib/connectors/mongodb/connector.rb:57:in `yield_documents'
	18: from /usr/share/enterprise-search/connectors-ruby/lib/connectors/mongodb/connector.rb:100:in `with_client'
	17: from /usr/share/enterprise-search/connectors-ruby/lib/connectors/mongodb/connector.rb:58:in `block in yield_documents'
	16: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/mongo-2.18.1/lib/mongo/collection/view/iterable.rb:85:in `each'
	15: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/mongo-2.18.1/lib/mongo/cursor.rb:165:in `each'
	14: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/mongo-2.18.1/lib/mongo/cursor.rb:165:in `loop'
	13: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/mongo-2.18.1/lib/mongo/cursor.rb:167:in `block in each'
	12: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/mongo-2.18.1/lib/mongo/collection/view/iterable.rb:86:in `block in each'
	11: from /usr/share/enterprise-search/connectors-ruby/lib/connectors/mongodb/connector.rb:62:in `block (2 levels) in yield_documents'
	10: from /usr/share/enterprise-search/connectors-ruby/lib/core/sync_job_runner.rb:65:in `block in do_sync!'
	 9: from /usr/share/enterprise-search/connectors-ruby/lib/core/output_sink/es_sink.rb:30:in `ingest'
	 8: from /usr/share/enterprise-search/connectors-ruby/lib/core/output_sink/es_sink.rb:45:in `flush'
	 7: from /usr/share/enterprise-search/connectors-ruby/lib/core/output_sink/es_sink.rb:66:in `send_data'
	 6: from /usr/share/enterprise-search/connectors-ruby/lib/utility/es_client.rb:53:in `bulk'
	 5: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elasticsearch-api-8.2.2/lib/elasticsearch/api/actions/bulk.rb:66:in `bulk'
	 4: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elasticsearch-8.2.2/lib/elasticsearch.rb:71:in `method_missing'
	 3: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elastic-transport-8.0.1/lib/elastic/transport/client.rb:176:in `perform_request'
	 2: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elastic-transport-8.0.1/lib/elastic/transport/transport/http/faraday.rb:36:in `perform_request'
	 1: from /usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elastic-transport-8.0.1/lib/elastic/transport/transport/base.rb:349:in `perform_request'
/usr/local/rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/elastic-transport-8.0.1/lib/elastic/transport/transport/base.rb:228:in `__raise_transport_error': [400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]"}],"type":"illegal_argument_exception","reason":"Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]"},"status":400} (Elastic::Transport::Transport::Errors::BadRequest)
```