### PR TITLE
Change condition for configuration job to also run if service_type is not defined

### DIFF
--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -141,8 +141,6 @@ module Core
     end
 
     def configuration_triggered?(connector_settings)
-      return false unless connector_registered?(connector_settings.service_type)
-
       connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
     end
 


### PR DESCRIPTION
Fixes a regression problem with on-prem connectors being unable to properly work.

Problem:

configuration_triggered? considered connectors with `service_type=null` invalid, while they are indeed valid in case of on-prem connectors.

This change provides a hacky-ish fix to fix the problem - native connectors won't be there with null service_type, and if they will be they will do nothing.

In future though, it should be fixed in a more robust manner.

## Checklists


#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions.