### PR TITLE
Update DEVELOPING.md

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -22,11 +22,17 @@ make install
 
 ### Building
 
-The repository can generate a ruby gem, if needed.
+The repository can generate ruby gems (connectors service itself or shared connectors service library), if needed.
 
+Generate Connector Service gem:
 ```shell
-make build
+make build_service_gem
 ```
+
+Generate shared Connector Services libraries gem:
+````shell
+make build_utility_gem
+````
 
 ### Testing
 ```shell


### PR DESCRIPTION
"make build" is not present anymore in the Makefile. I've updated DEVELOPING.md to reflect, how to build the shared libraries or the connectors service itself.