### PR TITLE
tim/allow-strings-and-symbols-for-configurable-fields

### DIFF
--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -24,7 +24,11 @@ module Connectors
         {
           'foo' => {
             'label' => 'Foo',
-            'value' => nil
+            'value' => 'Value'
+          },
+          :bar => {
+            :label => 'Bar',
+            :value => 'Value'
           }
         }
       end

--- a/lib/core/configuration.rb
+++ b/lib/core/configuration.rb
@@ -31,7 +31,7 @@ module Core
           doc[:service_type] = service_type if service_type && connector_settings.needs_service_type?
 
           # We want to set connector to CONFIGURED status if all configurable fields have default values
-          new_connector_status = if configuration.values.all? { |setting| setting[:value].present? }
+          new_connector_status = if configuration.with_indifferent_access.values.all? { |setting| setting[:value].present? }
                                    Utility::Logger.debug("All connector configurable fields provided default values for #{connector_settings.formatted}.")
                                    Connectors::ConnectorStatus::CONFIGURED
                                  else

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -53,7 +53,7 @@ describe Core::Configuration do
       described_class.update(connector_settings)
     end
 
-    context 'when all configurable fields are set' do
+    context 'when all configurable fields are set with symbols' do
       let(:configuration) { { :foo => { :value => 'bar' } } }
 
       it 'updates status to configured' do
@@ -61,6 +61,67 @@ describe Core::Configuration do
           .to receive(:update_connector_fields)
           .with(connector_id,
                 hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+
+        described_class.update(connector_settings, param_service_type)
+      end
+    end
+
+    context 'when all configurable fields are set with strings' do
+      let(:configuration) { { 'foo' => { 'value' => 'bar' } } }
+
+      it 'updates status to configured' do
+        expect(Core::ElasticConnectorActions)
+          .to receive(:update_connector_fields)
+          .with(connector_id,
+                hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+
+        described_class.update(connector_settings, param_service_type)
+      end
+    end
+
+    context 'when all configurable fields are set with a mix of strings and symbols' do
+      let(:configuration) {
+        {
+          'foo' => {
+            'value' => 'Foo'
+          },
+          :bar => {
+            :value => 'Bar'
+          }
+        }
+      }
+
+      it 'updates status to configured' do
+        expect(Core::ElasticConnectorActions)
+          .to receive(:update_connector_fields)
+          .with(connector_id,
+                hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+
+        described_class.update(connector_settings, param_service_type)
+      end
+    end
+
+    context 'when not all configurable fields are set (with strings)' do
+      let(:configuration) { { 'foo' => { 'value' => nil } } }
+
+      it 'updates status to configured' do
+        expect(Core::ElasticConnectorActions)
+          .to receive(:update_connector_fields)
+          .with(connector_id,
+                hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
+
+        described_class.update(connector_settings, param_service_type)
+      end
+    end
+
+    context 'when not all configurable fields are set (with symbols)' do
+      let(:configuration) { { :foo => { :value => nil } } }
+
+      it 'updates status to configured' do
+        expect(Core::ElasticConnectorActions)
+          .to receive(:update_connector_fields)
+          .with(connector_id,
+                hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
         described_class.update(connector_settings, param_service_type)
       end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3005##
 
I think it makes sense to not rely on the assumption, that developers implementing a new connector always use symbols for the self_configurable_fields. Therefore I've added .with_indifferent_access to these fields, updated the tests and added another example to the example-connector, so it's more obvious, that both can be used.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally