### PR TITLE
Ensure connector instantiations line up

### DIFF
--- a/connectors_service.gemspec
+++ b/connectors_service.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'lib/app/config'
+
 Gem::Specification.new do |s|
   s.name        = 'connectors_service'
-  s.version     = `cat VERSION`
+  s.version     = App::Config[:version]
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing Elastic connectors service'
   s.description = ''

--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
                     lib/connectors_utility.rb
                     lib/utility/es_client.rb
                     lib/utility/logger.rb
+                    lib/utility/common.rb
                     lib/utility/constants.rb
                     lib/utility/cron.rb
                     lib/utility/errors.rb

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -36,7 +36,7 @@ module Connectors
 
       def initialize(configuration: {}, job_description: {})
         @configuration = configuration.dup || {}
-        @job_description = job_description.dup || {}
+        @job_description = job_description&.dup || {}
 
         filter = get_filter(@job_description[:filtering])
 

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -34,7 +34,7 @@ module Connectors
         }
       end
 
-      def initialize(configuration: {})
+      def initialize(configuration: {}, job_description: {})
         super
       end
 

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -36,7 +36,7 @@ module Connectors
         }
       end
 
-      def initialize(configuration: {})
+      def initialize(configuration: {}, job_description: {})
         super
 
         @extractor = Connectors::GitLab::Extractor.new(

--- a/lib/connectors/registry.rb
+++ b/lib/connectors/registry.rb
@@ -24,7 +24,7 @@ module Connectors
       @connectors[name]
     end
 
-    def connector(name, configuration, job_description)
+    def connector(name, configuration, job_description: {})
       klass = connector_class(name)
       if klass.present?
         return klass.new(configuration: configuration, job_description: job_description)

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -53,7 +53,7 @@ module Core
 
         # will be replaced when job claiming returns full job description object
         job_description = { :filtering => @connector_settings.filtering }
-        connector_instance = Connectors::REGISTRY.connector(@connector_settings.service_type, @connector_settings.configuration, job_description)
+        connector_instance = Connectors::REGISTRY.connector(@connector_settings.service_type, @connector_settings.configuration, job_description: job_description)
 
         connector_instance.do_health_check!
 


### PR DESCRIPTION
See https://elastic.slack.com/archives/C03GAPTQ2JF/p1667590997792289

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally


## Related Pull Requests

* https://github.com/elastic/connectors-ruby/pull/385 introduced a new `job_description` argument for connectors, but we weren't consistent about its usage, and non-mongo connectors couldn't be created.

