### PR TITLE
use strings everywhere

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -129,11 +129,10 @@ module Connectors
           mongodb_document.map { |v| serialize(v) }
         when Hash
           mongodb_document.map do |key, value|
-            remapped_key = key.to_sym == :_id ? :id : key.to_sym
-
+            key = 'id' if key == '_id'
             remapped_value = serialize(value)
-            [remapped_key, remapped_value]
-          end.to_h.with_indifferent_access
+            [key, remapped_value]
+          end.to_h
         else
           mongodb_document
         end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -6,7 +6,6 @@
 
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/indifferent_access'
 require 'connectors/base/connector'
 require 'mongo'
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -57,9 +57,7 @@ module Connectors
       def yield_documents
         with_client do |client|
           client[@collection].find.each do |document|
-            doc = document.with_indifferent_access
-
-            yield serialize(doc)
+            yield serialize(document)
           end
         end
       end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -61,7 +61,7 @@ module Core
         @connector_instance.yield_documents do |document|
           document = add_ingest_metadata(document)
           @sink.ingest(document)
-          incoming_ids << document[:id]
+          incoming_ids << document['id']
           @status[:indexed_document_count] += 1
         end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3010


Remove symbols and `with_indifferent_access` and stop using symbols to improve memory usage/recycling + performance of the connector. Usage of `with_indifferent_access` affects performance heavily + produces unnecessary memory overhead while only adding minor utility improvements.

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
