### PR TITLE
Base::Connector uses invalid namespace for HealthCheckFailedError

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -42,7 +42,7 @@ module Connectors
         do_health_check
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, "Connector for service #{self.class.service_type} failed the health check for 3rd-party service.")
-        raise Utility::Errors::HealthCheckFailedError.new
+        raise Utility::HealthCheckFailedError.new
       end
 
       def is_healthy?


### PR DESCRIPTION
Minor typo/bug fix, there's no `Utility::Errors::` namespace, all errors are in `Utility::` namespace - whether it's good or bad.