### PR TITLE
Fix MongoDB leaking threads if auth is provided

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -72,22 +72,20 @@ module Connectors
         end
       end
 
-      def with_client
-        client = Mongo::Client.new(
-          @host,
-          database: @database,
-          app_name: 'Elastic Enterprise Search',
-          max_pool_size: 8,
-          socket_timeout: 60,
-          heartbeat_frequency: 120,
-          connect_timeout: 30,
-          direct_connection: @direct_connection
-        )
-
-        if @user.present? && @password.present?
-          client = client.with(
+      def with_client(&block)
+        client = if @user.present? || @password.present?
+          Mongo::Client.new(
+            @host,
+            database: @database,
+            direct_connection: @direct_connection,
             user: @user,
             password: @password
+          )
+        else
+          Mongo::Client.new(
+            @host,
+            database: @database,
+            direct_connection: @direct_connection
           )
         end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -72,22 +72,22 @@ module Connectors
         end
       end
 
-      def with_client(&block)
+      def with_client
         client = if @user.present? || @password.present?
-          Mongo::Client.new(
-            @host,
-            database: @database,
-            direct_connection: @direct_connection,
-            user: @user,
-            password: @password
-          )
-        else
-          Mongo::Client.new(
-            @host,
-            database: @database,
-            direct_connection: @direct_connection
-          )
-        end
+                   Mongo::Client.new(
+                     @host,
+                     database: @database,
+                     direct_connection: @direct_connection,
+                     user: @user,
+                     password: @password
+                   )
+                 else
+                   Mongo::Client.new(
+                     @host,
+                     database: @database,
+                     direct_connection: @direct_connection
+                   )
+                 end
 
         begin
           Utility::Logger.debug("Existing Databases #{client.database_names}")

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -70,7 +70,7 @@ describe Connectors::MongoDB::Connector do
       let(:mongodb_username) { 'admin' }
       let(:mongodb_password) { 'some-password' }
       it 'sets client to use basic auth' do
-        expect(mongo_client).to receive(:with).with(:user => mongodb_username, :password => mongodb_password)
+        expect(Mongo::Client).to receive(:new).with(anything, hash_including(:user => mongodb_username, :password => mongodb_password))
 
         do_test
       end
@@ -78,7 +78,7 @@ describe Connectors::MongoDB::Connector do
 
     context 'when no username and password are provided' do
       it 'does not set client to use basic auth' do
-        expect(mongo_client).to_not receive(:with).with(:user => mongodb_username, :password => mongodb_password)
+        expect(Mongo::Client).to_not receive(:new).with(anything, hash_including(:user => mongodb_username, :password => mongodb_password))
 
         do_test
       end


### PR DESCRIPTION
Big mistake by me when adding logic that adds basic auth for mongo in this line:

```
client = client.with(
            user: @user,
            password: @password
          )
```

This line actually creates an new client for this MongoDB instance and overwrites content of `client` variable with it. Old client is left hanging indefinitely and never deallocates the resources, and since new client is actually not an independent client - it's "derivative" client, it seems to also not deallocate the resources any more.

This PR removes usage of `client.with` and just initialize client once and not do fancy stuff with it.