### PR TITLE
[8.5] Make better use of memory for Mongo connector when iterating over documents (#362)

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -13,6 +13,8 @@ require 'mongo'
 module Connectors
   module MongoDB
     class Connector < Connectors::Base::Connector
+      PAGE_SIZE = 100
+
       def self.service_type
         'mongodb'
       end
@@ -57,10 +59,23 @@ module Connectors
 
       def yield_documents
         with_client do |client|
-          client[@collection].find.each do |document|
-            doc = document.with_indifferent_access
+          # We do paging using skip().limit() here to make Ruby recycle the memory for each page pulled from the server after it's not needed any more.
+          # This gives us more control on the usage of the memory (we can adjust PAGE_SIZE constant for that to decrease max memory consumption).
+          # It's done due to the fact that usage of .find.each leads to memory leaks or overuse of memory - the whole result set seems to stay in memory
+          # during the sync. Sometimes (not 100% sure) it even leads to a real leak, when the memory for these objects is never recycled.
+          cursor = client[@collection].find
+          skip = 0
 
-            yield serialize(doc)
+          loop do
+            found_count = 0
+            view = cursor.skip(skip).limit(PAGE_SIZE)
+            view.each do |document|
+              yield serialize(document)
+              found_count += 1
+            end
+
+            break if found_count == 0
+            skip += PAGE_SIZE
           end
         end
       end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Make better use of memory for Mongo connector when iterating over documents (#362)](https://github.com/elastic/connectors-ruby/pull/362)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)