### PR TITLE
Persist filtering in job records

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -129,7 +129,7 @@ module Core
             'domain' => filtering_domain['domain'],
             'rules' => filtering_domain.dig('active', 'rules'),
             'advanced_snippet' => filtering_domain.dig('active', 'advanced_snippet'),
-            'warnings' => [] # TODO in https://github.com/elastic/enterprise-search-team/issues/3174
+            'warnings' => [] # TODO: in https://github.com/elastic/enterprise-search-team/issues/3174
           }
         end
       end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -41,8 +41,8 @@ module Core
     def do_sync!
       Utility::Logger.info("Claiming a sync job for connector #{@connector_settings.id}.")
 
-      job = ElasticConnectorActions.claim_job(@connector_settings.id)
-      job_id = job['_id']
+      job_description = ElasticConnectorActions.claim_job(@connector_settings.id)
+      job_id = job_description['_id']
 
       unless job_id.present?
         Utility::Logger.error("Failed to claim the job for #{@connector_settings.id}. Please check the logs for the cause of this error.")
@@ -52,8 +52,6 @@ module Core
       begin
         Utility::Logger.debug("Successfully claimed job for connector #{@connector_settings.id}.")
 
-        # will be replaced when job claiming returns full job description object
-        job_description = { :filtering => @connector_settings.filtering }
         connector_instance = Connectors::REGISTRY.connector(@connector_settings.service_type, @connector_settings.configuration, job_description: job_description)
 
         connector_instance.do_health_check!

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -41,7 +41,8 @@ module Core
     def do_sync!
       Utility::Logger.info("Claiming a sync job for connector #{@connector_settings.id}.")
 
-      job_id = ElasticConnectorActions.claim_job(@connector_settings.id)
+      job = ElasticConnectorActions.claim_job(@connector_settings.id)
+      job_id = job['_id']
 
       unless job_id.present?
         Utility::Logger.error("Failed to claim the job for #{@connector_settings.id}. Please check the logs for the cause of this error.")

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -465,9 +465,6 @@ describe Core::ElasticConnectorActions do
         it_behaves_like 'job filtering'
       end
     end
-
-    context
-
   end
 
   context '#update_connector_status' do

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -41,6 +41,11 @@ describe Core::SyncJobRunner do
   let(:extracted_documents) { [] } # documents returned from 3rd-party system
 
   let(:job_id) { 'job-123' }
+  let(:job_definition) do
+    {
+      '_id' => job_id
+    }
+  end
 
   let(:extract_binary_content) { true }
   let(:reduce_whitespace) { true }
@@ -51,7 +56,7 @@ describe Core::SyncJobRunner do
   before(:each) do
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
 
-    allow(Core::ElasticConnectorActions).to receive(:claim_job).and_return(job_id)
+    allow(Core::ElasticConnectorActions).to receive(:claim_job).and_return(job_definition)
     allow(Core::ElasticConnectorActions).to receive(:fetch_document_ids).and_return(existing_document_ids)
     allow(Core::ElasticConnectorActions).to receive(:complete_sync)
     allow(Core::ElasticConnectorActions).to receive(:update_connector_status)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3149


looks up the filtering rules in `.elastic-connectors` and saves them into `.elastic-connectors-sync-jobs`.

With latest Kibana, choosing "build a connector", running the example connector, and triggering a sync, you get a `.elastic-connectors-sync-jobs` record like:

```
     {
        "_index": ".elastic-connectors-sync-jobs-v1",
        "_id": "_mEnRIQB5rPmQXyEqZAB",
        "_score": 1,
        "_source": {
          "connector_id": "9WEjRIQB5rPmQXyEWJB2",
          "status": "completed",
          "worker_hostname": "Seans-MacBook-Pro-2.local",
          "created_at": "2022-11-04T19:39:20.699+00:00",
          "filtering": [
            {
              "domain": "DEFAULT",
              "rules": [
                {
                  "created_at": "2022-11-04T19:34:37.926Z",
                  "field": "_",
                  "id": "DEFAULT",
                  "order": 0,
                  "policy": "include",
                  "rule": "regex",
                  "updated_at": "2022-11-04T19:34:37.926Z",
                  "value": ".*"
                }
              ],
              "advanced_snippet": {
                "created_at": "2022-11-04T19:34:37.926Z",
                "updated_at": "2022-11-04T19:34:37.926Z",
                "value": {}
              },
              "warnings": []
            }
          ],
          "indexed_document_count": 3,
          "completed_at": "2022-11-04T19:39:21.315+00:00",
          "deleted_document_count": 0,
          "error": null
        }
      },
```

## Checklists


#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally


## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->


## For Elastic Internal Use Only
- [x] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
  - PR: https://github.com/elastic/ent-search/pull/7012
