### PR TITLE
Fix: Inform user about MongoDB connection errors (invalid database/collection)

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -93,14 +93,30 @@ module Connectors
                  end
 
         begin
-          Utility::Logger.debug("Existing Databases #{client.database_names}")
-          Utility::Logger.debug('Existing Collections:')
+          databases = client.database_names
+          collections = client.collections.map(&:name)
 
-          client.collections.each { |coll| Utility::Logger.debug(coll.name) }
+          Utility::Logger.debug("Existing Databases: #{databases}")
+          Utility::Logger.debug("Existing Collections: #{collections}")
+
+          check_database_exists!(databases, @database)
+          check_collection_exists!(collections, @collection)
 
           yield client
         ensure
           client.close
+        end
+      end
+
+      def check_database_exists!(databases, database)
+        unless databases.include?(database)
+          raise "Database '#{@database}' does not exist. Existing databases: #{databases.join(', ')}"
+        end
+      end
+
+      def check_collection_exists!(collections, collection)
+        unless collections.include?(collection)
+          raise "Collection '#{@collection}' does not exist. Existing collections: #{collections.join(', ')}"
         end
       end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -94,13 +94,14 @@ module Connectors
 
         begin
           databases = client.database_names
-          collections = client.collections.map(&:name)
 
           Utility::Logger.debug("Existing Databases: #{databases}")
-          Utility::Logger.debug("Existing Collections: #{collections}")
-
           check_database_exists!(databases, @database)
-          check_collection_exists!(collections, @collection)
+
+          collections = client.database.collection_names
+
+          Utility::Logger.debug("Existing Collections: #{collections}")
+          check_collection_exists!(collections, @database, @collection)
 
           yield client
         ensure
@@ -111,13 +112,13 @@ module Connectors
       def check_database_exists!(databases, database)
         return if databases.include?(database)
 
-        raise "Database '#{@database}' does not exist. Existing databases: #{databases.join(', ')}"
+        raise "Database (#{database}) does not exist. Existing databases: #{databases.join(', ')}"
       end
 
-      def check_collection_exists!(collections, collection)
+      def check_collection_exists!(collections, database, collection)
         return if collections.include?(collection)
 
-        raise "Collection '#{@collection}' does not exist. Existing collections: #{collections.join(', ')}"
+        raise "Collection (#{collection}) does not exist within database '#{database}'. Existing collections: #{collections.join(', ')}"
       end
 
       def serialize(mongodb_document)

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -109,15 +109,15 @@ module Connectors
       end
 
       def check_database_exists!(databases, database)
-        unless databases.include?(database)
-          raise "Database '#{@database}' does not exist. Existing databases: #{databases.join(', ')}"
-        end
+        return if databases.include?(database)
+
+        raise "Database '#{@database}' does not exist. Existing databases: #{databases.join(', ')}"
       end
 
       def check_collection_exists!(collections, collection)
-        unless collections.include?(collection)
-          raise "Collection '#{@collection}' does not exist. Existing collections: #{collections.join(', ')}"
-        end
+        return if collections.include?(collection)
+
+        raise "Collection '#{@collection}' does not exist. Existing collections: #{collections.join(', ')}"
       end
 
       def serialize(mongodb_document)

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -46,19 +46,23 @@ describe Connectors::MongoDB::Connector do
 
   let(:actual_collection) { double }
   let(:actual_collection_name) { 'sample-collection' }
+  let(:actual_collection_names) { [actual_collection_name] }
   let(:actual_collection_data) { [] }
 
+  let(:actual_database) { double }
   let(:actual_database_names) { ['sample-database'] }
 
   before(:each) do
     allow(Mongo::Client).to receive(:new).and_return(mongo_client)
 
     allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => actual_collection_name })])
+    allow(mongo_client).to receive(:database).and_return(actual_database)
     allow(mongo_client).to receive(:database_names).and_return(actual_database_names)
     allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
     allow(mongo_client).to receive(:with).and_return(mongo_client)
     allow(mongo_client).to receive(:close)
 
+    allow(actual_database).to receive(:collection_names).and_return(actual_collection_names)
     allow(actual_collection).to receive(:find).and_return(actual_collection_data)
   end
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -37,7 +37,7 @@ describe Connectors::MongoDB::Connector do
 
   let(:mongodb_host) { '127.0.0.1:27027' }
   let(:mongodb_database) { 'sample-database' }
-  let(:mongodb_collection) { 'some-collection' }
+  let(:mongodb_collection) { 'sample-collection' }
   let(:mongodb_username) { nil }
   let(:mongodb_password) { nil }
   let(:direct_connection) { 'false' }
@@ -45,13 +45,16 @@ describe Connectors::MongoDB::Connector do
   let(:mongo_client) { double }
 
   let(:actual_collection) { double }
+  let(:actual_collection_name) { 'sample-collection' }
   let(:actual_collection_data) { [] }
+
+  let(:actual_database_names) { ['sample-database'] }
 
   before(:each) do
     allow(Mongo::Client).to receive(:new).and_return(mongo_client)
 
-    allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
-    allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
+    allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => actual_collection_name })])
+    allow(mongo_client).to receive(:database_names).and_return(actual_database_names)
     allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
     allow(mongo_client).to receive(:with).and_return(mongo_client)
     allow(mongo_client).to receive(:close)
@@ -132,24 +135,18 @@ describe Connectors::MongoDB::Connector do
     end
 
     context 'when database is not found' do
-      xit 'no error is raised' do
-        # Leaving this here to describe the work of MongoDB client:
-        # When database is not found on the server, the client does not raise errors
-        # Instead, it acts as if a database exists on server, but has no collections
-        # So every call to .collection will return empty iterator.
+      let(:mongodb_database) { 'non-existing-database' }
+
+      it 'does raise' do
+        expect { |b| subject.yield_documents(&b) }.to raise_error(anything)
       end
     end
 
     context 'when collection is not found' do
-      # mongo client does not raise an error when collection is not found on the server, instead it just returns an empty collection
-      let(:actual_collection_data) { [] }
+      let(:mongodb_collection) { 'non-existing-collection' }
 
-      it 'does not raise' do
-        expect { |b| subject.yield_documents(&b) }.to_not raise_error(anything)
-      end
-
-      it 'does not yield' do
-        expect { |b| subject.yield_documents(&b) }.to_not yield_with_args(anything)
+      it 'does raise' do
+        expect { |b| subject.yield_documents(&b) }.to raise_error(anything)
       end
     end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2977###

Mark a configuration with a non-existing database or collection as wrong and show a hint, which databases/collections exist. Also separate the variable for the database/collection configuration parameter and the stubbed return value within the test to be able to reflect a missing database/collection more explicitly. 

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
