### PR TITLE
[8.5] Allow strings and symbols for configurable fields in connectors (#380)

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -11,12 +11,18 @@ require 'core/output_sink'
 require 'utility/exception_tracking'
 require 'utility/errors'
 require 'app/config'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Connectors
   module Base
     class Connector
       def self.display_name
         raise 'Not implemented for this connector'
+      end
+
+      # Used as a framework util method, don't override
+      def self.configurable_fields_indifferent_access
+        configurable_fields.with_indifferent_access
       end
 
       def self.configurable_fields

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -20,11 +20,16 @@ module Connectors
         'Example Connector'
       end
 
+      # Field 'Foo' won't have a default value. Field 'Bar' will have the default value 'Value'.
       def self.configurable_fields
         {
           'foo' => {
             'label' => 'Foo',
             'value' => nil
+          },
+          :bar => {
+            :label => 'Bar',
+            :value => 'Value'
           }
         }
       end

--- a/lib/core/configuration.rb
+++ b/lib/core/configuration.rb
@@ -23,7 +23,7 @@ module Core
             Utility::Logger.error("Couldn't find connector for service type #{connector_settings.service_type || service_type}")
             return
           end
-          configuration = connector_class.configurable_fields
+          configuration = connector_class.configurable_fields_indifferent_access
           doc = {
             :configuration => configuration
           }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Allow strings and symbols for configurable fields in connectors (#380)](https://github.com/elastic/connectors-ruby/pull/380)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)