### PR TITLE
Update Pull Request Template to include a manual gem testing step

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ items that may help during the review.-->
 #### Pre-Review Checklist
 - [ ] Covered the changes with automated tests
 - [ ] Tested the changes locally
-- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and tested that Enterprise Search works well with new gem versions
+- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions.
 
 #### Changes Requiring Extra Attention
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ items that may help during the review.-->
 #### Pre-Review Checklist
 - [ ] Covered the changes with automated tests
 - [ ] Tested the changes locally
-- [ ] (Elastic Only) Built gems and tested that Enterprise Search works well with new gem versions
+- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and tested that Enterprise Search works well with new gem versions
 
 #### Changes Requiring Extra Attention
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ items that may help during the review.-->
 #### Pre-Review Checklist
 - [ ] Covered the changes with automated tests
 - [ ] Tested the changes locally
+- [ ] (Elastic Only) Built gems and tested that Enterprise Search works well with new gem versions
 
 #### Changes Requiring Extra Attention
 


### PR DESCRIPTION
Based on recent issues with introducing breaking changes to `ent-search`, I'm proposing to return the checklist item to check that gems are tested against Enterprise Search