### PR TITLE
Add filtering validation (advanced config) support to the framework

### DIFF
--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -73,6 +73,8 @@ module App
             start_heartbeat_task(connector_settings)
           when :configuration
             start_configuration_task(connector_settings)
+          when :filter_validation
+            start_filter_validation_task(connector_settings)
           else
             Utility::Logger.error("Unknown task type: #{task}. Skipping...")
           end
@@ -118,6 +120,16 @@ module App
           Core::Configuration.update(connector_settings, service_type)
         rescue StandardError => e
           Utility::ExceptionTracking.log_exception(e, "Configuration task for #{connector_settings.formatted} failed due to unexpected error.")
+        end
+      end
+
+      def start_filter_validation_task(connector_settings)
+        pool.post do
+          Utility::Logger.info("Validating filters for #{connector_settings.formatted}...")
+          validation_job_runner = Core::Filtering::ValidationJobRunner.new(connector_settings)
+          validation_job_runner.execute
+        rescue StandardError => e
+          Utility::ExceptionTracking.log_exception(e, "Filter validation task for #{connector_settings.formatted} failed due to unexpected error.")
         end
       end
     end

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -32,16 +32,20 @@ module Connectors
         raise 'Not implemented for this connector'
       end
 
+      def self.validate_filtering(_filtering = {})
+        raise 'Not implemented for this connector'
+      end
+
       attr_reader :rules, :advanced_filter_config
 
       def initialize(configuration: {}, job_description: {})
         @configuration = configuration.dup || {}
         @job_description = job_description&.dup || {}
 
-        filter = get_filter(@job_description[:filtering])
+        filtering = @job_description[:filtering] || {}
 
-        @rules = Utility::Common.return_if_present(filter[:rules], [])
-        @advanced_filter_config = Utility::Common.return_if_present(filter[:advanced_config], {})
+        @rules = filtering[:rules] || []
+        @advanced_filter_config = filtering[:advanced_snippet] || {}
       end
 
       def yield_documents; end
@@ -68,15 +72,6 @@ module Connectors
 
       def filtering_present?
         @advanced_filter_config.present? || @rules.present?
-      end
-
-      private
-
-      def get_filter(filtering)
-        # assume for now, that first object in filtering array or a filter object itself is the only filtering object
-        filter = filtering.is_a?(Array) ? filtering[0] : filtering
-
-        filter.present? ? filter : {}
       end
     end
   end

--- a/lib/connectors/example/connector.rb
+++ b/lib/connectors/example/connector.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require 'connectors/base/connector'
+require 'core/filtering/validation_status'
 require 'utility'
 
 module Connectors
@@ -43,6 +44,13 @@ module Connectors
         #
         # To emulate unhealthy 3rd-party system situation, uncomment the following line:
         # raise 'something went wrong'
+      end
+
+      def self.validate_filtering(filtering = {})
+        # TODO: real filtering validation will follow later
+        return { :state => Core::Filtering::ValidationStatus::INVALID, :errors => ['Filtering not implemented yet for MongoDB'] } if filtering.present?
+
+        { :state => Core::Filtering::ValidationStatus::VALID, :errors => [] }
       end
 
       def yield_documents

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -36,6 +36,13 @@ module Connectors
         }
       end
 
+      def self.validate_filtering(filtering = {})
+        # TODO: real filtering validation will follow later
+        return { :state => Core::Filtering::ValidationStatus::INVALID, :errors => ['No Filtering implemented yet for GitLab connector'] } if filtering.present?
+
+        { :state => Core::Filtering::ValidationStatus::VALID, :errors => [] }
+      end
+
       def initialize(configuration: {}, job_description: {})
         super
 

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -83,7 +83,12 @@ module Core
     end
 
     def filtering
-      Utility::Common.return_if_present(@elasticsearch_response[:filtering], DEFAULT_FILTERING)
+      # assume for now, that first object in filtering array or a filter object itself is the only filtering object
+      filtering = @elasticsearch_response[:filtering]
+
+      filter = filtering.is_a?(Array) ? filtering[0] : filtering
+
+      filter.present? ? filter : DEFAULT_FILTERING
     end
 
     def request_pipeline

--- a/lib/core/filtering/validation_job_runner.rb
+++ b/lib/core/filtering/validation_job_runner.rb
@@ -1,0 +1,49 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'connectors/connector_status'
+require 'connectors/registry'
+
+module Core
+  module Filtering
+    class ValidationJobRunner
+      def initialize(connector_settings)
+        @connector_settings = connector_settings
+        @connector_class = Connectors::REGISTRY.connector_class(connector_settings.service_type)
+        @validation_finished = false
+        @status = { :error => nil }
+      end
+
+      def execute
+        Utility::Logger.info("Starting a validation job for connector #{@connector_settings.id}.")
+
+        validation_result = @connector_class.validate_filtering(@connector_settings.filtering)
+
+        # for now only used for connectors -> DEFAULT domain can be assumed (will be changed with the integration of crawler)
+        domain_validations = { 'DEFAULT' => validation_result }
+        ElasticConnectorActions.update_filtering_validation(@connector_settings.id, domain_validations)
+
+        @validation_finished = true
+      rescue StandardError => e
+        @status[:error] = e.message
+        Utility::ExceptionTracking.log_exception(e)
+        ElasticConnectorActions.update_connector_status(@connector_settings.id, Connectors::ConnectorStatus::ERROR, Utility::Logger.abbreviated_message(e.message))
+      ensure
+        if !@validation_finished && !@status[:error].present?
+          @status[:error] = 'Validation thread did not finish execution. Check connector logs for more details.'
+        end
+
+        if @status[:error]
+          Utility::Logger.info("Failed to validate filtering for connector #{@connector_settings.id} with error '#{@status[:error]}'.")
+        else
+          Utility::Logger.info("Successfully validated filtering for connector #{@connector_settings.id}.")
+        end
+      end
+    end
+  end
+end

--- a/lib/core/filtering/validation_status.rb
+++ b/lib/core/filtering/validation_status.rb
@@ -1,0 +1,17 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+module Core
+  module Filtering
+    class ValidationStatus
+      INVALID = 'invalid'
+      VALID = 'valid'
+      EDITED = 'edited'
+    end
+  end
+end

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -10,6 +10,7 @@ require 'time'
 require 'fugit'
 require 'core/connector_settings'
 require 'core/elastic_connector_actions'
+require 'core/filtering/validation_status'
 require 'utility/cron'
 require 'utility/logger'
 require 'utility/exception_tracking'
@@ -37,6 +38,9 @@ module Core
           end
           if configuration_triggered?(cs)
             yield cs, :configuration
+          end
+          if filtering_validation_triggered?(cs)
+            yield cs, :filter_validation
           end
         end
         if @is_shutting_down
@@ -149,6 +153,51 @@ module Core
       end
 
       false
+    end
+
+    def filtering_validation_triggered?(connector_settings)
+      return false unless connector_registered?(connector_settings.service_type)
+
+      filtering = connector_settings.filtering
+
+      unless filtering.present?
+        Utility::Logger.info("#{connector_settings.formatted} does not contain filtering to be validated.")
+
+        return false
+      end
+
+      draft_filters = filtering[:draft]
+
+      unless draft_filters.present?
+        Utility::Logger.info("#{connector_settings.formatted} does not contain a draft filter to be validated.")
+
+        return false
+      end
+
+      advanced_filter_config = draft_filters[:advanced_config]
+
+      # rules checking will be added with future work
+      unless advanced_filter_config.present?
+        Utility::Logger.info("#{connector_settings.formatted} does not contain a draft advanced filter config to be validated.")
+
+        return false
+      end
+
+      validation = draft_filters[:validation]
+
+      unless validation.present?
+        Utility::Logger.warn("#{connector_settings.formatted} does not contain a validation object inside draft filtering. Check connectors index.")
+
+        return false
+      end
+
+      unless validation[:state] == Core::Filtering::ValidationStatus::EDITED
+        Utility::Logger.info("#{connector_settings.formatted} filtering validation needs to be in state #{Core::Filtering::ValidationStatus::EDITED} to be able to validate it.")
+
+        return false
+      end
+
+      true
     end
 
     def connector_registered?(service_type)

--- a/spec/connectors/base/connector_spec.rb
+++ b/spec/connectors/base/connector_spec.rb
@@ -45,7 +45,7 @@ describe Connectors::Base::Connector do
 
   let(:filtering) {
     {
-      :advanced_config => advanced_config,
+      :advanced_snippet => advanced_config,
       :rules => rules
     }
   }
@@ -284,6 +284,12 @@ describe Connectors::Base::Connector do
 
         it_behaves_like 'has default filter config value'
       end
+    end
+  end
+
+  context '.validate_filtering' do
+    it 'raises an exception, that filtering is not implemented' do
+      expect { described_class.validate_filtering }.to raise_error(RuntimeError, 'Not implemented for this connector')
     end
   end
 end

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -2,6 +2,7 @@
 
 require 'connectors/gitlab/connector'
 require 'connectors/gitlab/custom_client'
+require 'core/filtering/validation_status'
 require 'spec_helper'
 
 describe Connectors::GitLab::Connector do
@@ -14,11 +15,60 @@ describe Connectors::GitLab::Connector do
     }
   end
 
+  let(:advanced_config) {
+    {}
+  }
+
+  let(:filtering) {
+    {
+      :advanced_config => advanced_config
+    }
+  }
+
   subject do
     Connectors::GitLab::Connector.new(configuration: config)
   end
 
   it_behaves_like 'a connector'
+
+  context '#validate_filtering' do
+    shared_examples_for 'filtering is valid' do
+      it 'returns validation result with state \'valid\' and no errors' do
+        validation_result = described_class.validate_filtering(filtering)
+
+        expect(validation_result[:state]).to eq(Core::Filtering::ValidationStatus::VALID)
+        expect(validation_result[:errors]).to be_empty
+      end
+    end
+
+    shared_examples_for 'filtering is invalid' do
+      it 'returns validation result with state \'invalid\' and no errors' do
+        validation_result = described_class.validate_filtering(filtering)
+
+        expect(validation_result[:state]).to eq(Core::Filtering::ValidationStatus::INVALID)
+        expect(validation_result[:errors]).to_not be_empty
+      end
+    end
+
+    context 'filtering is not present' do
+      let(:filtering) {
+        {}
+      }
+
+      it_behaves_like 'filtering is valid'
+    end
+
+    context 'filtering is present' do
+      let(:filtering) {
+        {
+          :advanced_config => advanced_config
+        }
+      }
+
+      # TODO: will be replaced with GitLab specific filtering validation
+      it_behaves_like 'filtering is invalid'
+    end
+  end
 
   context '#is_healthy?' do
     it 'correctly returns true on 200' do

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -71,7 +71,7 @@ describe Core::ConnectorSettings do
               :domain => 'DEFAULT',
               :active => {
                 :rules => [],
-                :advanced_config => {},
+                :advanced_snippet => {},
               }
             }
           ]
@@ -79,12 +79,11 @@ describe Core::ConnectorSettings do
       }
 
       it 'extracts filtering field' do
-        filtering = subject.filtering
-        first_filter = filtering[0]
+        filter = subject.filtering
 
-        expect(first_filter[:domain]).to eq('DEFAULT')
-        expect(first_filter[:active][:rules]).to_not be_nil
-        expect(first_filter[:active][:advanced_config]).to_not be_nil
+        expect(filter[:domain]).to eq('DEFAULT')
+        expect(filter[:active][:rules]).to_not be_nil
+        expect(filter[:active][:advanced_snippet]).to_not be_nil
       end
     end
 

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -2,9 +2,15 @@ require 'core'
 require 'connectors/connector_status'
 require 'connectors/sync_status'
 require 'utility'
+require './spec/support/domain_validation_helpers'
+
+RSpec.configure do |c|
+  c.include DomainValidationHelpers
+end
 
 describe Core::ElasticConnectorActions do
   let(:connector_id) { 'one-two-three' }
+  let(:connector) { double }
   let(:es_client) { double }
   let(:es_client_indices_api) { double }
   let(:connectors_index) { Utility::Constants::CONNECTORS_INDEX }
@@ -281,6 +287,231 @@ describe Core::ElasticConnectorActions do
       )
 
       described_class.set_configurable_field(connector_id, field_name, field_label, field_value)
+    end
+  end
+
+  context '#update_filtering_validation' do
+    let(:current_filtering) {
+      []
+    }
+
+    let(:new_validation_states) {
+      []
+    }
+
+    let(:expected_filtering_update) {
+      []
+    }
+
+    before(:each) do
+      allow(connector).to receive(:[]).with(:filtering).and_return(current_filtering)
+      allow(described_class).to receive(:get_connector).with(connector_id).and_return(connector)
+    end
+
+    shared_examples_for 'does not update any validation result' do
+      it 'does not update' do
+        expect(es_client).to_not receive(:update).with(anything)
+
+        described_class.update_filtering_validation(connector_id, new_validation_states)
+      end
+    end
+
+    shared_examples_for 'updates domain validation results' do
+      it 'updates result' do
+        expect(es_client).to receive(:update).with(
+          :index => connectors_index,
+          :id => connector_id,
+          :body => {
+            :doc => hash_including(
+              :filtering => expected_filtering_update
+            )
+          },
+          :refresh => true,
+          :retry_on_conflict => 3
+        )
+
+        described_class.update_filtering_validation(connector_id, new_validation_states)
+      end
+    end
+
+    context 'filtering contains an array with multiple domains, only one should be updated' do
+      let(:current_filtering) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::EDITED, []),
+          domain_validation('domain-two', Core::Filtering::ValidationStatus::EDITED, []),
+          domain_validation('domain-three', Core::Filtering::ValidationStatus::EDITED, []),
+        ]
+      }
+
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::VALID,
+            :errors => []
+          }
+        }
+      }
+
+      let(:expected_filtering_update) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::VALID, []),
+          domain_validation('domain-two', Core::Filtering::ValidationStatus::EDITED, []),
+          domain_validation('domain-three', Core::Filtering::ValidationStatus::EDITED, []),
+        ]
+      }
+
+      it_behaves_like 'updates domain validation results'
+    end
+
+    context 'filtering contains an array with multiple domains, two should be updated' do
+      let(:current_filtering) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::EDITED, []),
+          domain_validation('domain-two', Core::Filtering::ValidationStatus::EDITED, []),
+          domain_validation('domain-three', Core::Filtering::ValidationStatus::EDITED, []),
+        ]
+      }
+
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['some error']
+          },
+          'domain-two' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['another error', 'and another one']
+          }
+        }
+      }
+
+      let(:expected_filtering_update) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::INVALID, ['some error']),
+          domain_validation('domain-two', Core::Filtering::ValidationStatus::INVALID, ['another error', 'and another one']),
+          domain_validation('domain-three', Core::Filtering::ValidationStatus::EDITED, []),
+        ]
+      }
+
+      it_behaves_like 'updates domain validation results'
+    end
+
+    context 'filtering is an object' do
+      let(:current_filtering) {
+        domain_validation('domain-one', Core::Filtering::ValidationStatus::EDITED, [])
+      }
+
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::VALID,
+            :errors => []
+          }
+        }
+      }
+
+      let(:expected_filtering_update) {
+        domain_validation('domain-one', Core::Filtering::ValidationStatus::VALID, [])
+      }
+
+      it_behaves_like 'updates domain validation results'
+    end
+
+    context 'filtering contains an array with only one object' do
+      let(:current_filtering) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::EDITED, [])
+        ]
+      }
+
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['error']
+          }
+        }
+      }
+
+      let(:expected_filtering_update) {
+        [
+          domain_validation('domain-one', Core::Filtering::ValidationStatus::INVALID, ['error'])
+        ]
+      }
+
+      it_behaves_like 'updates domain validation results'
+    end
+
+    context 'filtering contains an array with multiple domains, but not the one to update' do
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['error']
+          }
+        }
+      }
+
+      it_behaves_like 'does not update any validation result'
+    end
+
+    context 'filtering contains an empty array' do
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['error']
+          }
+        }
+      }
+
+      it_behaves_like 'does not update any validation result'
+    end
+
+    context 'filtering contains an empty object' do
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['error']
+          }
+        }
+      }
+
+      it_behaves_like 'does not update any validation result'
+    end
+
+    context 'new validations states are empty' do
+      let(:new_validation_states) {
+        {}
+      }
+
+      it_behaves_like 'does not update any validation result'
+    end
+
+    context 'ES filtering mapping is incorrect' do
+      let(:current_filtering) {
+        'wrong format'
+      }
+
+      it_behaves_like 'does not update any validation result'
+    end
+
+    context 'connector not present' do
+      let(:connector) {
+        nil
+      }
+
+      let(:new_validation_states) {
+        {
+          'domain-one' => {
+            :state => Core::Filtering::ValidationStatus::INVALID,
+            :errors => ['error']
+          }
+        }
+      }
+
+      it_behaves_like 'does not update any validation result'
     end
   end
 

--- a/spec/core/filtering/validation_job_runner_spec.rb
+++ b/spec/core/filtering/validation_job_runner_spec.rb
@@ -1,0 +1,122 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'core/filtering/validation_status'
+require 'core/filtering/validation_job_runner'
+require 'core/elastic_connector_actions'
+require 'core/connector_settings'
+require 'connectors/registry'
+
+describe Core::Filtering::ValidationJobRunner do
+  subject { described_class.new(connector_settings) }
+
+  let(:connector_id) { 123 }
+  let(:connector_class) { double }
+  let(:connector_settings) { double }
+
+  let(:service_type) { 'foo' }
+  let(:filtering) { {} }
+
+  let(:validation_state) {
+    Core::Filtering::ValidationStatus::EDITED
+  }
+
+  let(:validation_errors) {
+    []
+  }
+
+  let(:validation_result) {
+    {
+      :state => validation_state,
+      :errors => validation_errors
+    }
+  }
+
+  before(:each) do
+    allow(Connectors::REGISTRY).to receive(:connector_class).and_return(connector_class)
+
+    allow(Core::ElasticConnectorActions).to receive(:update_filtering_validation)
+    allow(Core::ElasticConnectorActions).to receive(:update_connector_status)
+
+    allow(connector_settings).to receive(:id).and_return(connector_id)
+    allow(connector_settings).to receive(:filtering).and_return(filtering)
+    allow(connector_settings).to receive(:service_type).and_return(service_type)
+
+    allow(connector_class).to receive(:service_type).and_return(service_type)
+    allow(connector_class).to receive(:validate_filtering).with(filtering).and_return(validation_result)
+  end
+
+  shared_examples_for 'updates the filtering validation' do |connector_id, expected_validation_result|
+    it "sets filtering validation with validation result #{expected_validation_result}" do
+      expect(Core::ElasticConnectorActions).to receive(:update_filtering_validation).with(connector_id, { 'DEFAULT' => validation_result })
+      subject.execute
+
+      expect(subject.instance_variable_get(:@validation_finished)).to eq(true)
+    end
+  end
+
+  context '.execute' do
+    context 'when validation state is \'valid\' and no errors are present' do
+      let(:validation_state) {
+        Core::Filtering::ValidationStatus::VALID
+      }
+
+      let(:errors) {
+        []
+      }
+
+      it_behaves_like 'updates the filtering validation', 123, { :state => Core::Filtering::ValidationStatus::VALID, :errors => [] }
+    end
+
+    context 'when validation state is \'invalid\' and errors are present' do
+      let(:validation_state) {
+        Core::Filtering::ValidationStatus::INVALID
+      }
+
+      let(:validation_errors) {
+        [
+          'Error 1',
+          'Error 2',
+          'Error 3'
+        ]
+      }
+
+      it_behaves_like 'updates the filtering validation', 123, { :state => Core::Filtering::ValidationStatus::INVALID, :errors => ['Error 1',
+                                                                                                                                   'Error 2',
+                                                                                                                                   'Error 3'] }
+    end
+
+    context 'when an error is thrown during validation' do
+      before(:each) do
+        allow(connector_class).to receive(:validate_filtering).with(filtering).and_raise(StandardError.new('Error occurred during validation'))
+      end
+
+      it 'sets an error for the connector indicating, that an error during validation appeared' do
+        expect(Core::ElasticConnectorActions).to receive(:update_connector_status).with(connector_id, Connectors::ConnectorStatus::ERROR, anything)
+
+        subject.execute
+
+        expect(subject.instance_variable_get(:@validation_finished)).to eq(false)
+      end
+    end
+
+    context 'when validation thread did not finish execution' do
+      before(:each) do
+        allow(connector_class).to receive(:validate_filtering).with(filtering).and_raise(Exception)
+      end
+
+      it 'sets an error, that the validation thread was killed' do
+        # Check for exception thrown on purpose, so that the test is not marked as failed for the wrong reason
+        expect { subject.execute }.to raise_exception
+
+        expect(subject.instance_variable_get(:@validation_finished)).to eq(false)
+        expect(subject.instance_variable_get(:@status)[:error]).to eq('Validation thread did not finish execution. Check connector logs for more details.')
+      end
+    end
+  end
+end

--- a/spec/support/domain_validation_helpers.rb
+++ b/spec/support/domain_validation_helpers.rb
@@ -1,0 +1,13 @@
+module DomainValidationHelpers
+  def domain_validation(domain, state, errors)
+    {
+      :domain => domain,
+      :draft => {
+        :validation => {
+          :state => state,
+          :errors => errors
+        }
+      }
+    }
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -34,6 +34,10 @@ shared_examples 'a connector' do
     expect(described_class.configurable_fields).to_not be_nil
   end
 
+  it 'implements validate filtering class method' do
+    expect(described_class.validate_filtering).to_not be_nil
+  end
+
   it 'configurable_fields class method returns valid configuration' do
     # expected configurable fields format:
     # {


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/3167 ##

This PR introduces filtering validation support (advanced config) to the connectors-ruby framework. Filtering validation tasks are now scheduled and then dispatched to a ValidationJobRunner updating the corresponding entry in the .elastic-connectors index. 

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests

* https://github.com/elastic/connectors-ruby/pull/407
* https://github.com/elastic/connectors-ruby/pull/403

## Release Note

Add filtering validation support to the connectors-ruby framework

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
