### PR TITLE
[8.5] Move service type check to xxx_registered? methods (#327)

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -38,11 +38,10 @@ Gem::Specification.new do |s|
                     lib/core/connector_settings.rb
                   ]
   s.license     = 'Elastic-2.0'
-  s.add_dependency 'ecs-logging', '~> 1.0'
   s.add_dependency 'activesupport', '~>5.2.6'
-  s.add_dependency 'mime-types', '= 3.1'
-  s.add_dependency 'tzinfo-data'
-  s.add_dependency 'tzinfo'
-  s.add_dependency 'nokogiri', '>= 1.13.6'
+  s.add_dependency 'ecs-logging', '~> 1.0.0'
   s.add_dependency 'fugit', '~> 1.5.3'
+  s.add_dependency 'mime-types', '= 3.1'
+  s.add_dependency 'tzinfo'
+  s.add_dependency 'tzinfo-data'
 end

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -82,20 +82,10 @@ module App
       end
 
       def start_sync_task(connector_settings)
-        # connector-level checks
-        unless Connectors::REGISTRY.registered?(connector_settings.service_type)
-          Utility::Logger.info("The service type (#{connector_settings.service_type}) is not supported. Skipping...")
-          return
-        end
-        unless connector_settings.valid_index_name?
-          Utility::Logger.info("The index name of #{connector_settings.formatted} is invalid. Skipping...")
-          return
-        end
-        Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
-
         start_heartbeat_task(connector_settings)
         pool.post do
           Utility::Logger.info("Starting a sync job for #{connector_settings.formatted}...")
+          Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
           job_runner = Core::SyncJobRunner.new(connector_settings)
           job_runner.execute
         rescue StandardError => e

--- a/lib/connectors/crawler/scheduler.rb
+++ b/lib/connectors/crawler/scheduler.rb
@@ -21,6 +21,12 @@ module Connectors
         Utility::ExceptionTracking.log_exception(e, 'Could not retrieve Crawler connectors due to unexpected error.')
         []
       end
+
+      private
+
+      def connector_registered?(service_type)
+        service_type == 'elastic-crawler'
+      end
     end
   end
 end

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -59,29 +59,36 @@ module Core
     private
 
     def sync_triggered?(connector_settings)
+      return false unless connector_registered?(connector_settings.service_type)
+
+      unless connector_settings.valid_index_name?
+        Utility::Logger.info("The index name of #{connector_settings.formatted} is invalid.")
+        return false
+      end
+
       unless connector_settings.connector_status_allows_sync?
-        Utility::Logger.info("Connector #{connector_settings.id} is in status \"#{connector_settings.connector_status}\" and won't sync yet. Connector needs to be in one of the following statuses: #{Connectors::ConnectorStatus::STATUSES_ALLOWING_SYNC} to run.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} is in status \"#{connector_settings.connector_status}\" and won't sync yet. Connector needs to be in one of the following statuses: #{Connectors::ConnectorStatus::STATUSES_ALLOWING_SYNC} to run.")
 
         return false
       end
 
       # Sync when sync_now flag is true for the connector
       if connector_settings[:sync_now] == true
-        Utility::Logger.info("Connector #{connector_settings.id} is manually triggered to sync now.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
         return true
       end
 
       # Don't sync if sync is explicitly disabled
       scheduling_settings = connector_settings.scheduling_settings
       unless scheduling_settings.present? && scheduling_settings[:enabled] == true
-        Utility::Logger.info("Connector #{connector_settings.id} scheduling is disabled.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} scheduling is disabled.")
         return false
       end
 
       # We want to sync when sync never actually happened
       last_synced = connector_settings[:last_synced]
       if last_synced.nil? || last_synced.empty?
-        Utility::Logger.info("Connector #{connector_settings.id} has never synced yet, running initial sync.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
         return true
       end
 
@@ -89,7 +96,7 @@ module Core
 
       # Don't sync if there is no actual scheduling interval
       if current_schedule.nil? || current_schedule.empty?
-        Utility::Logger.warn("No sync schedule configured for connector #{connector_settings.id}.")
+        Utility::Logger.warn("No sync schedule configured for #{connector_settings.formatted}.")
         return false
       end
 
@@ -103,7 +110,7 @@ module Core
 
       # Don't sync if the scheduling interval is non-parsable
       unless cron_parser
-        Utility::Logger.error("Unable to parse sync schedule for connector #{connector_settings.id}: expression #{current_schedule} is not a valid Quartz Cron definition.")
+        Utility::Logger.error("Unable to parse sync schedule for #{connector_settings.formatted}: expression #{current_schedule} is not a valid Quartz Cron definition.")
         return false
       end
 
@@ -111,7 +118,7 @@ module Core
 
       # Sync if next trigger for the connector is in past
       if next_trigger_time < Time.now
-        Utility::Logger.info("Connector #{connector_settings.id} sync is triggered by cron schedule #{current_schedule}.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} sync is triggered by cron schedule #{current_schedule}.")
         return true
       end
 
@@ -119,6 +126,8 @@ module Core
     end
 
     def heartbeat_triggered?(connector_settings)
+      return false unless connector_registered?(connector_settings.service_type)
+
       last_seen = connector_settings[:last_seen]
       return true if last_seen.nil? || last_seen.empty?
       last_seen = begin
@@ -132,7 +141,18 @@ module Core
     end
 
     def configuration_triggered?(connector_settings)
+      return false unless connector_registered?(connector_settings.service_type)
+
       connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
+    end
+
+    def connector_registered?(service_type)
+      if Connectors::REGISTRY.registered?(service_type)
+        true
+      else
+        Utility::Logger.info("The service type (#{service_type}) is not supported.")
+        false
+      end
     end
   end
 end

--- a/spec/app/dispatcher_spec.rb
+++ b/spec/app/dispatcher_spec.rb
@@ -86,13 +86,10 @@ describe App::Dispatcher do
 
       context 'with sync task' do
         let(:task) { :sync }
-        let(:valid_index_name) { true }
 
         before(:each) do
           allow(connector_settings).to receive(:service_type).and_return('')
           allow(connector_settings).to receive(:index_name).and_return('')
-          allow(connector_settings).to receive(:valid_index_name?).and_return(valid_index_name)
-          allow(Connectors::REGISTRY).to receive(:registered?).and_return(true)
         end
 
         shared_examples_for 'sync' do
@@ -112,20 +109,6 @@ describe App::Dispatcher do
         end
 
         it_behaves_like 'sync'
-
-        context 'when service type is not supported' do
-          before(:each) do
-            allow(Connectors::REGISTRY).to receive(:registered?).and_return(false)
-          end
-
-          it_behaves_like 'no sync'
-        end
-
-        context 'when index name is invalid' do
-          let(:valid_index_name) { false }
-
-          it_behaves_like 'no sync'
-        end
 
         context 'when sync throws an error' do
           before(:each) do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Move service type check to xxx_registered? methods (#327)](https://github.com/elastic/connectors-ruby/pull/327)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)