### PR TITLE
Revert "Use dot notation for App::Config (#319)"

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -2,14 +2,14 @@ require_relative 'lib/app/config'
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_utility'
-  s.version     = App::Config.version
+  s.version     = App::Config[:version]
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing shared Connector Services libraries'
   s.description = ''
   s.authors     = ['Elastic']
   s.metadata    = {
-    "revision" => App::Config.revision,
-    "repository" => App::Config.repository
+    "revision" => App::Config[:revision],
+    "repository" => App::Config[:repository]
   }
   s.email       = 'ent-search-dev@elastic.co'
   s.files       = %w[

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -122,11 +122,11 @@ module App
   Config = ::Settings.tap do |config|
     if ent_search_config = ent_search_es_config
       Utility::Logger.error('Overriding elasticsearch config with ent-search config')
-      original_es_config = config.elasticsearch.to_h
+      original_es_config = config[:elasticsearch].to_h
       original_es_config.delete(:cloud_id)
       original_es_config.delete(:hosts)
       original_es_config.delete(:api_key)
-      config.elasticsearch = original_es_config.merge(ent_search_config)
+      config[:elasticsearch] = original_es_config.merge(ent_search_config)
     end
   end
 end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -34,11 +34,11 @@ module App
     ]
 
     def connector_id
-      App::Config.connector_id
+      App::Config[:connector_id]
     end
 
     def update_connector_id(connector_id)
-      App::Config.connector_id = connector_id
+      App::Config[:connector_id] = connector_id
     end
 
     def start_sync_now
@@ -49,7 +49,7 @@ module App
 
       config_settings = Core::ConnectorSettings.fetch_by_id(connector_id)
       Core::ElasticConnectorActions.ensure_content_index_exists(config_settings[:index_name])
-      Core::SyncJobRunner.new(config_settings).execute
+      Core::SyncJobRunner.new(config_settings, App::Config[:service_type]).execute
     end
 
     def show_status
@@ -121,7 +121,7 @@ module App
     end
 
     def create_connector(index_name, use_analysis_icu = false, language_code = :en)
-      id = Core::ElasticConnectorActions.create_connector(index_name, App::Config.service_type)
+      id = Core::ElasticConnectorActions.create_connector(index_name, App::Config[:service_type])
       Core::ElasticConnectorActions.ensure_content_index_exists(index_name, use_analysis_icu, language_code)
       puts "Successfully registered connector #{index_name} with ID #{id}"
 
@@ -164,8 +164,8 @@ module App
     end
 
     def current_connector
-      connector_settings = Core::ConnectorSettings.fetch_by_id(App::Config.connector_id)
-      service_type = App::Config.service_type
+      connector_settings = Core::ConnectorSettings.fetch_by_id(App::Config[:connector_id])
+      service_type = App::Config[:service_type]
       if service_type.present?
         return registry.connector(service_type, connector_settings.configuration)
       end

--- a/lib/app/preflight_check.rb
+++ b/lib/app/preflight_check.rb
@@ -113,7 +113,7 @@ module App
       end
 
       def client
-        @client ||= Utility::EsClient.new(App::Config.elasticsearch)
+        @client ||= Utility::EsClient.new(App::Config[:elasticsearch])
       end
 
       def fail_check!(message)

--- a/lib/app/version.rb
+++ b/lib/app/version.rb
@@ -6,5 +6,5 @@
 require 'app/config'
 
 module App
-  VERSION = App::Config.version
+  VERSION = App::Config[:version]
 end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -256,7 +256,7 @@ module Core
       private
 
       def client
-        @client ||= Utility::EsClient.new(App::Config.elasticsearch)
+        @client ||= Utility::EsClient.new(App::Config[:elasticsearch])
       end
 
       def get_latest_index_in_alias(alias_name, indicies)

--- a/lib/core/output_sink/es_sink.rb
+++ b/lib/core/output_sink/es_sink.rb
@@ -16,7 +16,7 @@ module Core::OutputSink
   class EsSink < Core::OutputSink::BaseSink
     def initialize(index_name, request_pipeline, flush_threshold = 50)
       super()
-      @client = Utility::EsClient.new(App::Config.elasticsearch)
+      @client = Utility::EsClient.new(App::Config[:elasticsearch])
       @index_name = index_name
       @request_pipeline = request_pipeline
       @operation_queue = []

--- a/lib/utility/environment.rb
+++ b/lib/utility/environment.rb
@@ -13,10 +13,10 @@ module Utility
     def self.set_execution_environment(config, &block)
       # Set UTC as the timezone
       ENV['TZ'] = 'UTC'
-      Logger.level = config.log_level
-      es_config = config.elasticsearch
+      Logger.level = config[:log_level]
+      es_config = config[:elasticsearch]
       disable_warnings = if es_config.has_key?(:disable_warnings)
-                           es_config.disable_warnings
+                           es_config[:disable_warnings]
                          else
                            true
                          end

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -26,18 +26,18 @@ module Utility
 
     def connection_configs(es_config)
       configs = {}
-      configs[:api_key] = es_config.api_key if es_config.api_key
-      if es_config.cloud_id
-        configs[:cloud_id] = es_config.cloud_id
-      elsif es_config.hosts
-        configs[:hosts] = es_config.hosts
+      configs[:api_key] = es_config[:api_key] if es_config[:api_key]
+      if es_config[:cloud_id]
+        configs[:cloud_id] = es_config[:cloud_id]
+      elsif es_config[:hosts]
+        configs[:hosts] = es_config[:hosts]
       else
         raise 'Either elasticsearch.cloud_id or elasticsearch.hosts should be configured.'
       end
-      configs[:retry_on_failure] = es_config.retry_on_failure || false
-      configs[:request_timeout] = es_config.request_timeout || nil
-      configs[:log] = es_config.log || false
-      configs[:trace] = es_config.trace || false
+      configs[:retry_on_failure] = es_config[:retry_on_failure] || false
+      configs[:request_timeout] = es_config[:request_timeout] || nil
+      configs[:log] = es_config[:log] || false
+      configs[:trace] = es_config[:trace] || false
 
       # if log or trace is activated, we use the application logger
       configs[:logger] = if configs[:log] || configs[:trace]

--- a/lib/utility/logger.rb
+++ b/lib/utility/logger.rb
@@ -23,7 +23,7 @@ module Utility
       end
 
       def logger
-        @logger ||= Settings.ecs_logging ? EcsLogging::Logger.new(STDOUT) : ::Logger.new(STDOUT)
+        @logger ||= Settings[:ecs_logging] ? EcsLogging::Logger.new(STDOUT) : ::Logger.new(STDOUT)
       end
 
       SUPPORTED_LOG_LEVELS.each do |level|

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -4,7 +4,7 @@ require 'utility/environment'
 
 RSpec.describe Utility::EsClient do
   let(:host) { 'http://notreallyaserver' }
-  let(:config_hash) do
+  let(:config) do
     {
       :service_type => 'example',
       :log_level => 'INFO',
@@ -16,9 +16,8 @@ RSpec.describe Utility::EsClient do
       }
     }
   end
-  let(:config) { ::Config::Options.new.merge!(config_hash) }
 
-  let(:subject) { described_class.new(config.elasticsearch) }
+  let(:subject) { described_class.new(config[:elasticsearch]) }
 
   before(:each) do
     stub_request(:get, "#{host}:9200/")


### PR DESCRIPTION
This reverts commit 3fab4706b8f85c53ead7069729312b32fd9a8948.

Those changes are incompatible for ent-search 8.5

#### Pre-Review Checklist
- [x] Tested the changes locally