### PR TITLE
Cast direct_connection to bool, defaulting empty to false this way

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -52,7 +52,7 @@ module Connectors
         @collection = configuration.dig(:collection, :value)
         @user = configuration.dig(:user, :value)
         @password = configuration.dig(:password, :value)
-        @direct_connection = configuration.dig(:direct_connection, :value)
+        @direct_connection = !!configuration.dig(:direct_connection, :value)
       end
 
       def yield_documents


### PR DESCRIPTION
Adding logic to cast `direct_connection` option for MongoDB to boolean.

It's done to unblock testing (we haven't exposed options in UI for Native connectors). 

It also might be a good change to keep in future!