### PR TITLE
Change log level to reduce noise in the logs

### DIFF
--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -45,7 +45,7 @@ module Core
         Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
       ensure
         if @poll_interval > 0 && !@is_shutting_down
-          Utility::Logger.info("Sleeping for #{@poll_interval} seconds in #{self.class}.")
+          Utility::Logger.debug("Sleeping for #{@poll_interval} seconds in #{self.class}.")
           sleep(@poll_interval)
         end
       end
@@ -62,7 +62,7 @@ module Core
       return false unless connector_registered?(connector_settings.service_type)
 
       unless connector_settings.valid_index_name?
-        Utility::Logger.info("The index name of #{connector_settings.formatted} is invalid.")
+        Utility::Logger.warn("The index name of #{connector_settings.formatted} is invalid.")
         return false
       end
 
@@ -74,7 +74,7 @@ module Core
 
       # Sync when sync_now flag is true for the connector
       if connector_settings[:sync_now] == true
-        Utility::Logger.info("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
+        Utility::Logger.debug("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
         return true
       end
 

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -81,7 +81,7 @@ module Core
       # Don't sync if sync is explicitly disabled
       scheduling_settings = connector_settings.scheduling_settings
       unless scheduling_settings.present? && scheduling_settings[:enabled] == true
-        Utility::Logger.info("#{connector_settings.formatted.capitalize} scheduling is disabled.")
+        Utility::Logger.debug("#{connector_settings.formatted.capitalize} scheduling is disabled.")
         return false
       end
 

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -74,7 +74,7 @@ module Core
 
       # Sync when sync_now flag is true for the connector
       if connector_settings[:sync_now] == true
-        Utility::Logger.debug("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
         return true
       end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2874

It's too noisy in the crawler logs (most probably in connectors service as well) so PR will change log level for a few calls

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions.