### PR TITLE
[8.5] Connector service documentation (#367)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,4 +42,4 @@ author(s) can easily look it up.-->
 ## For Elastic Internal Use Only
 - [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
 - [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
-- [ ] [Manual test steps](https://github.com/elastic/connectors-ruby/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
+- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Elastic Enterprise Search connectors
+# Elastic Ruby connectors
 
 ![logo](logo-enterprise-search.png)
 
-The home of Elastic Enterprise Connector Clients. This repository contains the framework for customizing Elastic Enterprise Search native connectors, or writing your own connectors for advanced use cases.
+The home of Elastic connector service and native connectors in Ruby language. This repository contains the framework for customizing Elastic native connectors, or writing your own connectors for advanced use cases.
+
+If you are looking for the implementation in Python, See [connectors-python](https://github.com/elastic/connectors-python).
 
 **The connector will be operated by an administrative user from within Kibana.**
 
@@ -10,291 +12,18 @@ The home of Elastic Enterprise Connector Clients. This repository contains the f
 
 Before getting started, review important information about this feature:
 
-- [Terminology](#terminology)
-- [Getting help and providing feedback](#getting-help-and-providing-feedback)
+- [Terminology](docs/TERMINOLOGY.md)
+- [Getting help and providing feedback](docs/SUPPORT.md)
+- [Understand the connector protocol](docs/CONNECTOR_PROTOCOL.md)
 
-Build, deploy, and operate your connector:
+Build, deploy, and operate your own connector:
 
-- [Building a connector](#building-a-connector)
-- [Operating the connector](#operating-the-connector)
-- [Moving to production](#moving-to-production)
+- [Building/Deploying a connector](docs/DEVELOPING.md)
+- [Operating a connector](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html)
 
 How to publish your connector:
 
-- [Contribute to the repository](#contribute-to-the-repository-)
-
-Reference:
-
-- [Connector protocol reference](docs/CONNECTOR_PROTOCOL.md)
-
-## Terminology
-
-- `connector client` - specific light-weight connector implementation, open-code. Connector clients can be built by Elastic or Community.
-- `connector service` - the app that runs the asynchronous loop that calls Elasticsearch on a regular basis to check whether syncs need to happen.
-- `connector framework` - framework and libraries used to customize and build connector clients. Basically, it's what this repository is.
-- `connector packages` - a previous version of the connector clients. Refer to the [8.3 branch](https://github.com/elastic/connectors-ruby/tree/8.3) if you're looking for connector packages. Also, read more about them in the [custom connector packages guide](https://www.elastic.co/guide/en/workplace-search/8.4/custom-connector-package.html).
-- `data source` - file/database/service that provides data to be ingested into Elasticsearch. 
-
-## Getting help and providing feedback
-
-See [Getting Support](docs/SUPPORT.md).
-
-## Building a connector
-
-In this section:
-
-- [Implementing the connector protocol](#implementing-the-connector-protocol)
-- [Using the connector framework](#using-the-connector-framework)
-- [Operating the connector](#operating-the-connector)
-- [Testing the integration](#testing-the-integration)
-
-
-### Implementing the connector protocol
-
-The [connector protocol](docs/CONNECTOR_PROTOCOL.md) is document-based and building a connector is language- and tool-agnostic.
-To create an Elastic connector, you need to implement this protocol. At a high level, you need to create an application (the connector service) that can read and write to a specific document in Elasticsearch that represents the connector. This document "registers" the connector with Kibana, keeps the configuration that is made via the Kibana UI, as well as the scheduling configuration and the state information for the service. You need to update the connector state to keep up with the current status of the connector application and of the third-party data source. You also need to log sync jobs to an additional index, so that the history of synchronization tasks would be available. And of course, you need to write the results of the synchronization to the Elasticsearch document index, created for this connector service.
-
-The procedures to properly implement the protocol _without the connector framework_ are as follows:
-
-- Create a new index for the connector via the Kibana UI - Enterprise Search - Create an Elasticsearch index. Use the `Build a connector` option for an ingestion method.
-- Create an API key to work with the connector. It should be done either using the `Generate API key` button, which is available on the next step of the wizard, or by creating a new API key via the Security - API keys - `Create API key`. The second way is more generic and will allow the same API key to be used for multiple connectors.
-- By this time, the documents index for the connector is already created and registered in the [.elastic-connectors](docs/CONNECTOR_PROTOCOL.md#elastic-connectors) index. It has settings, but no mappings. So if any specific mappings are needed, they should be created manually. 
-- Implement the code to synchronize the connector documents via pushing the documents directly to the index that you have created. Make sure that the data is in the format that the mappings expect.
-- Implement reading the sync schedule from the [.elastic-connectors](docs/CONNECTOR_PROTOCOL.md#elastic-connectors) and synchronize with the data source on schedule.
-- Implement the code to log sync jobs to [.elastic-connectors-sync-jobs](docs/CONNECTOR_PROTOCOL.md#jobs-index).
-- Implement updating the connector status in the [.elastic-connectors](docs/CONNECTOR_PROTOCOL.md#elastic-connectors) index at regular intervals.
-
-### Using the connector framework
-
-Using this connector framework is optional and Ruby-specific. But the framework already has the code for common tasks like scheduling, so it requires less effort to implement. The framework contains a ruby application (we call it the **connector service** or **connector client**), required ruby libraries, and also some code examples that you can use to implement a connector in Ruby. To use it, you'll need a Ruby development environment.
-
-#### Current connector clients
-
-The connector clients implemented in this repository are [mongodb](/lib/connectors/mongodb), [gitlab](/lib/connectors/gitlab) and [example connector](lib/connectors/example). None of those are production-ready clients - rather, they are functional examples, which you can use as a base for your own work.
-
-- The `example` connector is the most basic and doesn't have any integration with the third-party data source - it just returns some stub data to ingest.
-- The `mongodb` connector is a MongoDB-based connector. It is lacking some features that one would definitely want in production - for example it does not implement any kind of authentication and it only works with a single collection, but it is still a good example of how to use the connector framework for handling the data from this kind of document storage.
-- The `gitlab` connector is the most involved out of the three but is also missing a lot of features - for one, it only grabs the projects and leaves aside all the other types of content, like files, folders, issues, etc. In the current simplified version, it also doesn't synchronize document permissions. But it implements the authentication via an API token, and it has the most developed class structure, which is easily extendable.
-
-#### System Requirements
-
-Under Linux or MacOS, you can run the application using Docker or directly on your system.
-
-For the latter you will need:
-- rbenv (see [rbenv installation](https://github.com/rbenv/rbenv#installation))
-- bundler (see [bundler installation](https://bundler.io/); for version, see [.bundler-version](.bundler-version))
-- yq (see [yq installation](https://github.com/mikefarah/yq#install))
-
-#### Windows support
-
-We provide experimental support for Windows 10.
-
-You can run the `win32\install.bat` script to have an unattended installation of Ruby
-and the tools we use. Once installed, you can run the `specs` using `make.bat`
-
-#### Implementing the connector protocol with the connector framework
-
-The first few steps for this would be the same [as for skipping the framework and implementing the protocol manually](#implementing-the-connector-protocol): creating a document index, setting up an API key, and updating the document index mappings as needed. The rest of the steps, however, are different.
-
-- Copy the [example connector](lib/connectors/example/connector.rb) into a separate folder under the [connectors](lib/connectors). Rename the class as required.
-- Change `self.service_type` and `self.display_name` to match the connector you are implementing. For example, this is how it is done in the provided [mongo connector](lib/connectors/mongodb/connector.rb).
-
-```ruby
-      def self.service_type
-        'mongo'
-      end
-
-      def self.display_name
-        'MongoDB'
-      end
-```
-
-- Change `self.configurable_fields` to provide a list of fields you want to configure via the Kibana UI on connecting the connector.
-
-For example, this is how it is done in the provided [mongo connector](lib/connectors/mongodb/connector.rb).
-
-```ruby
-    {
-       :host => {
-         :label => 'MongoDB Server Hostname'
-       },
-       :database => {
-         :label => 'MongoDB Database'
-       },
-       :collection => {
-         :label => 'MongoDB Collection'
-       }
-    }
-```
-
-If you wanted to also have default values for the fields, you could do it as follows:
-
-```ruby
-    {
-       :host => {
-         :label => 'MongoDB Server Hostname',
-         :value => 'localhost:27017'
-       },
-       :database => {
-         :label => 'MongoDB Database',
-         :value => 'test-database'
-       },
-       :collection => {
-         :label => 'MongoDB Collection',
-         :value => 'test'
-       }
-    }
-```
-
-This way, it's not necessary to set the values in the Kibana UI, unless they differ from the defaults.
-
-- Implement the `do_health_check` method to return a boolean value, corresponding to the health status of the connector. Currently, the `do_health_check` method is used to evaluate the connection to the third-party data source, depending on whether the method throws an exception or runs normally. So for example, the [mongo connector](lib/connectors/mongodb/connector.rb) just creates the mongo client to make sure the connection to the database is successful.
-
-```ruby
-    def do_health_check
-      with_client do |_client|
-        Utility::Logger.debug("Mongo at #{@host}/#{@database} looks healthy.")
-      end
-    end
-```
-
-- Implement the `yield_documents` method to yield documents to the connector framework. It should call `yield` for every document separately and you should yield the documents in the format, matching the mappings that you have defined for the documents index. Example from the [mongo connector](lib/connectors/mongodb/connector.rb):
-
-```ruby
-    def yield_documents
-      with_client do |client|
-        client[@collection].find.each do |document|
-          doc = document.with_indifferent_access
-      
-          yield serialize(doc)
-        end
-      end
-    end
-```
-
-Or from the [gitlab connector](lib/connectors/gitlab/connector.rb):
-
-```ruby
-    def yield_documents
-      next_page_link = nil
-      loop do
-        next_page_link = @extractor.yield_projects_page(next_page_link) do |projects_chunk|
-          projects_chunk.each do |project|
-            yield Connectors::GitLab::Adapter.to_es_document(:project, project)
-          end
-        end
-        break unless next_page_link.present?
-      end
-    end
-```
-
-#### Running the connector locally
-
-First, build the code with:
-
-```shell
-make build
-```
-
-Then, you can run the connector service with:
-
-```shell
-make run
-```
-
-#### Running the connector with Docker
-
-You can also run the connector service using our Dockerfile.
-
-First, build the Docker image with:
-
-```shell
-make build-docker
-```
-
-Then, you can run the connector service within Docker with:
-
-```shell
-make run-docker API_KEY=my-key
-```
-
-Where `my-key` is the Elasticsearch API key.
-
-If you need to create an API key for development purposes, you can use the following cURL call on Elasticsearch:
-
-```shell
-$ curl --user elastic:changeme -X POST "localhost:9200/_security/api_key?pretty" -H 'Content-Type: application/json' -d'
-{
-  "name": "my-connector",
-  "role_descriptors": {
-    "my-connector-role": {
-      "cluster": ["all"],
-      "index": [
-        {
-          "names": ["*"],
-          "privileges": ["all"]
-        }
-      ]
-    }
-  }
-}
-'
-{
-  "id" : "4eOWgYIBAYdMiGHcxmKH",
-  "name" : "my-connector",
-  "api_key" : "zIJThFg9TO6uaYVy57TFSA",
-  "encoded" : "NGVPV2dZSUJBWWRNaUdIY3htS0g6eklKVGhGZzlUTzZ1YVlWeTU3VEZTQQ=="
-}
-```
-
-And then use the `encoded` value:
-
-```
-make run-docker API_KEY="NGVPV2dZSUJBWWRNaUdIY3htS0g6eklKVGhGZzlUTzZ1YVlWeTU3VEZTQQ=="
-```
-
-## Operating the connector
-
-As stated above, the connector will be operated by an administrative user from within Kibana.
-
-- The connector operator sets the sync schedule in Kibana, and Kibana writes this to the connector's document in Elasticsearch. So the connector has to read this document to determine when to next sync.
-- The connector operator can see the state of the connector within Kibana. So the connector must regularly write its state back to the document, where Kibana can read it.
-
-### Configuring the connector in Kibana
-
-- In Kibana UI, navigate to `Enterprise Search` -
-  `Content` - `Elasticsearch indices`.
-- Click on the index that you created for the connector while [implementing the connector protocol](#implementing-the-connector-protocol).
-- Go to the tab `Configuration` and make sure the following message is displayed:
-
-```text
-Your connector <your-service-name> has connected to Enterprise Search successfully.
-```
-
-- If needed, set the values of configurable fields in the `Configuration` tab, using the `Edit configuration` button.
-- Use the `Set schedule and sync` on the same tab to set the sync schedule and run the sync for the first time.
-
-### Testing the integration
-
-If the connector synchronizes successfully, the documents should appear in `Enterprise Search
-Content - Elasticsearch indices - your-index-name` section, on the `Documents` tab.
-
-If the connector didn't specify any configurable fields, it will go into the `connected` status and will try to sync, without requiring any additional configuration via the Kibana UI.
-
-If the connector fails to synchronize, it will change its status to `error`.
-
-## Moving to production
-
-After you've implemented everything correctly, you're ready to go to Production. Before you do this, make sure the following topics are covered:
-
-- No sensitive values are committed to source code repositories.
-- No unsecured values are exposed via configurable fields.
-- The connector is properly authenticated to the third-party data source.
-- The connector implements the connector protocol correctly and does appropriate error handling.
-
-## Contribute to the repository 🚀
-
-We welcome contributors to the project. Before you begin, please read the [Connectors Contributor's Guide](docs/CONTRIBUTING.md).
+- [Contribute to the repository](docs/CONTRIBUTING.md)
 
 ## Other guides
 
@@ -305,3 +34,6 @@ We welcome contributors to the project. Before you begin, please read the [Conne
 - [Security Policy](docs/SECURITY.md)
 - [Elastic-internal guide](docs/INTERNAL.md)
 - [Connector Protocol](docs/CONNECTOR_PROTOCOL.md)
+- [Configuration](docs/CONFIG.md)
+- [Terminology](docs/TERMINOLOGY.md)
+- [Contributing guide](docs/CONTRIBUTING.md)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,52 @@
+# Configuration
+
+Configuration lives in `config/connectors.yml`.
+
+Get a copy of configuration with default values:
+```shell
+cp config/connectors.yml.example config/connectors.yml
+```
+
+- `version`: The version of the connector service application, this will be set automatically when the application runs.
+- `repository`: The repository to hold the source code of the connector service application.
+- `revision`: The specific revision which the connector service application is built on.
+- `elasticsearch`: Elasticsearch connection configurations.
+    - `cloud_id`: The cloud ID of the Elasticsearch deployment, if it's deployed on Elastic Cloud. Either this or `hosts` have to be configured.
+    - `hosts`: The hosts of the Elasticsearch deployment. This will be ignored if `cloud_id` is configured. Either this or `cloud_id` have to be configured.
+    - `api_key`: The API key to connect to the Elasticsearch server.
+    - `retry_on_failure`: Number of retries when request fails before raising an exception. Defaults to 3.
+    - `request_timeout`: The request timeout to be passed to transport in options. Defaults to 120.
+    - `disable_warnings`: Whether to display warnings in the log. Defaults to `true`.
+    - `trace`: Whether to use the default tracer. Defaults to `false`.
+    - `log`: Whether to use logger when connecting to Elasticsearch. Defaults to `false`.
+- `thread_pool`: Thread pool configurations.
+    - `min_threads`: When a new task is submitted and fewer than `min_threads` are running, a new thread is created. Defaults to `0`.
+    - `max_threads`: The maximum number of threads to be created. Defaults to `5`.
+    - `max_queue`: The maximum number of tasks allowed in the work queue at any one time; a value of zero means the queue may grow without bound. Defaults to `100`.
+- `log_level`: Log level. Defaults to `info`.
+- `ecs_logging`: Whether to output the log ECS compatible format, which is required when the application is deployed on Elastic Cloud. Defaults to `true`.
+- `poll_interval`: The interval (in seconds) to poll connectors from Elasticsearch. Defaults to `3`.
+- `termination_timeout`: The maximum number of seconds to wait for the pool shutdown to complete. Defaults to `60`.
+- `heartbeat_interval`: The interval (in seconds) to send a new heartbeat for a connector. Defaults to `1800`.
+- `native_mode`: Whether to run the application in `native mode`. Defaults to `true`.
+- `connector_id`: The ID of the connector that the application will sync data for. This is required when `native_mode` is `false`.
+- `service_type`: The service type of the connector that the application will sync data for. This is required when `native_mode` is `false`. 
+
+## Run the connector service on Elastic Cloud
+
+When you have an Enterprise Search deployment on Elastic Cloud post 8.5.0, the connector service is automatically deployed. The connector service can only run in native mode on Elastic Cloud (i.e. `native_mode` is always `true`), and the Elasticsearch connection configurations (i.e. `cloud_id`, `hosts`, `api_key`) will be overridden, and a special Cloud user `cloud-internal-enterprise_search-server` will be used for Elasticsearch connection, which will have proper privilege on the connector index (`.elastic-connectors`), the connector job index (`.elastic-connectors-sync-jobs`) and the connector content indices (`search-*`).
+
+## Run the connector service on-prem
+
+### Run the connector service in native mode
+
+1. Set `native_mode` to `true`
+2. Generate the API key via _Stack Management_ > _Security_ > _API keys_ > _Create API key_. Make sure the API key has at least the privileges to `manage`, `read` and `write` the connector index (`.elastic-connectors`), the connector job index (`.elastic-connectors-sync-jobs`) and the connector content indices (`search-*`).
+3. Run the connector service with
+    ```shell
+    make run
+    ```
+
+### Run the connector service for a custom connector
+
+Refer to [Test your connector](./DEVELOPING.md#test-your-connector) for detailed explanation.

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -1,5 +1,4 @@
 # Connector Protocol
-**Version 1, Jul 25 2022**
 
 To enable Elasticsearch users to ingest any kind of data and build a search experience on top of that data, we are providing a lightweight protocol that will allow users to easily ingest data, use Enterprise Search features to manipulate that data and create a search experience, while providing them with a seamless user experience in Kibana. To be compatible with Enterprise Search and take full advantage of the connector features available in Kibana, a connector should adhere to the protocol defined here.
 
@@ -22,61 +21,11 @@ At this stage, our assumption is that one connector will manage one index, and o
 
 ## Communication protocol
 
-All communication will need to go through Elasticsearch. We've created an index called `.elastic-connectors`, where each connector will have one entry. In addition, there's a synchronization jobs log index called `.elastic-connectors-sync-jobs`. You can find the definitions for these indices further below in this section.
+All communication will need to go through Elasticsearch. We've created a connector index called `.elastic-connectors`, where a document represents a connector. In addition, there's a connector job index called `.elastic-connectors-sync-jobs`, which holds the sync job history. You can find the definitions for these indices in the next section.
 
-### Protocol flow and responsibilities
+### Index definition
 
-To connect to Elasticsearch, a connector will need an Elasticsearch API key that grants read and write access to `.elastic-connectors` and `.elastic-connectors-sync-jobs` as well as `manage`, `read` and `write` to the index it will write documents to. In addition, the connector will need the document ID for their entry in the `.elastic-connectors` index. Users will need to manually configure that API key and the document ID in their deployment.
-
-Once configured, the connector will be able to connect and read the specified configuration in the `.elastic-connectors` index, and write its own configuration schema and status to that document. The user will then be able to use Kibana to update that configuration with the appropriate values, as well as enable and change a sync schedule or request an immediate sync.
-
-**Connector responsibilies**
-
-Connectors should update the last_seen field with their current datetime in UTC format (timezone-agnostic) every half hour, and every time they perform a sync job, so we can signal to the user when a connector is likely to be offline.
-
-- Read the configuration from the relevant document in `.elastic-connectors`, including the index name to be indexed to
-- Write its configuration schema to the document if not already present
-- Set the index mappings of the to-be-written-to index if not already present
-- Regularly write its status to the document
-- Read the sync schedule from the document and synchronize with the data source accordingly
-- Sync with the data source and index resulting documents into the correct index
-- Log sync jobs to `.elastic-connectors-sync-jobs`
-- Write a UTC date-time to the `last_seen` property as a heartbeat, at least every half hour. Kibana will show an error if the date in `last_seen` is more than half an hour ago.
-
-**Sequence diagram**:
-```mermaid
-sequenceDiagram
-    actor User
-    participant Kibana
-    participant Elasticsearch
-    participant Connector
-    participant Data source
-    User->>Kibana: Generates new API key & id
-    Kibana->>Elasticsearch: Saves API key & id
-    User->>Connector: Deploys with API key, id & Elasticsearch host
-    Connector->>Elasticsearch: Writes its connector definition to .elastic-connectors
-    Elasticsearch->>Kibana: Returns connector definition
-    Kibana->>User: Returns connector definition
-    User->>Kibana: Enters necessary configuration and synchronization schedule
-    Kibana->>Elasticsearch: Writes configuration and synchronization schedule
-    Connector->>Elasticsearch: Reads configuration and synchronization schedule
-    loop Every minute
-        Connector->>Elasticsearch: Reads sync_now flag and sync schedule
-        Connector->>Elasticsearch: Updates last_seen to current datetime
-        opt Sync_now is true or sync_schedule requires synchronization
-            Connector->>Elasticsearch: Sets sync_now to false and last_sync_status to in_progress
-            Connector->>Data source: Reads data
-            Connector->>Elasticsearch: Indexes data
-            alt Sync successfully completed
-                Connector->>Elasticsearch: Sets last_sync_status to success
-            else Sync error
-                Connector->>Elasticsearch: Sets status and last_sync_status to error
-                Connector->>Elasticsearch: Writes error message to error field
-            end
-        end
-    end
-```
-### .elastic-connectors
+#### Connector index `.elastic-connectors`
 
 This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.
 ```
@@ -84,58 +33,62 @@ This is our main communication index, used to communicate the connector's config
   api_key_id: string;   -> ID of the current API key in use
   configuration: {
     [key]: {
-      label: string
-      value: string,
+      label: string     -> The label to be displayed for the field in Kibana
+      value: string,    -> The value of the field configured in Kibana
     }
   };                    -> Definition and values of configurable
                            fields
+  description: string;  -> the description of the connector
   error: string;        -> Optional error message
-  index_name: string;   -> The index data will be written to
+  index_name: string;   -> The name of the content index where data will be written to
+  is_native: boolean;   -> Whether this is a native connector
   language: string;     -> the language used for the analyzer
   last_seen: date;      -> Connector writes check-in date-time
                            regularly (UTC)
   last_sync_error: string;   -> Optional last sync error message
-  last_sync_status: string;  -> last sync Enum, see below
-  last_synced: date;    -> Date/time of last completed sync (UTC)
-  last_indexed_document_count: number;    -> How many documents were inserted into the index
-  last_deleted_document_count: number;    -> How many documents were deleted from the index
+  last_sync_status: string;  -> last sync status Enum, see below
+  last_synced: date;    -> Date/time of last sync (UTC)
+  last_indexed_document_count: number;    -> How many documents were indexed in the last sync
+  last_deleted_document_count: number;    -> How many documents were deleted in the last sync
   name: string; -> the name to use for the connector
   pipeline: {
-    extract_binary_content: boolean; -> Whether or not the `request_pipeline` should handle binary data
+    extract_binary_content: boolean; -> Whether the `request_pipeline` should handle binary data
     name: string; ->  Ingest pipeline to utilize on indexing data to Elasticsearch
-    reduce_whitespace: boolean; -> Whether or not the `request_pipeline` should squish redundant whitespace
-    run_ml_inference: boolean; -> Whether or not the `request_pipeline` should run the ML Inference pipeline
+    reduce_whitespace: boolean; -> Whether the `request_pipeline` should squish redundant whitespace
+    run_ml_inference: boolean; -> Whether the `request_pipeline` should run the ML Inference pipeline
   }
   scheduling: {
-    enabled: boolean; -> Is sync schedule enabled?
+    enabled: boolean; -> Whether sync schedule is enabled
     interval: string; -> Quartz Cron syntax
   };
-  service_type: string; -> Optional, used for UI sugar
-  status: string;       -> Enum, see below
-  sync_now: boolean; -> Flag to signal user wants to initiate a sync
+  service_type: string; -> Service type of the connector
+  status: string;       -> Connector status Enum, see below
+  sync_now: boolean;    -> Flag to signal user wants to initiate a sync
 }
 ```
 **Possible values for 'status'**
-- `created` -> entry has been created but connector has not connected to elasticsearch (written by index creator)
-- `needs_configuration` -> connector has written its configuration to elasticsearch (written by connector)
-- `configured` -> connector has been fully configured (written by kibana on updating configuration, or directly by connector if no further configuration is necessary)
-- `connected` -> connector has successfully connected to the data source (written by connector on successfully connecting to data source )
-- `error` -> connector has encountered an error that needs recovery (written by connector on encountering any error)
+- `created` -> A document for a connector has been created in connector index but the connector has not connected to elasticsearch (written by index creator).
+- `needs_configuration` -> Configurable fields have been written into the connector, either by Kibana (for native connector) or connector (for custom connector.
+- `configured` -> A connector has been fully configured (written by Kibana on updating configuration, or directly by connector if no further configuration is necessary).
+- `connected` -> A connector has successfully connected to the data source (written by connector on successfully connecting to data source).
+- `error` -> A connector has encountered an error, either because the data source is not healthy or the last sync failed.
 
 **last_sync_status enum**
-- `null` -> no sync has ever started
-- `in_progress` -> sync successfully started
-- `completed` -> sync successfully completed
-- `error` -> sync error
+- `null` -> No sync job has ever started.
+- `in_progress` -> A sync job successfully started.
+- `completed` -> A sync job successfully completed.
+- `failed` -> A sync job failed.
 
-### Elasticsearch mappings for .elastic-connectors:
+#### Elasticsearch mappings for `.elastic-connectors`:
 ```
 "mappings" : {
   "properties" : {
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
+    "description" : { "type" : "text" },
     "error" : { "type" : "text" },
     "index_name" : { "type" : "keyword" },
+    "is_native" : { "type" : "boolean" },
     "language" : { "type" : "keyword" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "text" },
@@ -165,44 +118,107 @@ This is our main communication index, used to communicate the connector's config
 }
 ```
 
-### Jobs index
-In addition to the .elastic-connectors index for documents, we have an index to log all jobs run by connectors. This is the .elastic-connectors-sync-jobs index. Each JSON document will have the following structure:
+#### Connector job index `.elastic-connectors-sync-jobs`
+In addition to the connector index `.elastic-connectors`, we have an additional index to log all jobs run by connectors. This is the `.elastic-connectors-sync-jobs` index. Each JSON document will have the following structure:
 ```
 {
-  connector: object; -> Copy of the current connector document
-  connector_id: string; -> id of the connector document in .elastic-connectors
+  connector_id: string; -> ID of the connector document in .elastic-connectors
   status: string; -> Same enum as sync_status above
-  error: string;
-  Worker_hostname: string;
-  deleted_document_count: number;
-  indexed_document_count: number;
-  index_name: string;
-  created_at: date;
-  updated_at: date;
+  error: string; -> Optional error message
+  index_name: string; -> The name of the content index
+  worker_hostname: string; -> The hostname of the worker to run the sync job
+  indexed_document_count: number; -> Number of documents indexed in the sync job
+  deleted_document_count: number; -> Number of documents deleted in the sync job
+  created_at: date; -> The date/time when the sync job is created
+  completed_at: date; -> The data/time when the sync job is completed
 }
 ```
-### Elasticsearch mappings for .elastic-connectors-sync-jobs:
+#### Elasticsearch mappings for `.elastic-connectors-sync-jobs`:
 ```
 "mappings" " {
   "properties" : {
     "connector_id" : { "type" : "keyword" },
     "status" : { "type" : "keyword" },
     "error" : { "type" : "text" },
+    "index_name" : { "type" : "keyword" },
     "worker_hostname" : { "type" : "keyword" },
     "indexed_document_count" : { "type" : "integer" },
     "deleted_document_count" : { "type" : "integer" },
-    "index_name": { "type": "keyword" },
     "created_at" : { "type" : "date" },
     "completed_at" : { "type" : "date" }
   }
 }
 ```
 
+### Protocol flow and responsibilities
+
+To connect a custom connector to Elasticsearch, it requires an Elasticsearch API key that grants read and write access to `.elastic-connectors` and `.elastic-connectors-sync-jobs` as well as `manage`, `read` and `write` to the index it will write documents to. In addition, the connector will need the document ID for their entry in the `.elastic-connectors` index. Users will need to manually configure that API key and the document ID in their deployment.
+
+Once configured, the connector will be able to connect and read the specified configuration in the `.elastic-connectors` index, and write its own configuration schema and status to that document. The user will then be able to use Kibana to update that configuration with the appropriate values, as well as enable and change a sync schedule or request an immediate sync.
+
+**Connector responsibilities**
+
+For every half hour, and every time a sync job is executed, the connector should update the following fields so we can signal to the user when a connector is likely to be offline:
+- the `last_seen` field with their current datetime in UTC format (timezone-agnostic).
+- the `status` field to either `connected` or `error`, indicating the health status of the remote data source.
+- the `error` field, when the remote data source is not healthy.
+
+For custom connectors, the connector should also update `configuration` field if its status is `created`.
+
+The connector should also sync data for connectors:
+- Read connector definitions from `.elastic-connectors` regularly, and determine whether to sync data based on `sync_now` flag and `scheduling`. 
+- Set the index mappings of the to-be-written-to index if not already present.
+- Sync with the data source and index resulting documents into the correct index.
+- Log sync jobs to `.elastic-connectors-sync-jobs`.
+
+**Sequence diagram**:
+```mermaid
+sequenceDiagram
+    actor User
+    participant Kibana
+    participant Elasticsearch
+    participant Connector
+    participant Data source
+    alt Custom connector
+        User->>Kibana: Creates a connector via Build a connector
+        Kibana->>Elasticsearch: Saves connector definition
+        User->>Kibana: Generates new API key & id
+        Kibana->>Elasticsearch: Saves API key & id
+        User->>Connector: Deploys with API key, id & Elasticsearch host (for custom connector)
+    else Native connector
+        User->>Kibana: Creates a connector via Use a connector
+        Kibana->>Elasticsearch: Saves connector definition
+    end
+    User->>Kibana: Enters necessary configuration and synchronization schedule
+    Kibana->>Elasticsearch: Writes configuration and synchronization schedule
+    loop Every 3 seconds (by default)
+        par Heartbeat
+            Connector->>Elasticsearch: Updates last_seen and status regularly
+        and Configuration
+            Connector->>Elasticsearch: Updates configurable fields for custom connector
+        and Sync job
+            Connector->>Elasticsearch: Reads sync_now flag and sync schedule
+            opt Sync_now is true or sync_schedule requires synchronization
+                Connector->>Elasticsearch: Sets sync_now to false and last_sync_status to in_progress
+                Connector->>Data source: Reads data
+                Connector->>Elasticsearch: Indexes data
+                alt Sync successfully completed
+                    Connector->>Elasticsearch: Sets last_sync_status to completed
+                else Sync error
+                    Connector->>Elasticsearch: Sets status and last_sync_status to error
+                    Connector->>Elasticsearch: Writes error message to error field
+                end
+            end
+        end
+    end
+```
+
+
 ### Migration concerns
 If the mapping of `.elastic-connectors` or `.elastic-connectors-sync-jobs` is updated in a future version in a way that necessitates a complete re-indexing, Kibana will migrate that data if a user with sufficient permissions is logged in.
 
-To facilitate migrations we'll use aliases for the .elastic-connectors and .elastic-connectors-sync-jobs indices, and update the underlying index the alias points to when we need to migrate data to a new mapping. The name of those indices will be the same as the alias, with a version appended. So right now, those indices are:
-`.elastic-connectors-v1`
-`.elastic-connectors-sync-jobs-v1`
+To facilitate migrations we'll use aliases for the `.elastic-connectors` and `.elastic-connectors-sync-jobs` indices, and update the underlying index the alias points to when we need to migrate data to a new mapping. The name of those indices will be the same as the alias, with a version appended. So right now, those indices are:
+- `.elastic-connectors-v1`
+- `.elastic-connectors-sync-jobs-v1`
 
 In addition to the name of the index, we'll store a version number in each index's metadata to check against and make sure we're operating on the correct version of each index, and migrate the data otherwise.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,10 +9,7 @@ You may also want to read the [development guide](./DEVELOPING.md).
 * Prior to opening a pull request, please:
     * Read the entirety of this document
     * [Create an issue](https://github.com/elastic/connectors-ruby/issues) to discuss the scope of your proposal.
-    * Sign the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to
-      assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all
-      contributors in order to assure our users of the origin and continuing existence of the code. You only need to 
-      sign the CLA once.
+    * Sign the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
     * Run all tests locally, and ensure they are all passing  
 * Please write simple code and concise documentation, when appropriate.
 
@@ -31,10 +28,7 @@ make test
 
 ### Branching Strategy
 
-Our `main` branch holds the latest development code for the next release. If the next release will be a minor release,
-the expecation is that no breaking changes will be in `main`. If a change would be breaking, we need to put it behind a
-feature flag, or make it an opt-in change. We will only merge breaking PRs when we are ready to start working on the
-next major.
+Our `main` branch holds the latest development code for the next release. If the next release will be a minor release, the expecation is that no breaking changes will be in `main`. If a change would be breaking, we need to put it behind a feature flag, or make it an opt-in change. We will only merge breaking PRs when we are ready to start working on the next major.
 
 All PRs should be created from a fork, to keep a clean set of branches on `origin`.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -1,18 +1,18 @@
 # Connectors Developer's Guide
 
-So you want to modify some connectors code? Well, you've come to the right place!
+So you want to customize Elastic-built connectors, or build your own? Well, you've come to the right place!
 
 After you've made your changes, if you'd like to contribute back, please see the [contributing guide](./CONTRIBUTING.md).
 
-### Requirements
+## Requirements
 - rbenv (see [rbenv installation](https://github.com/rbenv/rbenv#installation))
-- bundler (for version, see [.bundler-version](./.bundler-version))
+- bundler (for version, see [.bundler-version](../.bundler-version))
 - yq (see [yq installation](https://github.com/mikefarah/yq#install))
 
-### Setup
+## Setup
 1. Fork this repository
 
-### Installing dependencies
+## Installing dependencies
 
 From the root level of this repository:
 
@@ -20,15 +20,122 @@ From the root level of this repository:
 make install
 ```
 
-### Building
+## Code Organization
 
-The repository can generate a ruby gem, if needed.
+- `config/connectors.yml`: This is where the config lives. See [Configuration](./CONFIG.md) for detailed explanation.
+- `lib/app`: This is where the connector service application and its helpers live.
+- `lib/connectors`: This is where the connector clients live. Each directory represent one connector client, e.g. `mongodb`, `gitlab`. The directory name must be the same as the service type. Connectors are hierarchical, so you may find that much of the underlying code for any given connector lives in `lib/connectors/base/**/*.rb`, rather than in the specific connector's implementation.
+- `lib/core`: The main components of the connector service application, e.g. `scheduler`, `sync_job_runner`, `output_sync`, etc..
+- `lib/stubs`: This is a holdover from migrating from Enterprise Search's monolithic codebase, and these files should eventually be refactored away.
+- `lib/utility`: This is where shared utilities, constants, error classes, etc.. live.
+- `spec`: This is where the tests live. All tests should match the path of the file/class that they test. For example a `lib/foo/bar.rb` should have a corresponding `spec/foo/bar_spec.rb` test file.
 
+## Add a custom connector
+
+To add a new custom connector, all you have to do is adding a new directory under `lib/connectors`, and make it implement the connector protocol.
+
+1. Copy the [example connector](../lib/connectors/example/connector.rb) into a separate folder under the [connectors](../lib/connectors) (Ignore the [example_attachments] ). Rename the directory to the service type, and rename the class accordingly
+    ```shell
+    mkdir lib/connectors/{service_type}
+    cp lib/connectors/example/connector.rb lib/connectors/{service_type}/connector.rb
+    ```
+
+2. Change `self.service_type` and `self.display_name` to match the connector you are implementing.
+    ```ruby
+    def self.service_type
+      'foobar'
+    end
+    
+    def self.display_name
+      'Foobar'
+    end
+    ```
+
+3. Change `self.configurable_fields` to provide a list of fields you want to configure via the Kibana UI when connecting the connector. This method should return a hash, with the format of
+    ```ruby
+    def self.configurable_fields
+      {
+        :key => { # The key to uniquely identify the configuration field
+          :label => 'label', # The label to be displayed for the field in Kibana
+          :value => 'default value', # The default value, optional
+        }
+      }
+    end
+    ```
+
+4. Implement the `do_health_check` method to evaluate the connection to the third-party data source, depending on whether the method throws an exception or runs normally. E.g.
+    ```ruby
+    def do_health_check
+      foobar_client.health
+    end
+    ```
+
+5. Customize `initialize` method if necessary. Make sure `super` is called to assign instance variable `configuration`, which contains all the info required to connect to the third-party data source.
+
+6. Implement the `yield_documents` method to sync data from the third-party data source. This is where your main logic goes to. This method should try to connect to the third-party data source, fetch data and transform to documents and yield them one by one. Each document is a hash and it must contain a key `id`, and it's unique across all the documents in one connector. Below is an example implementation:
+    ```ruby
+    def yield_documents
+      foobar_client.files do |file|
+        yield {
+          :id => file.id,
+          :name => file.name,
+          :size => file.size
+        }
+      end
+    end
+    ```
+
+7. Register your new connector in [Connectors::REGISTRY](https://github.com/elastic/connectors-ruby/blob/main/lib/connectors/registry.rb). E.g.
+    ```ruby
+    require_relative 'foobar/connector'
+    REGISTRY.register(Connectors::Foobar::Connector.service_type, Connectors::Foobar::Connector)
+    ```
+
+
+## Test your connector
+
+Once you have implemented your new connector, it's time to see how it integrates with Kibana (Refer to [Elastic connectors](https://www.elastic.co/guide/en/enterprise-search/current/connectors.html) on how to operate connectors in Kibana).
+
+1. Make sure you have [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html), [Kibana](https://www.elastic.co/guide/en/kibana/current/install.html) and [Enterprise Search](https://www.elastic.co/guide/en/enterprise-search/current/start.html) running. By far the easiest way is to start an Elastic Cloud deployment at https://cloud.elastic.co
+
+2. Go to Kibana, _Enterprise Search_ > _Create an Elasticsearch index_. Use the `Build a connector` option for an ingestion method to create an index.
+
+3. Create an API key to work with the connector. It should be done either using the `Generate API key` button under `Configuration` tab, which is available on the next step of the wizard, or by creating a new API key via _Stack Management_ > _Security_ > _API keys_ > _Create API key_. The second way is more generic and will allow the same API key to be used for multiple connectors.
+
+4. Configure your connector service application (See [Configuration](./CONFIG.md)). You need to configure the followings fields, and leave the rest as default.
+    1.  `elasticsearch.cloud_id`: Configure this if the Elasticsearch server is on Cloud. You can find the `cloud_id` on the deployment Overview page.
+    2. `elasticsearch.hosts`: Configure this if the Elasticsearch server is deployed on-prem.
+    3. `elasticsearch.api_key`: Configure the API key generated in step 3.
+    4. `native_mode`: Set it to `false`.
+    5. `connector_id`: You can find the `connector_id` in step 3 `Deploy a connector` under `Configuration` tab in Kibana.
+    6. `service_type`: Configure it to the service type of your new connector.
+
+5. Run the connector service application with
+    ```shell
+    make run
+    ```
+
+6. Now you should see the message `Your connector {name} has connected to Enterprise Search successfully.` under the `Configuration` tab.
+
+7. The configurable fields should also be displayed. Configure them accordingly.
+
+8. Go to the Overview page, the `Ingestion sync` should be `Connected`. Click the `Sync` button on the top-right corner to start a sync, and see if documents are successfully ingested.
+
+## Building
+
+The repository can generate ruby gems (connectors service itself or shared connectors service library), if needed.
+
+Generate Connector Service gem:
 ```shell
-make build
+make build_service_gem
 ```
 
-### Testing
+Generate shared Connector Services libraries gem:
+````shell
+make build_utility_gem
+````
+
+## Testing
 ```shell
 # ensure code standards
 make lint
@@ -37,25 +144,8 @@ make lint
 make test
 ```
 
-### Code Organization
-
-Each connector has its own dedicated directory under `lib/connectors`. Connectors are hierarchical, so you may find that much of the underlying code for any given connector lives in `lib/connectors/base/**/*.rb`, rather than in the specific connector's implementation.
-
-Shared utilities, constants, error classes, etc live under `lib/utility`.
-
-The connectors server and its helpers live under `lib/app`.
-
-Finally, you may notice a `lib/stubs` directory. This is a holdover from migrating from Enterprise Search's monolithic codebase, and these files should eventually be refactored away.
-
-All tests in the repo live under `spec`, and should match the path of the file/class that they test. For example a `lib/foo/bar.rb` should have a corresponding `spec/foo/bar_spec.rb` test file.
-
-### IDE and Debugging
+## IDE and Debugging
 
 This project is fairly simple and conventional as a bundler-based Ruby project, so any popular IDE with ruby support should work fine. The maintaining team uses several IDEs including Intellij, RubyMine, Sublime, and VSCode.
 
 Debugging varies from IDE to IDE, but the gems `ruby-debug-ide`, `pry-remote`, `pry-nav`, and `debase` are all included in the Gemfile, and should be sufficient to power your debugging.
-
-In addition, you can spin up a local interactive REPL using
-```shell
-make console
-```

--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -37,9 +37,3 @@
 * `cd` into your connectors checkout
 * run `make install` to get the latest dependencies
 * run `make run` to start Connectors.
-
-##### Register your local Connectors with Enterprise Search
-* TBD
-
-### Minimal manual tests
-* TBD

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,29 +1,27 @@
-# Releasing the Connectors project
+# Releasing the connector service
 
-The version scheme we use is **MAJOR.MINOR.PATCH.BUILD** and stored in the [VERSION](https://github.com/elastic/connectors-ruby/blob/main/VERSION) file
-at the root of this repository.
+> Note: This is for internal use within Elastic. Only Elastic members can release the connector service.
+
+The version scheme we use is **MAJOR.MINOR.PATCH.BUILD** and stored in the [VERSION](https://github.com/elastic/connectors-ruby/blob/main/VERSION) file at the root of this repository.
 
 ## RubyGem Account
 
-When releasing Gems, you will be asked for an Email and Password.
-Look into the Vault in the `ent-search-team/rubygem` secret.
+When releasing Gems, you will be asked for an Email and Password. Look into the Vault in the `ent-search-team/rubygem` secret.
 
 ## Unified release
 
-**MAJOR.MINOR.PATCH** should match the Elastic and Enterprise Search version it targets
-and the *BUILD* number should be set to **0** the day the Connectors release is created
-to be included with the Enterprise Search distribution.
+**MAJOR.MINOR.PATCH** should match the Elastic and Enterprise Search version it targets and the *BUILD* number should be set to **0** the day the Connector service release is created to be included with the Enterprise Search distribution.
 
 For example, when shipping for `8.1.2`, the version is `8.1.2.0`.
 
-To release Connectors:
+To release the connector service:
 
-- Set the VERSION file to the new/incremented version on the release branch
-- Make sure all tests and linter pass with `make lint test`
-- PR these changes to the appropriate Connectors release branch
-- Run `make release`
+1. Make sure all tests and linter pass with `make lint test`
+2. Run `make release_service release_utility`
+3. Set the [VERSION](../VERSION) file to the new/incremented version on the release branch
+4. PR these changes to the appropriate connector service release branch
 
-A Gem will be published to RubyGems: #TODO: change the name, what's gonna be the new gem, if any is needed? https://rubygems.org/gems/connectors.
+Two Gems will be published to RubyGems: [connectors_service](https://rubygems.org/gems/connectors_service) and [connectors_utility](https://rubygems.org/gems/connectors_utility)
 
 Take care of the branching (minor releases only):
 
@@ -32,24 +30,19 @@ Take care of the branching (minor releases only):
 
 After the Elastic unified release is complete
 
-- Update the **BUILD** version ([example PR](https://github.com/elastic/connectors-ruby/pull/81)). Note that the Connectors project does not immediately bump to the next **PATCH** version. That wont happen until that patch release's FF date.
+- Update the **BUILD** version ([example PR](https://github.com/elastic/connectors-ruby/pull/81)). Note that the Connectors project does not immediately bump to the next **PATCH** version. That won't happen until that patch release's FF date.
 
 ## In-Between releases
 
-Sometimes, we need to release Connectors independantly from Enterprise Search.
-For instance, if someone wants to use the project as an HTTP Service and we have a
-bug fix we want them to have as soon as possible.
+Sometimes, we need to release connector service independently from Enterprise Search.
+For instance, if someone wants to use the project as an HTTP Service and we have a bug fix we want them to have as soon as possible.
 
-In that case, we increment the **BUILD** number, and follow the same release
-process than for the unified release.
+In that case, we increment the **BUILD** number, and follow the same release process than for the unified release.
 
-So `8.1.2.1`, `8.1.2.2` etc. On the next unified release, the version will be bumped to
-the next **PATCH** value, and **BUILD** set to `0`
+So `8.1.2.1`, `8.1.2.2` etc. On the next unified release, the version will be bumped to the next **PATCH** value, and **BUILD** set to `0`
 
-**In-Between releases should never introduce new features since they will eventually be
-merged into the next PATCH release. New features are always done in Developer previews**
+**In-Between releases should never introduce new features since they will eventually be merged into the next PATCH release. New features are always done in Developer previews**
 
 ## Developer preview releases
 
-For developer previews, we are adding a `pre` tag using an ISO8601 date.
-You can use `make release_dev` instead of `make release` in that case.
+For developer previews, we are adding a `pre` tag using an ISO8601 date. You can use `make build_service build_utility`, and the gems will be generated in directory `.gems/`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,7 +1,6 @@
 # Security Policy
 
-Thanks for your interest in the security of our products.
-Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
+Thanks for your interest in the security of our products. Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
 
 ## Reporting a Vulnerability
 Please send security vulnerability reports to security@elastic.co.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -7,8 +7,4 @@ If you have an Elastic subscription, you are entitled to Support services. See o
 If something is not working as expected, please open an [issue](https://github.com/elastic/connectors-ruby/issues/new).
 
 ### Where else can I go to get help?
-The Ingestion team at Elastic maintains this repository and is happy to help. Try posting your question to the
-[Elastic discuss forums](https://discuss.elastic.co/c/enterprise-search/84). Be sure to mention that you're
-using Connectors and also let us know what service type you're trying to use, and any errors/issues you are
-encountering. You can also find us in the `#enterprise-search` channel of the
-[Elastic Community Slack](http://elasticstack.slack.com).
+The Ingestion team at Elastic maintains this repository and is happy to help. Try posting your question to the [Elastic discuss forums](https://discuss.elastic.co/c/enterprise-search/84). Be sure to mention that you're using Connectors and also let us know what service type you're trying to use, and any errors/issues you are encountering. You can also find us in the `#enterprise-search` channel of the [Elastic Community Slack](http://elasticstack.slack.com).

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -1,0 +1,10 @@
+# Terminology
+
+- `connector client` - specific light-weight connector implementation, open-code. Connector clients can be built by Elastic or Community.
+- `native connector` - a connector client built and supported by Elastic, made available by default on Elastic Cloud.
+- `connector service` - the app that runs the asynchronous loop that calls Elasticsearch on a regular basis to check whether syncs need to happen.
+- `connector packages` - a previous version of the connector clients specific to Workplace Search. Refer to the [8.3 branch](https://github.com/elastic/connectors-ruby/tree/8.3) if you're looking for connector packages. Also, read more about them in the [custom connector packages guide](https://www.elastic.co/guide/en/workplace-search/current/custom-connector-package.html).
+- `data source` - file/database/service that provides data to be ingested into Elasticsearch.
+- `connector index` - `.elastic-connectors`, the index to hold connector definitions, e.g. name, service type, configuration, scheduling, etc..
+- `connector job index` - `.elastic-connectors-sync-jobs`, the index to hold sync job history.
+- `connector content index` - The index to hold data for a connector. It has prefix `search-`, and is set in `index_name` of `connector index`.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Connector service documentation (#367)](https://github.com/elastic/connectors-ruby/pull/367)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)