### PR TITLE
Fix parsing on boolean values in "Direct Connect" MongoDB field

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -80,7 +80,7 @@ module Connectors
                    Mongo::Client.new(
                      @host,
                      database: @database,
-                     direct_connection: @direct_connection,
+                     direct_connection: to_b(@direct_connection),
                      user: @user,
                      password: @password
                    )
@@ -88,7 +88,7 @@ module Connectors
                    Mongo::Client.new(
                      @host,
                      database: @database,
-                     direct_connection: @direct_connection
+                     direct_connection: to_b(@direct_connection)
                    )
                  end
 
@@ -128,6 +128,10 @@ module Connectors
         else
           mongodb_document
         end
+      end
+
+      def to_b(value)
+        value == true || value =~ (/(true|t|yes|y|1)$/i)
       end
     end
   end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -80,7 +80,7 @@ module Connectors
                    Mongo::Client.new(
                      @host,
                      database: @database,
-                     direct_connection: to_b(@direct_connection),
+                     direct_connection: to_boolean(@direct_connection),
                      user: @user,
                      password: @password
                    )
@@ -88,7 +88,7 @@ module Connectors
                    Mongo::Client.new(
                      @host,
                      database: @database,
-                     direct_connection: to_b(@direct_connection)
+                     direct_connection: to_boolean(@direct_connection)
                    )
                  end
 
@@ -130,7 +130,7 @@ module Connectors
         end
       end
 
-      def to_b(value)
+      def to_boolean(value)
         value == true || value =~ (/(true|t|yes|y|1)$/i)
       end
     end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2839

Adding a kind of coersion to massage the string property into boolean.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests

* [Kibana PR](https://github.com/elastic/kibana/pull/141457)