### PR TITLE
Remove local_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In this section:
 The [connector protocol](docs/CONNECTOR_PROTOCOL.md) is document-based and building a connector is language- and tool-agnostic.
 To create an Elastic connector, you need to implement this protocol. At a high level, you need to create an application (the connector service) that can read and write to a specific document in Elasticsearch that represents the connector. This document "registers" the connector with Kibana, keeps the configuration that is made via the Kibana UI, as well as the scheduling configuration and the state information for the service. You need to update the connector state to keep up with the current status of the connector application and of the third-party data source. You also need to log sync jobs to an additional index, so that the history of synchronization tasks would be available. And of course, you need to write the results of the synchronization to the Elasticsearch document index, created for this connector service.
 
-The procedures to properly implement the protocol _without the connector framework_ is as follows:
+The procedures to properly implement the protocol _without the connector framework_ are as follows:
 
 - Create a new index for the connector via the Kibana UI - Enterprise Search - Create an Elasticsearch index. Use the `Build a connector` option for an ingestion method.
 - Create an API key to work with the connector. It should be done either using the `Generate API key` button, which is available on the next step of the wizard, or by creating a new API key via the Security - API keys - `Create API key`. The second way is more generic and will allow the same API key to be used for multiple connectors.

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -52,14 +52,6 @@ puts "Parsing #{CONFIG_FILE} configuration file."
     optional(:poll_interval).value(:integer)
     optional(:termination_timeout).value(:integer)
     optional(:heartbeat_interval).value(:integer)
-
-    optional(:gitlab).hash do
-      required(:api_token).value(:string)
-    end
-
-    optional(:mongo).hash do
-      required(:direct_connection).value(:bool?)
-    end
   end
 end
 

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -27,9 +27,8 @@ module Connectors
         raise 'Not implemented for this connector'
       end
 
-      def initialize(local_configuration: {}, remote_configuration: {})
-        @local_configuration = local_configuration || {} # configuration of connector from local file
-        @remote_configuration = remote_configuration || {} # configuration of connector from configurable fields
+      def initialize(configuration: {})
+        @configuration = configuration.dup || {}
       end
 
       def yield_documents; end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -41,7 +41,7 @@ module Connectors
         do_health_check
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, "Connector for service #{self.class.service_type} failed the health check for 3rd-party service.")
-        raise Utility::HealthCheckFailedError.new
+        raise Utility::HealthCheckFailedError.new, e.message
       end
 
       def is_healthy?

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -29,7 +29,7 @@ module Connectors
         }
       end
 
-      def initialize(local_configuration: {}, remote_configuration: {})
+      def initialize(configuration: {})
         super
       end
 

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -15,8 +15,6 @@ require 'core/output_sink'
 
 module Connectors
   module GitLab
-    class InvalidConfigurationError < StandardError; end
-
     class Connector < Connectors::Base::Connector
       def self.service_type
         'gitlab'
@@ -31,18 +29,19 @@ module Connectors
           :base_url => {
             :label => 'Base URL',
             :value => Connectors::GitLab::DEFAULT_BASE_URL
+          },
+          :api_key => {
+             :label => 'API Key'
           }
         }
       end
 
-      def initialize(local_configuration: {}, remote_configuration: {})
+      def initialize(configuration: {})
         super
 
-        raise InvalidConfigurationError.new("Configuration section '#{self.class.service_type}' is required but not provided.") unless local_configuration
-
         @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => remote_configuration.dig(:base_url, :value),
-          :api_token => local_configuration[:api_token]
+          :base_url => configuration.dig(:base_url, :value),
+          :api_token => configuration.dig(:api_token, :value)
         )
       end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -41,16 +41,15 @@ module Connectors
         }
       end
 
-      def initialize(local_configuration: {}, remote_configuration: {})
+      def initialize(configuration: {})
         super
 
-        @host = remote_configuration.dig(:host, :value)
-        @database = remote_configuration.dig(:database, :value)
-        @collection = remote_configuration.dig(:collection, :value)
-        @user = remote_configuration.dig(:user, :value)
-        @password = remote_configuration.dig(:password, :value)
-
-        @direct_connection = local_configuration.present? && !!local_configuration[:direct_connection]
+        @host = configuration.dig(:host, :value)
+        @database = configuration.dig(:database, :value)
+        @collection = configuration.dig(:collection, :value)
+        @user = configuration.dig(:user, :value)
+        @password = configuration.dig(:password, :value)
+        @direct_connection = false
       end
 
       def yield_documents

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -24,19 +24,22 @@ module Connectors
       def self.configurable_fields
         {
            :host => {
-             :label => 'MongoDB Server Hostname'
+             :label => 'Server Hostname'
            },
            :user => {
-             :label => 'MongoDB User'
+             :label => 'Username'
            },
            :password => {
-             :label => 'MongoDB Passwd'
+             :label => 'Password'
            },
            :database => {
-             :label => 'MongoDB Database'
+             :label => 'Database'
            },
            :collection => {
-             :label => 'MongoDB Collection'
+             :label => 'Collection'
+           },
+           :direct_connection => {
+             :label => 'Direct connection? (true/false)'
            }
         }
       end
@@ -49,7 +52,7 @@ module Connectors
         @collection = configuration.dig(:collection, :value)
         @user = configuration.dig(:user, :value)
         @password = configuration.dig(:password, :value)
-        @direct_connection = false
+        @direct_connection = configuration.dig(:direct_connection, :value)
       end
 
       def yield_documents
@@ -71,6 +74,8 @@ module Connectors
       end
 
       def with_client
+        raise "Invalid value for 'Direct connection' : #{@direct_connection}." unless %w[true false].include?(@direct_connection.to_s.strip.downcase)
+
         client = if @user.present? || @password.present?
                    Mongo::Client.new(
                      @host,

--- a/lib/connectors/registry.rb
+++ b/lib/connectors/registry.rb
@@ -24,14 +24,10 @@ module Connectors
       @connectors[name]
     end
 
-    def connector(name, remote_configuration)
+    def connector(name, configuration)
       klass = connector_class(name)
       if klass.present?
-        local_configuration = App::Config[name]
-        return klass.new(
-          local_configuration: local_configuration,
-          remote_configuration: remote_configuration
-        )
+        return klass.new(configuration: configuration)
       end
       raise "Connector #{name} is not yet registered. You need to register it before use"
     end

--- a/lib/utility/errors.rb
+++ b/lib/utility/errors.rb
@@ -119,8 +119,8 @@ module Utility
   end
 
   class HealthCheckFailedError < StandardError
-    def initialize
-      super('Health check failed for 3rd-party service.')
+    def initialize(msg = nil)
+      super("Health check failed for 3rd-party service: #{msg}")
     end
   end
 

--- a/spec/connectors/example/connector_spec.rb
+++ b/spec/connectors/example/connector_spec.rb
@@ -4,9 +4,8 @@ require 'connectors/example/connector'
 require 'spec_helper'
 
 describe Connectors::Example::Connector do
-  subject { described_class.new(local_configuration: local_configuration, remote_configuration: remote_configuration) }
-  let(:local_configuration) { {} }
-  let(:remote_configuration) do
+  subject { described_class.new(configuration: configuration) }
+  let(:configuration) do
     {
        :foo => {
          :label => 'Foo',

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -7,20 +7,15 @@ require 'spec_helper'
 describe Connectors::GitLab::Connector do
   let(:user_json) { connectors_fixture_raw('gitlab/user.json') }
   let(:base_url) { Connectors::GitLab::DEFAULT_BASE_URL }
-  let(:app_config) do
+  let(:config) do
     {
-      :elasticsearch => { :api_key => 'hello-world', :hosts => 'localhost:9200' },
-      :gitlab => { :api_token => 'some_token' }
-    }
-  end
-  let(:remote_config) do
-    {
-      :base_url => { :value => base_url }
+      :base_url => { :value => base_url },
+      :api_key => { :value => 'some_token' }
     }
   end
 
   subject do
-    Connectors::GitLab::Connector.new(local_configuration: app_config, remote_configuration: remote_config)
+    Connectors::GitLab::Connector.new(configuration: config)
   end
 
   it_behaves_like 'a connector'

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -9,15 +9,15 @@ describe Connectors::MongoDB::Connector do
   let(:configuration) do
     {
        :host => {
-         :label => 'MongoDB Server Hostname',
+         :label => 'Server Hostname',
          :value => mongodb_host
        },
        :database => {
-         :label => 'MongoDB Database',
+         :label => 'Database',
          :value => mongodb_database
        },
        :collection => {
-         :label => 'MongoDB Collection',
+         :label => 'Collection',
          :value => mongodb_collection
        },
        :user => {
@@ -27,6 +27,10 @@ describe Connectors::MongoDB::Connector do
        :password => {
          :label => 'Password',
          :value => mongodb_password
+       },
+       :direct_connection => {
+         :label => 'Direct connection? (true/false)',
+         :value => direct_connection
        }
     }
   end
@@ -36,6 +40,7 @@ describe Connectors::MongoDB::Connector do
   let(:mongodb_collection) { 'some-collection' }
   let(:mongodb_username) { nil }
   let(:mongodb_password) { nil }
+  let(:direct_connection) { 'false' }
 
   let(:mongo_client) { double }
 
@@ -84,6 +89,26 @@ describe Connectors::MongoDB::Connector do
     end
   end
 
+  shared_examples_for 'validates direct_connection' do
+    %w[true false].each do |value|
+      context "when direct_connection is #{value}" do
+        let(:direct_connection) { value }
+
+        it 'does not throw error' do
+          expect { do_test }.to_not raise_error
+        end
+      end
+    end
+
+    context 'when direct_connection is not a boolean' do
+      let(:direct_connection) { 'foobar' }
+
+      it 'throws error' do
+        expect { do_test }.to raise_error
+      end
+    end
+  end
+
   context '#is_healthy?' do
     it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
@@ -100,6 +125,9 @@ describe Connectors::MongoDB::Connector do
   context '#yield_documents' do
     it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
+      let(:do_test) { subject.yield_documents { |doc|; } }
+    end
+    it_behaves_like 'validates direct_connection' do
       let(:do_test) { subject.yield_documents { |doc|; } }
     end
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -5,9 +5,8 @@ require 'hashie/mash'
 require 'spec_helper'
 
 describe Connectors::MongoDB::Connector do
-  subject { described_class.new(local_configuration: local_configuration, remote_configuration: remote_configuration) }
-  let(:local_configuration) { {} }
-  let(:remote_configuration) do
+  subject { described_class.new(configuration: configuration) }
+  let(:configuration) do
     {
        :host => {
          :label => 'MongoDB Server Hostname',


### PR DESCRIPTION
With the decision made to store credentials in clear text in 8.5, the local configuration is no longer needed.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally