### PR TITLE
[8.5] Add Authentication checks to preflight check and connector settings retrieval (#372)

### DIFF
--- a/lib/app/preflight_check.rb
+++ b/lib/app/preflight_check.rb
@@ -75,6 +75,10 @@ module App
           else
             raise UnhealthyCluster, "Unexpected cluster status: #{response['status']}"
           end
+        rescue *Utility::AUTHORIZATION_ERRORS => e
+          Utility::ExceptionTracking.log_exception(e)
+
+          fail_check!("Elasticsearch returned 'Unauthorized' response. Check your authentication details. Terminating...")
         rescue *App::RETRYABLE_CONNECTION_ERRORS => e
           Utility::Logger.warn('Could not connect to Elasticsearch. Make sure it is running and healthy.')
           Utility::Logger.debug("Error: #{e.full_message}")

--- a/lib/core/native_scheduler.rb
+++ b/lib/core/native_scheduler.rb
@@ -16,6 +16,9 @@ module Core
   class NativeScheduler < Core::Scheduler
     def connector_settings
       Core::ConnectorSettings.fetch_native_connectors || []
+    rescue *Utility::AUTHORIZATION_ERRORS => e
+      # should be handled by the general scheduler
+      raise e
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, 'Could not retrieve native connectors due to unexpected error.')
       []

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -41,6 +41,8 @@ module Core
         if @is_shutting_down
           break
         end
+      rescue *Utility::AUTHORIZATION_ERRORS => e
+        Utility::ExceptionTracking.log_exception(e, 'Could not retrieve connectors settings due to authorization error.')
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
       ensure

--- a/lib/core/single_scheduler.rb
+++ b/lib/core/single_scheduler.rb
@@ -21,6 +21,9 @@ module Core
     def connector_settings
       connector_settings = Core::ConnectorSettings.fetch_by_id(@connector_id)
       [connector_settings]
+    rescue *Utility::AUTHORIZATION_ERRORS => e
+      # should be handled by the general scheduler
+      raise e
     rescue StandardError => e
       Utility::ExceptionTracking.log_exception(e, "Could not retrieve the connector by id #{@connector_id} due to unexpected error.")
       []

--- a/lib/utility/errors.rb
+++ b/lib/utility/errors.rb
@@ -5,6 +5,7 @@
 #
 
 require 'active_support/core_ext/string'
+require 'elasticsearch'
 
 module Utility
   class DocumentError
@@ -89,6 +90,7 @@ module Utility
   class InvalidTokenError < StandardError; end
   class TokenRefreshFailedError < StandardError; end
   class ConnectorNotAvailableError < StandardError; end
+  class AuthorizationError < StandardError; end
 
   # For when we want to explicitly set a #cause but can't
   class ExplicitlyCausedError < StandardError
@@ -124,6 +126,7 @@ module Utility
     end
   end
 
+  AUTHORIZATION_ERRORS = [Elastic::Transport::Transport::Errors::Unauthorized]
   INTERNAL_SERVER_ERROR = Utility::Error.new(500, 'INTERNAL_SERVER_ERROR', 'Internal server error')
   INVALID_API_KEY = Utility::Error.new(401, 'INVALID_API_KEY', 'Invalid API key')
   UNSUPPORTED_AUTH_SCHEME = Utility::Error.new(401, 'UNSUPPORTED_AUTH_SCHEME', 'Unsupported authorization scheme')

--- a/spec/app/preflight_check_spec.rb
+++ b/spec/app/preflight_check_spec.rb
@@ -141,6 +141,19 @@ describe App::PreflightCheck do
               expect { described_class.run! }.to raise_error(described_class::CheckFailure)
             end
           end
+
+          context 'when authorization error appears' do
+            let(:connector_index_exist) { true }
+            let(:job_index_exist) { true }
+
+            before(:each) do
+              allow(client).to receive_message_chain(:cluster, :health).and_raise(Elastic::Transport::Transport::Errors::Unauthorized)
+            end
+
+            it 'should fail the check' do
+              expect { described_class.run! }.to raise_error(described_class::CheckFailure)
+            end
+          end
         end
       end
     end

--- a/spec/core/native_scheduler_spec.rb
+++ b/spec/core/native_scheduler_spec.rb
@@ -28,5 +28,15 @@ describe Core::NativeScheduler do
         expect(subject.connector_settings).to be_empty
       end
     end
+
+    context 'when authorization error appears' do
+      before(:each) do
+        allow(Core::ConnectorSettings).to receive(:fetch_native_connectors).and_raise(Elastic::Transport::Transport::Errors::Unauthorized, 'Unauthorized')
+      end
+
+      it 'rethrows error' do
+        expect { subject.connector_settings }.to raise_error(Elastic::Transport::Transport::Errors::Unauthorized, 'Unauthorized')
+      end
+    end
   end
 end

--- a/spec/core/single_scheduler_spec.rb
+++ b/spec/core/single_scheduler_spec.rb
@@ -29,5 +29,15 @@ describe Core::SingleScheduler do
         expect(subject.connector_settings).to be_empty
       end
     end
+
+    context 'when authorization error appears' do
+      before(:each) do
+        allow(Core::ConnectorSettings).to receive(:fetch_by_id).and_raise(Elastic::Transport::Transport::Errors::Unauthorized, 'Unauthorized')
+      end
+
+      it 'rethrows error' do
+        expect { subject.connector_settings }.to raise_error(Elastic::Transport::Transport::Errors::Unauthorized, 'Unauthorized')
+      end
+    end
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Add Authentication checks to preflight check and connector settings retrieval (#372)](https://github.com/elastic/connectors-ruby/pull/372)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)