### PR TITLE
Replace body_content by body

### DIFF
--- a/lib/utility/elasticsearch/index/mappings.rb
+++ b/lib/utility/elasticsearch/index/mappings.rb
@@ -60,7 +60,7 @@ module Utility
 
         CRAWLER_FIELD_MAPPINGS = {
           additional_urls: KEYWORD_FIELD_MAPPING,
-          body_content: TEXT_FIELD_MAPPING,
+          body: TEXT_FIELD_MAPPING,
           domains: KEYWORD_FIELD_MAPPING,
           headings: TEXT_FIELD_MAPPING,
           last_crawled_at: DATE_FIELD_MAPPING,

--- a/spec/utility/elasticsearch/mappings_spec.rb
+++ b/spec/utility/elasticsearch/mappings_spec.rb
@@ -36,7 +36,7 @@ describe Utility::Elasticsearch::Index::Mappings do
             properties: {
               id: Hash,
               additional_urls: Hash,
-              body_content: Hash,
+              body: Hash,
               domains: Hash,
               headings: Hash,
               last_crawled_at: Hash,


### PR DESCRIPTION
This PR will change `body_content` field to `body` to use in crawler indices mappings

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests
* https://github.com/elastic/ent-search/pull/6851