### PR TITLE
Only register MongoDB as native connector

### DIFF
--- a/lib/connectors/registry.rb
+++ b/lib/connectors/registry.rb
@@ -39,14 +39,6 @@ module Connectors
 
   REGISTRY = Factory.new
 
-  require_relative './example/connector'
-  REGISTRY.register(Connectors::Example::Connector.service_type, Connectors::Example::Connector)
-
-  # loading plugins (might replace this with a directory scan and conventions on names)
-  require_relative './gitlab/connector'
-
-  REGISTRY.register(Connectors::GitLab::Connector.service_type, Connectors::GitLab::Connector)
-
   require_relative 'mongodb/connector'
   REGISTRY.register(Connectors::MongoDB::Connector.service_type, Connectors::MongoDB::Connector)
 end


### PR DESCRIPTION
Only `MongoDB` will be registered as native connector in 8.5

There's another PR https://github.com/elastic/connectors-ruby/pull/323, which tries to register connectors in YAML, but there are different opinions from @artem-shelkovnikov and I don't want to push it so close to FF. This PR should be sufficient for 8.5

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally