### PR TITLE
Fix last sync status FAILED to follow the protocol

### DIFF
--- a/lib/connectors/sync_status.rb
+++ b/lib/connectors/sync_status.rb
@@ -10,12 +10,12 @@ module Connectors
   class SyncStatus
     COMPLETED = 'completed'
     IN_PROGRESS = 'in_progress'
-    FAILED = 'failed'
+    ERROR = 'error'
 
     STATUSES = [
       COMPLETED,
       IN_PROGRESS,
-      FAILED
+      ERROR
     ]
   end
 end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -100,7 +100,7 @@ module Core
       end
 
       def complete_sync(connector_id, job_id, status)
-        sync_status = status[:error] ? Connectors::SyncStatus::FAILED : Connectors::SyncStatus::COMPLETED
+        sync_status = status[:error] ? Connectors::SyncStatus::ERROR : Connectors::SyncStatus::COMPLETED
 
         update_connector_fields(connector_id,
                                 :last_sync_status => sync_status,

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -418,7 +418,7 @@ describe Core::ElasticConnectorActions do
               :last_synced,
               :last_indexed_document_count,
               :last_deleted_document_count,
-              :last_sync_status => Connectors::SyncStatus::FAILED,
+              :last_sync_status => Connectors::SyncStatus::ERROR,
               :last_sync_error => status[:error],
               :error => status[:error]
             )


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2974

Fixed the problem with sync displayed incorrectly in the interface if an error happened. The error happened because the job sync status enum had incorrect value representing the sync error that does not follow the protocol.

## Checklists
#### Pre-Review Checklist
- [x] Tested the changes locally
- [ ] (Elastic Only) Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions.
