### PR TITLE
Display actual first error that happened when applying bulk operations

### DIFF
--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -60,7 +60,7 @@ module Utility
         first_error = nil
 
         response['items'].each do |item|
-          [ 'index', 'delete' ].each do |op|
+          ['index', 'delete'].each do |op|
             if item.has_key?(op) && item[op].has_key?('error')
               first_error = item
 


### PR DESCRIPTION
Problem found: when doing bulk insert/delete operations and an error happened, we always just pick the first operation and display it in the error message, when in reality it can be any operation in the array.

This PR attempts to find the first index/delete operation that failed and use it as an error.

If no error is found, another error message is displayed.