### PR TITLE
[8.5] run ml inference by default (#326)

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -17,7 +17,7 @@ module Core
     DEFAULT_REQUEST_PIPELINE = 'ent-search-generic-ingestion'
     DEFAULT_EXTRACT_BINARY_CONTENT = true
     DEFAULT_REDUCE_WHITESPACE = true
-    DEFAULT_RUN_ML_INFERENCE = false
+    DEFAULT_RUN_ML_INFERENCE = true
 
     DEFAULT_PAGE_SIZE = 100
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [run ml inference by default (#326)](https://github.com/elastic/connectors-ruby/pull/326)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)