### PR TITLE
catch SINGINT/SIGTERM (to be tested)

### DIFF
--- a/lib/connectors_service.rb
+++ b/lib/connectors_service.rb
@@ -15,6 +15,18 @@ class ConnectorsService
   def self.run!
     Utility::Environment.set_execution_environment(App::Config) do
       App::PreflightCheck.run!
+
+      # set up exits signals to shut down gracefully
+      Signal.trap("INT") {
+        App::Dispatcher.shutdown!
+        exit(0)
+      }
+      Signal.trap("TERM") {
+        App::Dispatcher.shutdown!
+        exit(0)
+      }
+
+      # start the dispatcher
       App::Dispatcher.start!
     rescue App::PreflightCheck::CheckFailure => e
       Utility::Logger.error("Preflight check failed: #{e.message}")


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-ruby/issues/###

needs tests, also not sure it's the proper spot.

when the service runs a ctrl+C or a kill should call shutdown so the service gracefully stops with exit code 0