### PR TITLE
Optimize lifecycle of MongoDB client

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -76,31 +76,22 @@ module Connectors
       def with_client
         raise "Invalid value for 'Direct connection' : #{@direct_connection}." unless %w[true false].include?(@direct_connection.to_s.strip.downcase)
 
-        client = if @user.present? || @password.present?
-                   Mongo::Client.new(
-                     @host,
-                     database: @database,
-                     direct_connection: to_boolean(@direct_connection),
-                     user: @user,
-                     password: @password
-                   )
-                 else
-                   Mongo::Client.new(
-                     @host,
-                     database: @database,
-                     direct_connection: to_boolean(@direct_connection)
-                   )
-                 end
+        args = {
+                 database: @database,
+                 direct_connection: to_boolean(@direct_connection)
+               }
 
-        begin
+        if @user.present? || @password.present?
+          args[:user] = @user
+          args[:password] = @password
+        end
+
+        Mongo::Client.new(@host, args) do |client|
           Utility::Logger.debug("Existing Databases #{client.database_names}")
           Utility::Logger.debug('Existing Collections:')
-
           client.collections.each { |coll| Utility::Logger.debug(coll.name) }
 
           yield client
-        ensure
-          client.close
         end
       end
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -48,7 +48,7 @@ describe Connectors::MongoDB::Connector do
   let(:actual_collection_data) { [] }
 
   before(:each) do
-    allow(Mongo::Client).to receive(:new).and_return(mongo_client)
+    allow(Mongo::Client).to receive(:new).and_yield(mongo_client)
 
     allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
     allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
@@ -60,14 +60,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   it_behaves_like 'a connector'
-
-  shared_examples_for 'closes a client in the end' do
-    it '' do
-      expect(mongo_client).to receive(:close)
-
-      subject.is_healthy?
-    end
-  end
 
   shared_examples_for 'handles auth' do
     context 'when username and password are provided' do
@@ -110,7 +102,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   context '#is_healthy?' do
-    it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.is_healthy? }
     end
@@ -123,7 +114,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   context '#yield_documents' do
-    it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.yield_documents { |doc|; } }
     end


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3039

This change attempts to use MongoDB client in such a way that the application does not leak threads any more. Somehow usage of `client.new` and `client.close` still left connections hanging after all the classes needed for sync are destroyed.

Switching to new syntax seems to properly recycle threads and stop the leaks:

```ruby
Mongo::Client.new(@host, args) do |client|
  # After the method returns, the client seems to be recycled correctly.
end
```

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally

## Release Note

Fix thread leak when using MongoDB connector.