### PR TITLE
[8.5] Termination of connectors shows error (#381)

### DIFF
--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -54,6 +54,12 @@ module Connectors
 
         attachments.each_with_index do |att, index|
           data = { id: (index + 1).to_s, name: "example document #{index + 1}", _attachment: File.read(att) }
+
+          # Uncomment one of these two lines to simulate longer running sync jobs
+          #
+          # sleep(rand(10..60).seconds)
+          # sleep(rand(1..10).minutes)
+
           yield data
         end
       end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -24,6 +24,7 @@ module Core
       @sink = Core::OutputSink::EsSink.new(connector_settings.index_name, @connector_settings.request_pipeline)
       @connector_class = Connectors::REGISTRY.connector_class(connector_settings.service_type)
       @connector_instance = Connectors::REGISTRY.connector(connector_settings.service_type, connector_settings.configuration)
+      @sync_finished = false
       @status = {
         :indexed_document_count => 0,
         :deleted_document_count => 0,
@@ -75,6 +76,10 @@ module Core
         end
 
         @sink.flush
+
+        # We use this mechanism for checking, whether an interrupt (or something else lead to the thread not finishing)
+        # occurred as most of the time the main execution thread is interrupted and we miss this Signal/Exception here
+        @sync_finished = true
       rescue StandardError => e
         @status[:error] = e.message
         Utility::ExceptionTracking.log_exception(e)
@@ -83,10 +88,15 @@ module Core
         Utility::Logger.info("Upserted #{@status[:indexed_document_count]} documents into #{@connector_settings.index_name}.")
         Utility::Logger.info("Deleted #{@status[:deleted_document_count]} documents into #{@connector_settings.index_name}.")
 
+        # Make sure to not override a previous error message
+        if !@sync_finished && @status[:error].nil?
+          @status[:error] = 'Sync thread didn\'t finish execution. Check connector logs for more details.'
+        end
+
         ElasticConnectorActions.complete_sync(@connector_settings.id, job_id, @status.dup)
 
         if @status[:error]
-          Utility::Logger.info("Failed to sync for connector #{@connector_settings.id} with error #{@status[:error]}.")
+          Utility::Logger.info("Failed to sync for connector #{@connector_settings.id} with error '#{@status[:error]}'.")
         else
           Utility::Logger.info("Successfully synced for connector #{@connector_settings.id}.")
         end

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -132,6 +132,25 @@ describe Core::SyncJobRunner do
       subject.execute
     end
 
+    it 'marks the sync as finished' do
+      subject.execute
+
+      expect(subject.instance_variable_get(:@sync_finished)).to eq(true)
+    end
+
+    context 'when an error occurs' do
+      before(:each) do
+        allow(connector_instance).to receive(:do_health_check!).and_raise(StandardError.new('error message'))
+      end
+
+      it 'marks the sync as unfinished without overriding the error message with the thread error message' do
+        subject.execute
+
+        expect(subject.instance_variable_get(:@sync_finished)).to eq(false)
+        expect(subject.instance_variable_get(:@status)[:error]).to eq('error message')
+      end
+    end
+
     context 'when a bunch of documents are returned from 3rd-party system' do
       let(:doc1) do
         {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Termination of connectors shows error (#381)](https://github.com/elastic/connectors-ruby/pull/381)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)