### PR TITLE
Make better use of memory for Mongo connector when iterating over documents

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -12,8 +12,6 @@ require 'mongo'
 module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
-      PAGE_SIZE = 100
-
       def self.service_type
         'mongodb'
       end
@@ -41,6 +39,10 @@ module Connectors
            },
            :direct_connection => {
              :label => 'Direct connection? (true/false)'
+           },
+           :batch_size => {
+             :label => 'Batch Size',
+             :value => 100
            }
         }
       end
@@ -54,6 +56,7 @@ module Connectors
         @user = configuration.dig(:user, :value)
         @password = configuration.dig(:password, :value)
         @direct_connection = configuration.dig(:direct_connection, :value)
+        @batch_size = configuration.dig(:batch_size, :value).to_i.freeze
       end
 
       def yield_documents
@@ -62,19 +65,18 @@ module Connectors
           # This gives us more control on the usage of the memory (we can adjust PAGE_SIZE constant for that to decrease max memory consumption).
           # It's done due to the fact that usage of .find.each leads to memory leaks or overuse of memory - the whole result set seems to stay in memory
           # during the sync. Sometimes (not 100% sure) it even leads to a real leak, when the memory for these objects is never recycled.
-          cursor = client[@collection].find
           skip = 0
 
           loop do
             found_count = 0
-            view = cursor.skip(skip).limit(PAGE_SIZE)
+            view = client[@collection].find.skip(skip).limit(100)
             view.each do |document|
               yield serialize(document)
               found_count += 1
             end
 
             break if found_count == 0
-            skip += PAGE_SIZE
+            skip += @batch_size
           end
         end
       end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -12,6 +12,8 @@ require 'mongo'
 module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
+      PAGE_SIZE = 100
+
       def self.service_type
         'mongodb'
       end
@@ -39,10 +41,6 @@ module Connectors
            },
            :direct_connection => {
              :label => 'Direct connection? (true/false)'
-           },
-           :batch_size => {
-             :label => 'Batch Size',
-             :value => 100
            }
         }
       end
@@ -56,7 +54,6 @@ module Connectors
         @user = configuration.dig(:user, :value)
         @password = configuration.dig(:password, :value)
         @direct_connection = configuration.dig(:direct_connection, :value)
-        @batch_size = configuration.dig(:batch_size, :value).to_i.freeze
       end
 
       def yield_documents
@@ -65,18 +62,19 @@ module Connectors
           # This gives us more control on the usage of the memory (we can adjust PAGE_SIZE constant for that to decrease max memory consumption).
           # It's done due to the fact that usage of .find.each leads to memory leaks or overuse of memory - the whole result set seems to stay in memory
           # during the sync. Sometimes (not 100% sure) it even leads to a real leak, when the memory for these objects is never recycled.
+          cursor = client[@collection].find
           skip = 0
 
           loop do
             found_count = 0
-            view = client[@collection].find.skip(skip).limit(100)
+            view = cursor.skip(skip).limit(PAGE_SIZE)
             view.each do |document|
               yield serialize(document)
               found_count += 1
             end
 
             break if found_count == 0
-            skip += @batch_size
+            skip += PAGE_SIZE
           end
         end
       end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -12,6 +12,8 @@ require 'mongo'
 module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
+      PAGE_SIZE = 100
+
       def self.service_type
         'mongodb'
       end
@@ -56,8 +58,24 @@ module Connectors
 
       def yield_documents
         with_client do |client|
-          client[@collection].find.each do |document|
-            yield serialize(document)
+          # We do paging using skip().limit() here to make Ruby recycle the memory for each page pulled from the server after it's not needed any more.
+          # This gives us more control on the usage of the memory (we can adjust PAGE_SIZE constant for that to decrease max memory consumption).
+          # It's done due to the fact that usage of .find.each leads to memory leaks or overuse of memory - the whole result set seems to stay in memory
+          # during the sync. Sometimes (not 100% sure) it even leads to a real leak, when the memory for these objects is never recycled.
+          cursor = client[@collection].find
+          skip = 0
+
+          while true
+            found_count = 0
+            view = cursor.skip(skip).limit(PAGE_SIZE)
+            view.each do |document|
+              yield serialize(document)
+              found_count += 1
+            end
+
+            break if found_count == 0
+
+            skip += PAGE_SIZE
           end
         end
       end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -65,7 +65,7 @@ module Connectors
           cursor = client[@collection].find
           skip = 0
 
-          while true
+          loop do
             found_count = 0
             view = cursor.skip(skip).limit(PAGE_SIZE)
             view.each do |document|
@@ -74,7 +74,6 @@ module Connectors
             end
 
             break if found_count == 0
-
             skip += PAGE_SIZE
           end
         end

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -44,11 +44,12 @@ describe Connectors::MongoDB::Connector do
 
   let(:mongo_client) { double }
 
-  let(:actual_collection) { double }
   let(:actual_collection_name) { 'sample-collection' }
+  let(:actual_collection) { double }
   let(:actual_collection_names) { [actual_collection_name] }
   let(:actual_collection_data) { [] }
-
+  let(:mongo_collection_cursor) { double }
+  let(:mongo_collection_data) { [] }
   let(:actual_database) { double }
   let(:actual_database_names) { ['sample-database'] }
 
@@ -63,7 +64,10 @@ describe Connectors::MongoDB::Connector do
     allow(mongo_client).to receive(:close)
 
     allow(actual_database).to receive(:collection_names).and_return(actual_collection_names)
-    allow(actual_collection).to receive(:find).and_return(actual_collection_data)
+    allow(actual_collection).to receive(:find).and_return(mongo_collection_cursor)
+
+    allow(mongo_collection_cursor).to receive(:skip).and_return(mongo_collection_cursor)
+    allow(mongo_collection_cursor).to receive(:limit).and_return(mongo_collection_data)
   end
 
   it_behaves_like 'a connector'
@@ -145,25 +149,64 @@ describe Connectors::MongoDB::Connector do
     end
 
     context 'when collection is found' do
-      let(:actual_collection_data) do
-        [
-          { '_id' => '1', 'some' => { 'nested' => 'data' } },
-          { '_id' => '2', 'more' => { 'nested' => 'data' } },
-          { '_id' => '167', 'nothing' => nil },
-          { '_id' => 'last' }
-        ]
-      end
+      context 'when data is distributed in multiple pages' do
+        let(:page_size) { 3 }
 
-      it 'yields each document of the collection remapping ids correctly' do
-        expected_ids = actual_collection_data.map { |d| d['_id'] }.to_a
+        let(:first_page_data) do
+          [
+            { '_id' => '1', 'some' => { 'nested' => 'data' } },
+            { '_id' => '2', 'more' => { 'nested' => 'data' } },
+            { '_id' => '167', 'nothing' => nil }
+          ]
+        end
 
-        yielded_documents = []
+        let(:second_page_data) do
+          [
+            { '_id' => 'last' }
+          ]
+        end
 
-        subject.yield_documents { |doc| yielded_documents << doc }
+        let(:third_page_data) do
+          []
+        end
 
-        expect(yielded_documents.size).to eq(actual_collection_data.size)
-        expected_ids.each do |id|
-          expect(yielded_documents).to include(a_hash_including('id' => id))
+        let(:all_data) { first_page_data + second_page_data + third_page_data }
+
+        let(:second_page_cursor) { double }
+        let(:third_page_cursor) { double }
+
+        before(:each) do
+          stub_const('Connectors::MongoDB::Connector::PAGE_SIZE', page_size)
+          allow(mongo_collection_cursor).to receive(:skip).with(0).and_return(mongo_collection_cursor)
+          allow(mongo_collection_cursor).to receive(:limit).and_return(first_page_data)
+
+          allow(mongo_collection_cursor).to receive(:skip).with(page_size).and_return(second_page_cursor)
+          allow(second_page_cursor).to receive(:limit).and_return(second_page_data)
+
+          allow(mongo_collection_cursor).to receive(:skip).with(page_size * 2).and_return(third_page_cursor)
+          allow(third_page_cursor).to receive(:limit).and_return(third_page_data)
+        end
+
+        it 'fetches each page' do
+          # a bit weird test, but I did not figure out to do a better job ensuring that each page was fetched
+          expect(mongo_collection_cursor).to receive(:limit).once
+          expect(second_page_cursor).to receive(:limit).once
+          expect(third_page_cursor).to receive(:limit).once
+
+          subject.yield_documents { |doc|; }
+        end
+
+        it 'yields each document of the collection remapping ids correctly scrolling through pages' do
+          expected_ids = all_data.map { |d| d['_id'] }.to_a
+
+          yielded_documents = []
+
+          subject.yield_documents { |doc| yielded_documents << doc }
+
+          expect(yielded_documents.size).to eq(all_data.size)
+          expected_ids.each do |id|
+            expect(yielded_documents).to include(a_hash_including('id' => id))
+          end
         end
       end
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3039

This change updates the way the documents from MongoDB collections are gathered and sent to Elasticsearch.

Before the data is ingested like this:

```ruby
client[@collection].find.each do |document|
  doc = document.with_indifferent_access

  yield serialize(doc)
end
```

Problem with this code seems to be that all documents that were collected from MongoDB are kept in memory until the end of `.each` method call. To reduce the memory footprint we switch to explicit manual cursor paging:

```ruby
while true
  found_count = 0
  view = cursor.skip(skip).limit(PAGE_SIZE)
  view.each do |document|
    yield serialize(document)
    found_count += 1
  end

  break if found_count == 0

  skip += PAGE_SIZE
end
```

This way we keep in memory only one page of data and ready to GC the data with each `while` iteration.

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally

## Release Note
Decrease amount of memory used by MongoDB connector during the sync.
