### PR TITLE
Allow multi phrase queries

### DIFF
--- a/lib/utility/elasticsearch/index/mappings.rb
+++ b/lib/utility/elasticsearch/index/mappings.rb
@@ -23,7 +23,7 @@ module Utility
         TEXT_FIELD_MAPPING = {
           type: 'text',
           analyzer: 'iq_text_base',
-          index_options: 'freqs',
+          index_options: 'positions',
           fields: {
             'stem': {
               type: 'text',
@@ -33,18 +33,15 @@ module Utility
               type: 'text',
               analyzer: 'i_prefix',
               search_analyzer: 'q_prefix',
-              index_options: 'docs'
             },
             'delimiter' => {
               type: 'text',
               analyzer: 'iq_text_delimiter',
-              index_options: 'freqs'
             },
             'joined': {
               type: 'text',
               analyzer: 'i_text_bigram',
               search_analyzer: 'q_text_bigram',
-              index_options: 'freqs'
             },
             'enum': {
               type: 'keyword',


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/2975###

This fixes the issue, that queries under the 'Documents' tabs containing whitespaces weren't possible (also queries with delimiters lead to the same error; in general multi phrase queries). The error appeared actually within lucene and stated, that certain text fields weren't indexed with position data (preventing MultiPhraseQuery). According to the docs https://www.elastic.co/guide/en/elasticsearch/reference/current/index-options.html we need to use 'index_options: positions' to enable phrase queries (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html). If we don't use 'index_options' explicitly it defaults to 'positions'. I thought it would be good to add it explicitly anyway so that it's clear with one look, what the 'index_options' are set to.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Tested the changes locally