### PR TITLE
[8.5] Optimize lifecycle of MongoDB client (#363)

### DIFF
--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -54,7 +54,7 @@ describe Connectors::MongoDB::Connector do
   let(:actual_database_names) { ['sample-database'] }
 
   before(:each) do
-    allow(Mongo::Client).to receive(:new).and_return(mongo_client)
+    allow(Mongo::Client).to receive(:new).and_yield(mongo_client)
 
     allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
     allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
@@ -70,14 +70,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   it_behaves_like 'a connector'
-
-  shared_examples_for 'closes a client in the end' do
-    it '' do
-      expect(mongo_client).to receive(:close)
-
-      subject.is_healthy?
-    end
-  end
 
   shared_examples_for 'handles auth' do
     context 'when username and password are provided' do
@@ -120,7 +112,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   context '#is_healthy?' do
-    it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.is_healthy? }
     end
@@ -133,7 +124,6 @@ describe Connectors::MongoDB::Connector do
   end
 
   context '#yield_documents' do
-    it_behaves_like 'closes a client in the end'
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.yield_documents { |doc|; } }
     end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Optimize lifecycle of MongoDB client (#363)](https://github.com/elastic/connectors-ruby/pull/363)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)