### PR TITLE
Use key specified in connectors mapping for advanced filter config

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -41,7 +41,7 @@ module Connectors
         filter = get_filter(@job_description[:filtering])
 
         @rules = Utility::Common.return_if_present(filter[:rules], [])
-        @advanced_filter_config = Utility::Common.return_if_present(filter[:advanced_config], {})
+        @advanced_filter_config = Utility::Common.return_if_present(filter[:advanced_snippet], {})
       end
 
       def yield_documents; end

--- a/spec/connectors/base/connector_spec.rb
+++ b/spec/connectors/base/connector_spec.rb
@@ -11,7 +11,7 @@ require 'connectors/base/connector'
 describe Connectors::Base::Connector do
   subject { described_class.new(job_description: job_description) }
 
-  let(:advanced_config) {
+  let(:advanced_snippet) {
     {
       :find => {
         :filter => {
@@ -45,7 +45,7 @@ describe Connectors::Base::Connector do
 
   let(:filtering) {
     {
-      :advanced_config => advanced_config,
+      :advanced_snippet => advanced_snippet,
       :rules => rules
     }
   }
@@ -57,32 +57,32 @@ describe Connectors::Base::Connector do
   }
 
   context '.advanced_filter_config?' do
-    shared_examples_for 'advanced_config is not present' do
+    shared_examples_for 'advanced_filter_config is not present' do
       it 'returns empty object' do
         expect(subject.advanced_filter_config).to be_empty
       end
     end
 
-    context 'advanced config is present' do
+    context 'advanced filter config is present' do
       it 'returns advanced filter config' do
-        expect(subject.advanced_filter_config).to eq(advanced_config)
+        expect(subject.advanced_filter_config).to eq(advanced_snippet)
       end
     end
 
-    context 'advanced config is nil' do
-      let(:advanced_config) {
+    context 'advanced filter config is nil' do
+      let(:advanced_snippet) {
         nil
       }
 
-      it_behaves_like 'advanced_config is not present'
+      it_behaves_like 'advanced_filter_config is not present'
     end
 
-    context 'advanced config is empty' do
-      let(:advanced_config) {
+    context 'advanced filter config is empty' do
+      let(:advanced_snippet) {
         {}
       }
 
-      it_behaves_like 'advanced_config is not present'
+      it_behaves_like 'advanced_filter_config is not present'
     end
   end
 
@@ -129,7 +129,7 @@ describe Connectors::Base::Connector do
       end
     end
 
-    context 'rules and advanced_config are present' do
+    context 'rules and advanced filter config are present' do
       it_behaves_like 'filtering is present'
     end
 
@@ -149,40 +149,40 @@ describe Connectors::Base::Connector do
       it_behaves_like 'filtering is present'
     end
 
-    context 'only advanced_config is empty' do
-      let(:advanced_config) {
+    context 'only advanced filter config is empty' do
+      let(:advanced_snippet) {
         {}
       }
 
       it_behaves_like 'filtering is present'
     end
 
-    context 'only advanced_config is nil' do
-      let(:advanced_config) {
+    context 'only advanced filter config is nil' do
+      let(:advanced_snippet) {
         nil
       }
 
       it_behaves_like 'filtering is present'
     end
 
-    context 'rules are empty and advanced_config is empty' do
+    context 'rules are empty and advanced filter config is empty' do
       let(:rules) {
         []
       }
 
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {}
       }
 
       it_behaves_like 'filtering is not present'
     end
 
-    context 'rules are nil and advanced_config is nil' do
+    context 'rules are nil and advanced filter config is nil' do
       let(:rules) {
         nil
       }
 
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         nil
       }
 
@@ -256,7 +256,7 @@ describe Connectors::Base::Connector do
         it 'extracts the advanced filter config' do
           advanced_filter_config = subject.advanced_filter_config
 
-          expect(advanced_filter_config).to eq(advanced_config)
+          expect(advanced_filter_config).to eq(advanced_snippet)
         end
       end
 
@@ -270,7 +270,7 @@ describe Connectors::Base::Connector do
       end
 
       context 'filter config is nil' do
-        let(:advanced_config) {
+        let(:advanced_snippet) {
           nil
         }
 
@@ -278,7 +278,7 @@ describe Connectors::Base::Connector do
       end
 
       context 'filter config is empty' do
-        let(:advanced_config) {
+        let(:advanced_snippet) {
           {}
         }
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -87,7 +87,7 @@ describe Connectors::MongoDB::Connector do
     }
   }
 
-  let(:advanced_config) {
+  let(:advanced_snippet) {
     {
       :find => find
     }
@@ -96,7 +96,7 @@ describe Connectors::MongoDB::Connector do
   let(:filtering) {
     {
       :rules => rules,
-      :advanced_config => advanced_config
+      :advanced_snippet => advanced_snippet
     }
   }
 
@@ -292,7 +292,7 @@ describe Connectors::MongoDB::Connector do
             }
           }
 
-          let(:advanced_config) {
+          let(:advanced_snippet) {
             {
               :find => {
                 :options => options
@@ -316,7 +316,7 @@ describe Connectors::MongoDB::Connector do
             }
           }
 
-          let(:advanced_config) {
+          let(:advanced_snippet) {
             {
               :find => {
                 :options => options
@@ -443,7 +443,7 @@ describe Connectors::MongoDB::Connector do
 
     context 'rules and advanced filtering config are empty' do
       let(:rules) { [] }
-      let(:advanced_config) { {} }
+      let(:advanced_snippet) { {} }
 
       it 'calls find without arguments' do
         expect(actual_collection).to receive(:find).with(no_args)
@@ -453,7 +453,7 @@ describe Connectors::MongoDB::Connector do
     end
 
     context 'find and aggregate exist' do
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :find => {
             :filter => filter,
@@ -537,7 +537,7 @@ describe Connectors::MongoDB::Connector do
 
     context 'aggregate field exists (with pipeline and options) in an active advanced filtering config' do
       # find should not exist
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :aggregate => aggregate
         }
@@ -560,7 +560,7 @@ describe Connectors::MongoDB::Connector do
       }
 
       # find should not exist
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :aggregate => aggregate
         }
@@ -583,7 +583,7 @@ describe Connectors::MongoDB::Connector do
       }
 
       # find should not exist
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :aggregate => aggregate
         }
@@ -604,7 +604,7 @@ describe Connectors::MongoDB::Connector do
         }
       }
 
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :aggregate => aggregate
         }
@@ -618,7 +618,7 @@ describe Connectors::MongoDB::Connector do
     end
 
     context 'wrong top level keys exist' do
-      let(:advanced_config) {
+      let(:advanced_snippet) {
         {
           :wrong_key_one => {},
           :wrong_key_two => {},

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -71,7 +71,7 @@ describe Core::ConnectorSettings do
               :domain => 'DEFAULT',
               :active => {
                 :rules => [],
-                :advanced_config => {},
+                :advanced_snippet => {},
               }
             }
           ]
@@ -84,7 +84,7 @@ describe Core::ConnectorSettings do
 
         expect(first_filter[:domain]).to eq('DEFAULT')
         expect(first_filter[:active][:rules]).to_not be_nil
-        expect(first_filter[:active][:advanced_config]).to_not be_nil
+        expect(first_filter[:active][:advanced_snippet]).to_not be_nil
       end
     end
 


### PR DESCRIPTION
## Relates to elastic/enterprise-search-team#3150 ###

This PR changes the key used for extracting the advanced filter config to reflect the key used in the connectors mapping.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests

* https://github.com/elastic/connectors-ruby/pull/385
