### PR TITLE
Add an elasticsearch client bulk patch to reduce memory usage

### DIFF
--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -8,9 +8,9 @@
 
 require 'logger'
 require 'elasticsearch'
-require "elasticsearch/api"
-require "elasticsearch/api/namespace/common"
-require "elasticsearch/api/utils"
+require 'elasticsearch/api'
+require 'elasticsearch/api/namespace/common'
+require 'elasticsearch/api/utils'
 require 'elasticsearch/api/response'
 
 module Utility
@@ -70,25 +70,25 @@ module Utility
     def patched_bulk(arguments = {})
       headers = arguments.delete(:headers) || {}
 
-      body   = arguments.delete(:body)
+      body = arguments.delete(:body)
 
-      _index = arguments.delete(:index)
+      index = arguments.delete(:index)
 
       method = ::Elasticsearch::API::HTTP_POST
-      path   = if _index
-                 "#{Utils.__listify(_index)}/_bulk"
-               else
-                 "_bulk"
-               end
+      path = if index
+               "#{Utils.__listify(index)}/_bulk"
+             else
+               '_bulk'
+             end
       params = ::Elasticsearch::API::Utils.process_params(arguments)
 
-      if body.is_a? Array
-        payload = ::Elasticsearch::API::Utils.__bulkify(body)
-      else
-        payload = body
-      end
+      payload = if body.is_a? Array
+                  ::Elasticsearch::API::Utils.__bulkify(body)
+                else
+                  body
+                end
 
-      headers.merge!("Content-Type" => "application/x-ndjson")
+      headers['Content-Type'] = 'application/x-ndjson'
       ::Elasticsearch::API::Response.new(
         perform_request(method, path, params, payload, headers)
       )


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3039

Optimisation change - as written in the comment in the PR, Elasticsearch client by default clones the arguments that are passed into it before processing the data.

This PR stops cloning the arguments to reduce the memory usage of bulk function. For example if the size of bulk request is 50MB, then call to `.bulk` will make it 100MB memory until bulk request finishes. Therefore, we don't use the original method, instead the original method is copied into `patched_bulk` method and `.clone` usage is deleted.

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally

## Release Note

Decrease the amount of memory used by the connector service when sending bulk requests to Elasticsearch.