### PR TITLE
[8.5] Add more ECS fields (#321)

### DIFF
--- a/lib/utility/exception_tracking.rb
+++ b/lib/utility/exception_tracking.rb
@@ -21,13 +21,13 @@ module Utility
       end
 
       def capture_exception(exception, context = {})
-        Utility::Logger.error(generate_stack_trace(exception))
+        Utility::Logger.log_stacktrace(generate_stack_trace(exception))
         Utility::Logger.error("Context: #{context.inspect}") if context
       end
 
       def log_exception(exception, message = nil)
         Utility::Logger.error(message) if message
-        Utility::Logger.error(generate_stack_trace(exception))
+        Utility::Logger.log_stacktrace(generate_stack_trace(exception))
       end
 
       def augment_exception(exception)

--- a/spec/utility/logger_spec.rb
+++ b/spec/utility/logger_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Utility::Logger do
   let(:message_with_breaks) { 'This is a message with line breaks.\nThis is a message with line breaks.' }
   let(:message_with_tabs) { 'This is a message  with tabs.\t\t\tThis is a message  with tabs.' }
   let(:message_with_many_spaces) { '  This is a    message with a lot of spaces.  ' }
-  let(:global_settings) { double(:ecs_logging => false) }
+  let(:logger) { ::Logger.new(STDOUT) }
 
   before do
     stub_const('Utility::Logger::MAX_SHORT_MESSAGE_LENGTH', 100)
-    stub_const('Settings', global_settings)
+    allow(described_class).to receive(:logger).and_return(logger)
   end
 
   it 'can give the connectors logger' do
@@ -43,5 +43,30 @@ RSpec.describe Utility::Logger do
     expect(msg.match(/\s{2,}/)).to be_falsey
     expect(msg.match(/^\s/)).to be_falsey
     expect(msg.match(/\s$/)).to be_falsey
+  end
+
+  context 'with ecs logging' do
+    let(:logger) { EcsLogging::Logger.new(STDOUT) }
+
+    it 'outputs ecs fields' do
+      expect { described_class.info(message) }.to output(/@timestamp/).to_stdout_from_any_process
+      expect { described_class.info(message) }.to output(/ecs\.version/).to_stdout_from_any_process
+    end
+  end
+
+  describe '.log_stacktrace' do
+    let(:stacktrace) { 'stacktrace' }
+    it 'outputs stacktrace' do
+      expect { described_class.log_stacktrace(stacktrace) }.to output(/#{stacktrace}/).to_stdout_from_any_process
+    end
+
+    context 'with ecs logging' do
+      let(:logger) { EcsLogging::Logger.new(STDOUT) }
+
+      it 'outputs error.stack_trace' do
+        expect { described_class.log_stacktrace(stacktrace) }.to output(/"error":\{"stack_trace":/).to_stdout_from_any_process
+        expect { described_class.log_stacktrace(stacktrace) }.to output(/@timestamp/).to_stdout_from_any_process
+      end
+    end
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Add more ECS fields (#321)](https://github.com/elastic/connectors-ruby/pull/321)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)