### PR TITLE
run ml inference by default

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -17,7 +17,7 @@ module Core
     DEFAULT_REQUEST_PIPELINE = 'ent-search-generic-ingestion'
     DEFAULT_EXTRACT_BINARY_CONTENT = true
     DEFAULT_REDUCE_WHITESPACE = true
-    DEFAULT_RUN_ML_INFERENCE = false
+    DEFAULT_RUN_ML_INFERENCE = true
 
     DEFAULT_PAGE_SIZE = 100
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2811

default `run_ml_inference` to `true`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally


## Related Pull Requests

- https://github.com/elastic/connectors-python/pull/61
- https://github.com/elastic/kibana/pull/141161
- https://github.com/elastic/ent-search/pull/6852