### PR TITLE
Add metadata to connector protocol and job index mapping

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -228,6 +228,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
   canceled_at: date; -> The date/time when the job is canceled
   completed_at: date; -> The data/time when the job is completed
+  configuration: object; -> Connector configuration
   connector_id: string; -> ID of the connector document in .elastic-connectors
   created_at: date; -> The date/time when the job is created
   deleted_document_count: number; -> Number of documents deleted in the job
@@ -259,8 +260,15 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   indexed_document_volume: number; -> The volume (in bytes) of documents indexed in the job
   last_seen: date; -> Connector writes check-in date-time regularly (UTC)
   metadata: object; -> Connector-specific metadata
+  pipeline: { -> Connector pipeline
+    extract_binary_content: boolean;
+    name: string;
+    reduce_whitespace: boolean;
+    run_ml_inference: boolean;
+  },
   started_at: date; -> The date/time when the job is started
   status: string; -> Job status Enum, see below
+  total_document_count: number; -> Number of documents in the index after the job completes
   trigger_method: string; -> How the job is triggered. Possible values are on-demand, scheduled.
   worker_hostname: string; -> The hostname of the worker to run the job
 }
@@ -285,6 +293,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "cancelation_requested_at" : { "type" : "date" },
     "canceled_at" : { "type" : "date" },
     "completed_at" : { "type" : "date" },
+    "configuration" : { "type" : "object" },
     "connector_id" : { "type" : "keyword" },
     "created_at" : { "type" : "date" },
     "deleted_document_count" : { "type" : "integer" },
@@ -324,8 +333,17 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "indexed_document_volume" : { "type" : "integer" },
     "last_seen" : { "type" : "date" },
     "metadata" : { "type" : "object" },
+    "pipeline" : {
+      "properties" : {
+        "extract_binary_content" : { "type" : "boolean" },
+        "name" : { "type" : "keyword" },
+        "reduce_whitespace" : { "type" : "boolean" },
+        "run_ml_inference" : { "type" : "boolean" }
+      }
+    },
     "started_at" : { "type" : "date" },
     "status" : { "type" : "keyword" },
+    "total_document_count" : { "type" : "integer" },
     "trigger_method" : { "type" : "keyword" },
     "worker_hostname" : { "type" : "keyword" }
   }

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -71,13 +71,12 @@ This is our main communication index, used to communicate the connector's config
   index_name: string;   -> The name of the content index where data will be written to
   is_native: boolean;   -> Whether this is a native connector
   language: string;     -> the language used for the analyzer
-  last_seen: date;      -> Connector writes check-in date-time
-                           regularly (UTC)
+  last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
   last_sync_error: string;   -> Optional last job error message
   last_sync_status: string;  -> Status of the last job, or null if no job has been executed
   last_synced: date;    -> Date/time of last job (UTC)
-  last_indexed_document_count: number;    -> How many documents were indexed in the last job
   last_deleted_document_count: number;    -> How many documents were deleted in the last job
+  last_indexed_document_count: number;    -> How many documents were indexed in the last job
   name: string; -> the name to use for the connector
   pipeline: {
     extract_binary_content: boolean; -> Whether the `request_pipeline` should handle binary data
@@ -198,8 +197,8 @@ This is our main communication index, used to communicate the connector's config
     "last_sync_error" : { "type" : "keyword" },
     "last_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
-    "last_indexed_document_count" : { "type" : "long" },
     "last_deleted_document_count" : { "type" : "long" },
+    "last_indexed_document_count" : { "type" : "long" },
     "name" : { "type" : "keyword" },
     "pipeline" : {
       "properties" : {
@@ -226,10 +225,13 @@ This is our main communication index, used to communicate the connector's config
 In addition to the connector index `.elastic-connectors`, we have an additional index to log all jobs run by connectors. This is the `.elastic-connectors-sync-jobs` index. Each JSON document will have the following structure:
 ```
 {
+  cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
+  canceled_at: date; -> The date/time when the job is canceled
+  completed_at: date; -> The data/time when the job is completed
   connector_id: string; -> ID of the connector document in .elastic-connectors
-  status: string; -> Job status Enum, see below
+  created_at: date; -> The date/time when the job is created
+  deleted_document_count: number; -> Number of documents deleted in the job
   error: string; -> Optional error message
-  trigger_method: string; -> How the job is triggered. Possible values are on-demand, scheduled.
   filtering: {          -> Filtering rules
     domain: string,     -> what data domain these rules apply to
     rules: {
@@ -253,17 +255,14 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     }
   };
   index_name: string; -> The name of the content index
-  worker_hostname: string; -> The hostname of the worker to run the job
   indexed_document_count: number; -> Number of documents indexed in the job
   indexed_document_volume: number; -> The volume (in bytes) of documents indexed in the job
-  deleted_document_count: number; -> Number of documents deleted in the job
+  last_seen: date; -> Connector writes check-in date-time regularly (UTC)
   metadata: object; -> Connector-specific metadata
-  created_at: date; -> The date/time when the job is created
   started_at: date; -> The date/time when the job is started
-  cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
-  canceled_at: date; -> The date/time when the job is canceled
-  completed_at: date; -> The data/time when the job is completed
-  updated_at: date; -> The date/time when the job is updated
+  status: string; -> Job status Enum, see below
+  trigger_method: string; -> How the job is triggered. Possible values are on-demand, scheduled.
+  worker_hostname: string; -> The hostname of the worker to run the job
 }
 ```
 
@@ -283,16 +282,11 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "version" : 1
   },
   "properties" : {
+    "cancelation_requested_at" : { "type" : "date" },
+    "canceled_at" : { "type" : "date" },
     "completed_at" : { "type" : "date" },
     "connector_id" : { "type" : "keyword" },
     "created_at" : { "type" : "date" },
-    "status" : { "type" : "keyword" },
-    "error" : { "type" : "text" },
-    "trigger_method" : { "type" : "keyword" },
-    "index_name" : { "type" : "keyword" },
-    "worker_hostname" : { "type" : "keyword" },
-    "indexed_document_count" : { "type" : "integer" },
-    "indexed_document_volume" : { "type" : "integer" },
     "deleted_document_count" : { "type" : "integer" },
     "error" : { "type" : "keyword" },
     "filtering" : {
@@ -325,16 +319,15 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
         }
       }
     },
+    "index_name" : { "type" : "keyword" },
     "indexed_document_count" : { "type" : "integer" },
-    "status" : { "type" : "keyword" },
-    "worker_hostname" : { "type" : "keyword" }
+    "indexed_document_volume" : { "type" : "integer" },
+    "last_seen" : { "type" : "date" },
     "metadata" : { "type" : "object" },
-    "created_at" : { "type" : "date" },
     "started_at" : { "type" : "date" },
-    "cancelation_requested_at" : { "type" : "date" },
-    "canceled_at" : { "type" : "date" },
-    "completed_at" : { "type" : "date" },
-    "updated_at" : { "type" : "date" }
+    "status" : { "type" : "keyword" },
+    "trigger_method" : { "type" : "keyword" },
+    "worker_hostname" : { "type" : "keyword" }
   }
 }
 ```

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -229,6 +229,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   connector_id: string; -> ID of the connector document in .elastic-connectors
   status: string; -> Job status Enum, see below
   error: string; -> Optional error message
+  trigger_method: string; -> How the job is triggered. Possible values are on-demand, scheduled.
   filtering: {          -> Filtering rules
     domain: string,     -> what data domain these rules apply to
     rules: {
@@ -254,9 +255,15 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   index_name: string; -> The name of the content index
   worker_hostname: string; -> The hostname of the worker to run the job
   indexed_document_count: number; -> Number of documents indexed in the job
+  indexed_document_volume: number; -> The volume (in bytes) of documents indexed in the job
   deleted_document_count: number; -> Number of documents deleted in the job
+  metadata: object; -> Connector-specific metadata
   created_at: date; -> The date/time when the job is created
+  started_at: date; -> The date/time when the job is started
+  cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
+  canceled_at: date; -> The date/time when the job is canceled
   completed_at: date; -> The data/time when the job is completed
+  updated_at: date; -> The date/time when the job is updated
 }
 ```
 
@@ -279,6 +286,13 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "completed_at" : { "type" : "date" },
     "connector_id" : { "type" : "keyword" },
     "created_at" : { "type" : "date" },
+    "status" : { "type" : "keyword" },
+    "error" : { "type" : "text" },
+    "trigger_method" : { "type" : "keyword" },
+    "index_name" : { "type" : "keyword" },
+    "worker_hostname" : { "type" : "keyword" },
+    "indexed_document_count" : { "type" : "integer" },
+    "indexed_document_volume" : { "type" : "integer" },
     "deleted_document_count" : { "type" : "integer" },
     "error" : { "type" : "keyword" },
     "filtering" : {
@@ -314,6 +328,13 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     "indexed_document_count" : { "type" : "integer" },
     "status" : { "type" : "keyword" },
     "worker_hostname" : { "type" : "keyword" }
+    "metadata" : { "type" : "object" },
+    "created_at" : { "type" : "date" },
+    "started_at" : { "type" : "date" },
+    "cancelation_requested_at" : { "type" : "date" },
+    "canceled_at" : { "type" : "date" },
+    "completed_at" : { "type" : "date" },
+    "updated_at" : { "type" : "date" }
   }
 }
 ```

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -71,12 +71,12 @@ This is our main communication index, used to communicate the connector's config
   index_name: string;   -> The name of the content index where data will be written to
   is_native: boolean;   -> Whether this is a native connector
   language: string;     -> the language used for the analyzer
+  last_deleted_document_count: number;    -> How many documents were deleted in the last job
+  last_indexed_document_count: number;    -> How many documents were indexed in the last job  
   last_seen: date;      -> Connector writes check-in date-time regularly (UTC)
   last_sync_error: string;   -> Optional last job error message
   last_sync_status: string;  -> Status of the last job, or null if no job has been executed
   last_synced: date;    -> Date/time of last job (UTC)
-  last_deleted_document_count: number;    -> How many documents were deleted in the last job
-  last_indexed_document_count: number;    -> How many documents were indexed in the last job
   name: string; -> the name to use for the connector
   pipeline: {
     extract_binary_content: boolean; -> Whether the `request_pipeline` should handle binary data
@@ -193,12 +193,12 @@ This is our main communication index, used to communicate the connector's config
     "index_name" : { "type" : "keyword" },
     "is_native" : { "type" : "boolean" },
     "language" : { "type" : "keyword" },
+    "last_deleted_document_count" : { "type" : "long" },
+    "last_indexed_document_count" : { "type" : "long" },
     "last_seen" : { "type" : "date" },
     "last_sync_error" : { "type" : "keyword" },
     "last_sync_status" : { "type" : "keyword" },
     "last_synced" : { "type" : "date" },
-    "last_deleted_document_count" : { "type" : "long" },
-    "last_indexed_document_count" : { "type" : "long" },
     "name" : { "type" : "keyword" },
     "pipeline" : {
       "properties" : {

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -363,6 +363,7 @@ module Core
             :cancelation_requested_at => { :type => :date },
             :canceled_at => { :type => :date },
             :completed_at => { :type => :date },
+            :configuration => { :type => :object },
             :connector_id => { :type => :keyword },
             :created_at => { :type => :date },
             :deleted_document_count => { :type => :integer },
@@ -402,8 +403,17 @@ module Core
             :indexed_document_volume => { :type => :integer },
             :last_seen => { :type => :date },
             :metadata => { :type => :object },
+            :pipeline => {
+              :properties => {
+                :extract_binary_content => { :type => :boolean },
+                :name => { :type => :keyword },
+                :reduce_whitespace => { :type => :boolean },
+                :run_ml_inference => { :type => :boolean }
+              }
+            },
             :started_at => { :type => :date },
             :status => { :type => :keyword },
+            :total_document_count => { :type => :integer },
             :trigger_method => { :type => :keyword },
             :worker_hostname => { :type => :keyword }
           }

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -248,12 +248,99 @@ module Core
           :properties => {
             :api_key_id => { :type => :keyword },
             :configuration => { :type => :object },
-            :error => { :type => :text },
+            :description => { :type => :text },
+            :error => { :type => :keyword },
+            :filtering => {
+              :properties => {
+                :domain => { :type => :keyword },
+                :active => {
+                  :properties => {
+                    :rules => {
+                      :properties => {
+                        :id => { :type => :keyword },
+                        :policy => { :type => :keyword },
+                        :field => { :type => :keyword },
+                        :rule => { :type => :keyword },
+                        :value => { :type => :keyword },
+                        :order => { :type => :short },
+                        :created_at => { :type => :date },
+                        :updated_at => { :type => :date }
+                      }
+                    },
+                    :advanced_snippet => {
+                      :properties => {
+                        :value => { :type => :object },
+                        :created_at => { :type => :date },
+                        :updated_at => { :type => :date }
+                       }
+                    },
+                    :validation => {
+                      :properties => {
+                        :state => { :type => :keyword },
+                        :errors => {
+                          :properties => {
+                            :ids => { :type => :keyword },
+                            :messages => { :type => :text }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                :draft => {
+                  :properties => {
+                    :rules => {
+                      :properties => {
+                        :id => { :type => :keyword },
+                        :policy => { :type => :keyword },
+                        :field => { :type => :keyword },
+                        :rule => { :type => :keyword },
+                        :value => { :type => :keyword },
+                        :order => { :type => :short },
+                        :created_at => { :type => :date },
+                        :updated_at => { :type => :date }
+                      }
+                    },
+                    :advanced_snippet => {
+                      :properties => {
+                        :value => { :type => :object },
+                        :created_at => { :type => :date },
+                        :updated_at => { :type => :date }
+                      }
+                    },
+                    :validation => {
+                      :properties => {
+                        :state => { :type => :keyword },
+                        :errors => {
+                          :properties => {
+                            :ids => { :type => :keyword },
+                            :messages => { :type => :text }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             :index_name => { :type => :keyword },
+            :is_native => { :type => :boolean },
+            :language => { :type => :keyword },
             :last_seen => { :type => :date },
+            :last_sync_error => { :type => :keyword },
+            :last_sync_status => { :type => :keyword },
             :last_synced => { :type => :date },
-            :last_indexed_document_count => { :type => :integer },
-            :last_deleted_document_count => { :type => :integer },
+            :last_deleted_document_count => { :type => :long },
+            :last_indexed_document_count => { :type => :long },
+            :name => { :type => :keyword },
+            :pipeline => {
+              :properties => {
+                :extract_binary_content => { :type => :boolean },
+                :name => { :type => :keyword },
+                :reduce_whitespace => { :type => :boolean },
+                :run_ml_inference => { :type => :boolean }
+              }
+            },
             :scheduling => {
               :properties => {
                 :enabled => { :type => :boolean },
@@ -262,9 +349,7 @@ module Core
             },
             :service_type => { :type => :keyword },
             :status => { :type => :keyword },
-            :sync_error => { :type => :text },
-            :sync_now => { :type => :boolean },
-            :sync_status => { :type => :keyword }
+            :sync_now => { :type => :boolean }
           }
         }
         ensure_index_exists("#{Utility::Constants::CONNECTORS_INDEX}-v1", system_index_body(:alias_name => Utility::Constants::CONNECTORS_INDEX, :mappings => mappings))
@@ -275,22 +360,52 @@ module Core
       def ensure_job_index_exists
         mappings = {
           :properties => {
-            :connector_id => { :type => :keyword },
-            :status => { :type => :keyword },
-            :error => { :type => :text },
-            :trigger_method => { :type => :keyword },
-            :index_name => { :type => :keyword },
-            :worker_hostname => { :type => :keyword },
-            :indexed_document_count => { :type => :integer },
-            :indexed_document_volume => { :type => :integer },
-            :deleted_document_count => { :type => :integer },
-            :metadata => { :type => :object },
-            :created_at => { :type => :date },
-            :started_at => { :type => :date },
             :cancelation_requested_at => { :type => :date },
             :canceled_at => { :type => :date },
             :completed_at => { :type => :date },
-            :updated_at => { :type => :date }
+            :connector_id => { :type => :keyword },
+            :created_at => { :type => :date },
+            :deleted_document_count => { :type => :integer },
+            :error => { :type => :text },
+            :filtering => {
+              :properties => {
+                :domain => { :type => :keyword },
+                :rules => {
+                  :properties => {
+                    :id => { :type => :keyword },
+                    :policy => { :type => :keyword },
+                    :field => { :type => :keyword },
+                    :rule => { :type => :keyword },
+                    :value => { :type => :keyword },
+                    :order => { :type => :short },
+                    :created_at => { :type => :date },
+                    :updated_at => { :type => :date }
+                  }
+                },
+                :advanced_snippet => {
+                  :properties => {
+                    :value => { :type => :object },
+                    :created_at => { :type => :date },
+                    :updated_at => { :type => :date }
+                  }
+                },
+                :warnings => {
+                  :properties => {
+                    :ids => { :type => :keyword },
+                    :messages => { :type => :text }
+                  }
+                }
+              }
+            },
+            :index_name => { :type => :keyword },
+            :indexed_document_count => { :type => :integer },
+            :indexed_document_volume => { :type => :integer },
+            :last_seen => { :type => :date },
+            :metadata => { :type => :object },
+            :started_at => { :type => :date },
+            :status => { :type => :keyword },
+            :trigger_method => { :type => :keyword },
+            :worker_hostname => { :type => :keyword }
           }
         }
         ensure_index_exists("#{Utility::Constants::JOB_INDEX}-v1", system_index_body(:alias_name => Utility::Constants::JOB_INDEX, :mappings => mappings))

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -278,11 +278,19 @@ module Core
             :connector_id => { :type => :keyword },
             :status => { :type => :keyword },
             :error => { :type => :text },
+            :trigger_method => { :type => :keyword },
+            :index_name => { :type => :keyword },
             :worker_hostname => { :type => :keyword },
             :indexed_document_count => { :type => :integer },
+            :indexed_document_volume => { :type => :integer },
             :deleted_document_count => { :type => :integer },
+            :metadata => { :type => :object },
             :created_at => { :type => :date },
-            :completed_at => { :type => :date }
+            :started_at => { :type => :date },
+            :cancelation_requested_at => { :type => :date },
+            :canceled_at => { :type => :date },
+            :completed_at => { :type => :date },
+            :updated_at => { :type => :date }
           }
         }
         ensure_index_exists("#{Utility::Constants::JOB_INDEX}-v1", system_index_body(:alias_name => Utility::Constants::JOB_INDEX, :mappings => mappings))


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3193

This PR adds generic and connector-specific metadata to connector protocol and job index mapping