### PR TITLE
[8.5] Fix: Inform user about MongoDB connection errors (invalid database/collection) (#368)

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -101,12 +101,30 @@ module Connectors
         end
 
         Mongo::Client.new(@host, args) do |client|
-          Utility::Logger.debug("Existing Databases #{client.database_names}")
-          Utility::Logger.debug('Existing Collections:')
-          client.collections.each { |coll| Utility::Logger.debug(coll.name) }
+          databases = client.database_names
+
+          Utility::Logger.debug("Existing Databases: #{databases}")
+          check_database_exists!(databases, @database)
+
+          collections = client.database.collection_names
+
+          Utility::Logger.debug("Existing Collections: #{collections}")
+          check_collection_exists!(collections, @database, @collection)
 
           yield client
         end
+      end
+
+      def check_database_exists!(databases, database)
+        return if databases.include?(database)
+
+        raise "Database (#{database}) does not exist. Existing databases: #{databases.join(', ')}"
+      end
+
+      def check_collection_exists!(collections, database, collection)
+        return if collections.include?(collection)
+
+        raise "Collection (#{collection}) does not exist within database '#{database}'. Existing collections: #{collections.join(', ')}"
       end
 
       def serialize(mongodb_document)

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -37,7 +37,7 @@ describe Connectors::MongoDB::Connector do
 
   let(:mongodb_host) { '127.0.0.1:27027' }
   let(:mongodb_database) { 'sample-database' }
-  let(:mongodb_collection) { 'some-collection' }
+  let(:mongodb_collection) { 'sample-collection' }
   let(:mongodb_username) { nil }
   let(:mongodb_password) { nil }
   let(:direct_connection) { 'false' }
@@ -45,6 +45,8 @@ describe Connectors::MongoDB::Connector do
   let(:mongo_client) { double }
 
   let(:actual_collection) { double }
+  let(:actual_collection_name) { 'sample-collection' }
+  let(:actual_collection_names) { [actual_collection_name] }
   let(:actual_collection_data) { [] }
   let(:actual_collection_name) { 'sample-collection' }
   let(:actual_collection_names) { [actual_collection_name] }
@@ -53,11 +55,15 @@ describe Connectors::MongoDB::Connector do
   let(:actual_database) { double }
   let(:actual_database_names) { ['sample-database'] }
 
+  let(:actual_database) { double }
+  let(:actual_database_names) { ['sample-database'] }
+
   before(:each) do
     allow(Mongo::Client).to receive(:new).and_yield(mongo_client)
 
-    allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => mongodb_collection })])
-    allow(mongo_client).to receive(:database_names).and_return([Hashie::Mash.new({ :name => mongodb_database })])
+    allow(mongo_client).to receive(:collections).and_return([Hashie::Mash.new({ :name => actual_collection_name })])
+    allow(mongo_client).to receive(:database).and_return(actual_database)
+    allow(mongo_client).to receive(:database_names).and_return(actual_database_names)
     allow(mongo_client).to receive(:[]).with(mongodb_collection).and_return(actual_collection)
     allow(mongo_client).to receive(:with).and_return(mongo_client)
     allow(mongo_client).to receive(:close)
@@ -132,24 +138,18 @@ describe Connectors::MongoDB::Connector do
     end
 
     context 'when database is not found' do
-      xit 'no error is raised' do
-        # Leaving this here to describe the work of MongoDB client:
-        # When database is not found on the server, the client does not raise errors
-        # Instead, it acts as if a database exists on server, but has no collections
-        # So every call to .collection will return empty iterator.
+      let(:mongodb_database) { 'non-existing-database' }
+
+      it 'does raise' do
+        expect { |b| subject.yield_documents(&b) }.to raise_error(anything)
       end
     end
 
     context 'when collection is not found' do
-      # mongo client does not raise an error when collection is not found on the server, instead it just returns an empty collection
-      let(:actual_collection_data) { [] }
+      let(:mongodb_collection) { 'non-existing-collection' }
 
-      it 'does not raise' do
-        expect { |b| subject.yield_documents(&b) }.to_not raise_error(anything)
-      end
-
-      it 'does not yield' do
-        expect { |b| subject.yield_documents(&b) }.to_not yield_with_args(anything)
+      it 'does raise' do
+        expect { |b| subject.yield_documents(&b) }.to raise_error(anything)
       end
     end
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Fix: Inform user about MongoDB connection errors (invalid database/collection) (#368)](https://github.com/elastic/connectors-ruby/pull/368)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)