### PR TITLE
Revert "Add an elasticsearch client bulk patch to reduce memory usage"

### DIFF
--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -8,10 +8,6 @@
 
 require 'logger'
 require 'elasticsearch'
-require 'elasticsearch/api'
-require 'elasticsearch/api/namespace/common'
-require 'elasticsearch/api/utils'
-require 'elasticsearch/api/response'
 
 module Utility
   class EsClient < ::Elasticsearch::Client
@@ -54,45 +50,10 @@ module Utility
     end
 
     def bulk(arguments = {})
-      raise_if_necessary(patched_bulk(arguments))
+      raise_if_necessary(super(arguments))
     end
 
     private
-
-    # This method is a copy of a method from original Elasticsearch client from here:
-    # https://github.com/elastic/elasticsearch-ruby/blob/8.5/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb#L43
-    # Small (or not so small) problem for us was that the original method clones the arguments.
-    # Sometimes our bulk payload is pretty big and .clone on arguments essentially doubles the amount of memory
-    # that is needed to ingest the data. In our case it's an important thing, thus we copy-pasted the method here
-    # and removed the .clone call.
-    # It produces some overhead for us when updating `elasticsearch` gem - we should check that this function did not change
-    # but it seems like a small price to pay for memory usage reduction.
-    def patched_bulk(arguments = {})
-      headers = arguments.delete(:headers) || {}
-
-      body = arguments.delete(:body)
-
-      index = arguments.delete(:index)
-
-      method = ::Elasticsearch::API::HTTP_POST
-      path = if index
-               "#{Utils.__listify(index)}/_bulk"
-             else
-               '_bulk'
-             end
-      params = ::Elasticsearch::API::Utils.process_params(arguments)
-
-      payload = if body.is_a? Array
-                  ::Elasticsearch::API::Utils.__bulkify(body)
-                else
-                  body
-                end
-
-      headers['Content-Type'] = 'application/x-ndjson'
-      ::Elasticsearch::API::Response.new(
-        perform_request(method, path, params, payload, headers)
-      )
-    end
 
     def raise_if_necessary(response)
       if response['errors']


### PR DESCRIPTION
Reverts elastic/connectors-ruby#364

The change was tested in the batch with the other changes and seemed like something that reduces our memory usage significantly.

After thorough testing I wasn't able to find correlation between this change and actual memory usage reduction, thus reverting it.

A little meta about testing:

The assumption was that `.clone` function is a deep cloning function, but documentation states that it's a _shallow_ copy. `arguments` that are passed into the function for us consists only two properties: `body` and `pipeline` where `body` is an array and `pipeline` is a string.

Therefore shallow clone _should not copy the array_ which is the largest size object there. Testing showed that it's indeed the case and amount of memory is approximately the same.