### PR TITLE
[Mongo] add "simple" pre-processing filtering logic

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -67,7 +67,7 @@ module Connectors
       end
 
       def filtering_present?
-        @advanced_filter_config.present? || @rules.present?
+        @advanced_filter_config.present? && !@advanced_filter_config.empty? || @rules.present?
       end
 
       private

--- a/lib/connectors/base/simple_rules_parser.rb
+++ b/lib/connectors/base/simple_rules_parser.rb
@@ -5,6 +5,8 @@
 #
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/indifferent_access'
+
 module Connectors
   module Base
     class SimpleRulesParser
@@ -14,6 +16,7 @@ module Connectors
 
       def parse
         merge_rules(@rules.map do |rule|
+          rule = rule.with_indifferent_access
           unless is_include?(rule) || is_exclude?(rule)
             raise "Unknown policy: #{rule[:policy]}"
           end
@@ -34,11 +37,11 @@ module Connectors
       end
 
       def is_include?(rule)
-        rule[:policy] == 'include'
+        rule['policy'] == 'include'
       end
 
       def is_exclude?(rule)
-        rule[:policy] == 'exclude'
+        rule['policy'] == 'exclude'
       end
     end
   end

--- a/lib/connectors/base/simple_rules_parser.rb
+++ b/lib/connectors/base/simple_rules_parser.rb
@@ -1,0 +1,45 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+# frozen_string_literal: true
+
+module Connectors
+  module Base
+    class SimpleRulesParser
+      def initialize(rules)
+        @rules = (rules || []).sort_by { |r| r[:order] }
+      end
+
+      def parse
+        merge_rules(@rules.map do |rule|
+          unless is_include?(rule) || is_exclude?(rule)
+            raise "Unknown policy: #{rule[:policy]}"
+          end
+          parse_rule(rule)
+        end)
+      end
+
+      private
+
+      # merge all rules into a filter object or array
+      # in a base case, does no transformations
+      def merge_rules(rules)
+        rules || []
+      end
+
+      def parse_rule(rule)
+        raise 'Not implemented'
+      end
+
+      def is_include?(rule)
+        rule[:policy] == 'include'
+      end
+
+      def is_exclude?(rule)
+        rule[:policy] == 'exclude'
+      end
+    end
+  end
+end

--- a/lib/connectors/base/simple_rules_parser.rb
+++ b/lib/connectors/base/simple_rules_parser.rb
@@ -29,7 +29,7 @@ module Connectors
         rules || []
       end
 
-      def parse_rule(rule)
+      def parse_rule(_rule)
         raise 'Not implemented'
       end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -130,7 +130,7 @@ module Connectors
       end
 
       def check_find_and_aggregate
-        if @advanced_filter_config.keys.size != 1
+        if !@advanced_filter_config&.empty? && @advanced_filter_config&.keys&.size != 1
           invalid_keys_msg = "Only one of #{ALLOWED_TOP_LEVEL_FILTER_KEYS} is allowed in the filtering object. Keys present: '#{@advanced_filter_config.keys}'."
           raise Utility::InvalidFilterConfigError.new(invalid_keys_msg)
         end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -168,6 +168,7 @@ module Connectors
           parser = MongoRulesParser.new(@rules)
           filter = parser.parse
         end
+        Utility::Logger.info("Filtering with simple rules filter: #{filter}")
         collection.find(filter)
       end
 

--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -24,7 +24,7 @@ module Connectors
         when 'regex'
           parse_regex(rule, field, value)
         else
-          raise "Unknown operator: #{rule}"
+          raise "Unknown operator: #{op}"
         end
       end
 

--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -1,0 +1,72 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+require 'connectors/base/simple_rules_parser'
+
+module Connectors
+  module MongoDB
+    class MongoRulesParser < Connectors::Base::SimpleRulesParser
+      def parse_rule(rule)
+        field = rule[:field]
+        value = rule[:value]
+        op = rule[:rule]&.to_s
+        case op
+        when 'Equals'
+          parse_equals(rule, field, value)
+        when '>'
+          parse_greater_than(rule, field, value)
+        when '<'
+          parse_less_than(rule, field, value)
+        when 'regex'
+          parse_regex(rule, field, value)
+        else
+          raise "Unknown operator: #{rule}"
+        end
+      end
+
+      def merge_rules(rules)
+        return {} if rules.empty?
+        return rules[0] if rules.size == 1
+        { '$and' => rules }
+      end
+
+      private
+
+      def parse_equals(rule, field, value)
+        if is_include?(rule)
+          { field => value }
+        else
+          { field => { '$ne' => value } }
+        end
+      end
+
+      def parse_greater_than(rule, field, value)
+        if is_include?(rule)
+          { field => { '$gt' => value } }
+        else
+          { field => { '$lte' => value } }
+        end
+      end
+
+      def parse_less_than(rule, field, value)
+        if is_include?(rule)
+          { field => { '$lt' => value } }
+        else
+          { field => { '$gte' => value } }
+        end
+      end
+
+      def parse_regex(rule, field, value)
+        if is_include?(rule)
+          { field => /#{value}/ }
+        else
+          { field => { '$not' => /#{value}/ } }
+        end
+      end
+    end
+  end
+end

--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -5,6 +5,8 @@
 #
 
 # frozen_string_literal: true
+
+require 'active_support/core_ext/object'
 require 'connectors/base/simple_rules_parser'
 
 module Connectors
@@ -13,6 +15,12 @@ module Connectors
       def parse_rule(rule)
         field = rule[:field]
         value = rule[:value]
+        unless value.present?
+          raise "Value is required for field: #{field}"
+        end
+        unless field.present?
+          raise "Field is required for rule: #{rule}"
+        end
         op = rule[:rule]&.to_s
         case op
         when 'Equals'

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -19,6 +19,12 @@ module Core
     end
   end
 
+  class JobNotCreatedError < StandardError
+    def initialize(connector_id, response)
+      super("Sync job for connector '#{connector_id}' could not be created. Response: #{response}")
+    end
+  end
+
   class ConnectorVersionChangedError < StandardError
     def initialize(connector_id, seq_no, primary_term)
       super("Version conflict: seq_no [#{seq_no}] and primary_term [#{primary_term}] do not match for connector '#{connector_id}'.")
@@ -118,17 +124,26 @@ module Core
           :filtering => convert_connector_filtering_to_job_filtering(connector_record.dig('_source', 'filtering'))
         }
 
-        client.index(:index => Utility::Constants::JOB_INDEX, :body => body)
+        index_response = client.index(:index => Utility::Constants::JOB_INDEX, :body => body, :refresh => true)
+        if index_response['result'] == 'created'
+          return client.get(
+            :index => Utility::Constants::JOB_INDEX,
+            :id => index_response['_id'],
+            :ignore => 404
+          ).with_indifferent_access
+        end
+        raise JobNotCreatedError.new(connector_id, index_response)
       end
 
       def convert_connector_filtering_to_job_filtering(connector_filtering)
         return [] unless connector_filtering
         connector_filtering = [connector_filtering] unless connector_filtering.is_a?(Array)
         connector_filtering.each_with_object([]) do |filtering_domain, job_filtering|
+          snippet = filtering_domain.dig('active', 'advanced_snippet') || {}
           job_filtering << {
             'domain' => filtering_domain['domain'],
             'rules' => filtering_domain.dig('active', 'rules'),
-            'advanced_snippet' => filtering_domain.dig('active', 'advanced_snippet'),
+            'advanced_snippet' => snippet['value'] || snippet,
             'warnings' => [] # TODO: in https://github.com/elastic/enterprise-search-team/issues/3174
           }
         end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -41,8 +41,10 @@ module Core
     def do_sync!
       Utility::Logger.info("Claiming a sync job for connector #{@connector_settings.id}.")
 
-      job_description = ElasticConnectorActions.claim_job(@connector_settings.id)
-      job_id = job_description['_id']
+      job_record = ElasticConnectorActions.claim_job(@connector_settings.id)
+      job_description = job_record['_source']
+      job_id = job_record['_id']
+      job_description['_id'] = job_id
 
       unless job_id.present?
         Utility::Logger.error("Failed to claim the job for #{@connector_settings.id}. Please check the logs for the cause of this error.")

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -9,41 +9,39 @@ describe Connectors::MongoDB::Connector do
 
   let(:configuration) do
     {
-       :host => {
-         :label => 'Server Hostname',
-         :value => mongodb_host
-       },
-       :database => {
-         :label => 'Database',
-         :value => mongodb_database
-       },
-       :collection => {
-         :label => 'Collection',
-         :value => mongodb_collection
-       },
-       :user => {
-         :label => 'Username',
-         :value => mongodb_username
-       },
-       :password => {
-         :label => 'Password',
-         :value => mongodb_password
-       },
-       :direct_connection => {
-         :label => 'Direct connection? (true/false)',
-         :value => direct_connection
-       },
-       :filtering => {
-         :active => filtering
-       }
+      :host => {
+        :label => 'Server Hostname',
+        :value => mongodb_host
+      },
+      :database => {
+        :label => 'Database',
+        :value => mongodb_database
+      },
+      :collection => {
+        :label => 'Collection',
+        :value => mongodb_collection
+      },
+      :user => {
+        :label => 'Username',
+        :value => mongodb_username
+      },
+      :password => {
+        :label => 'Password',
+        :value => mongodb_password
+      },
+      :direct_connection => {
+        :label => 'Direct connection? (true/false)',
+        :value => direct_connection
+      },
+      :filtering => {
+        :active => filtering
+      }
     }
   end
 
-  let(:rules) {
-    [
-      # empty rules for now, replace, when rules are supported
-    ]
-  }
+  let(:rules) do
+    [{ 'field' => 'name', 'rule' => 'Equals', 'policy' => 'include', 'value' => 'apple' }]
+  end
 
   let(:pipeline) {
     [
@@ -447,6 +445,24 @@ describe Connectors::MongoDB::Connector do
 
       it 'calls find without arguments' do
         expect(actual_collection).to receive(:find).with(no_args)
+
+        subject.yield_documents
+      end
+    end
+
+    context 'rule is present and advanced filtering is empty' do
+      let(:advanced_snippet) { {} }
+
+      it 'applies the simple rule' do
+        expect(actual_collection).to receive(:find).with(match({ 'name' => 'apple' }))
+
+        subject.yield_documents
+      end
+    end
+
+    context 'both rules and advanced filtering are present' do
+      it 'does not apply the simple rule' do
+        expect(actual_collection).to receive(:find).with(filter, options)
 
         subject.yield_documents
       end

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -99,4 +99,47 @@ describe Connectors::MongoDB::MongoRulesParser do
       expect { subject.parse }.to raise_error(RuntimeError, /Unknown policy/)
     end
   end
+
+  context 'with empty string value' do
+    let(:rules) { [{ field: 'foo', value: '', policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    end
+  end
+
+  context 'with empty string field' do
+    let(:rules) { [{ field: '', value: '123', policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    end
+  end
+
+  context 'with nil value' do
+    let(:rules) { [{ field: 'foo', value: nil, policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    end
+  end
+
+  context 'with nil field' do
+    let(:rules) { [{ field: nil, value: '123', policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    end
+  end
+
+  context 'with non-existent value' do
+    let(:rules) { [{ field: 'foo', policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    end
+  end
+
+  context 'with non-existent field' do
+    let(:rules) { [{ value: '123', policy: 'include', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    end
+  end
+
 end

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -1,0 +1,102 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+# frozen_string_literal: true
+
+require 'connectors/mongodb/mongo_rules_parser'
+
+describe Connectors::MongoDB::MongoRulesParser do
+  let(:rules) { [] }
+  let(:policy) { '' }
+  let(:operator) { '' }
+
+  subject { described_class.new(rules) }
+
+  context 'with one rule' do
+    let(:rules) { [{ field: 'foo', value: 'bar', policy: policy, rule: operator }] }
+    context 'on include rule' do
+      let(:policy) { 'include' }
+      context 'equals' do
+        let(:operator) { 'Equals' }
+        it 'parses rule as equals' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => 'bar' })
+        end
+      end
+      context 'greater' do
+        let(:operator) { '>' }
+        it 'parses rule as greater' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => { '$gt' => 'bar' } })
+        end
+      end
+      context 'less' do
+        let(:operator) { '<' }
+        it 'parses rule as less' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => { '$lt' => 'bar' } })
+        end
+      end
+    end
+    context 'on exclude rule' do
+      let(:policy) { 'exclude' }
+      context 'equals' do
+        let(:operator) { 'Equals' }
+        it 'parses rule as not equals' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => { '$ne' => 'bar' } })
+        end
+      end
+      context 'greater' do
+        let(:operator) { '>' }
+        it 'parses rule as less or equals' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => { '$lte' => 'bar' } })
+        end
+      end
+      context 'less' do
+        let(:operator) { '<' }
+        it 'parses rule as less or equals' do
+          result = subject.parse
+          expect(result).to match({ 'foo' => { '$gte' => 'bar' } })
+        end
+      end
+    end
+  end
+
+  context 'with multiple rules' do
+    let(:rules) do
+      [
+        { field: 'foo', value: 'bar1', policy: 'include', rule: 'Equals' },
+        { field: 'foo', value: 'bar2', policy: 'exclude', rule: '>' }
+      ]
+    end
+    it 'parses rules as and' do
+      result = subject.parse
+      expect(result).to match({ '$and' => [{ 'foo' => 'bar1' }, { 'foo' => { '$lte' => 'bar2' } }] })
+    end
+  end
+
+  context 'with empty rules' do
+    it 'parses rules as empty' do
+      result = subject.parse
+      expect(result).to match({})
+    end
+  end
+
+  context 'with invalid operator' do
+    let(:rules) { [{ field: 'foo', value: 'bar', policy: 'include', rule: 'invalid' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Unknown operator/)
+    end
+  end
+
+  context 'with invalid policy' do
+    let(:rules) { [{ field: 'foo', value: 'bar', policy: 'invalid', rule: 'Equals' }] }
+    it 'raises error' do
+      expect { subject.parse }.to raise_error(RuntimeError, /Unknown policy/)
+    end
+  end
+end

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -141,5 +141,4 @@ describe Connectors::MongoDB::MongoRulesParser do
       expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
     end
   end
-
 end

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -72,12 +72,12 @@ describe Core::ElasticConnectorActions do
     before(:each) do
       allow(es_client)
         .to receive(:index)
-              .with(:index => connectors_index, :body => anything)
-              .and_return(
-                {
-                  '_id' => created_connector_id
-                }
-              )
+        .with(:index => connectors_index, :body => anything)
+        .and_return(
+          {
+            '_id' => created_connector_id
+          }
+        )
     end
 
     it 'sends a index request with proper index_name and service_type' do
@@ -149,7 +149,7 @@ describe Core::ElasticConnectorActions do
     before(:each) do
       allow(es_client_indices_api)
         .to receive(:get_mapping)
-              .and_return({ "#{Utility::Constants::CONNECTORS_INDEX}-v1" => { 'mappings' => { '_meta' => { 'version' => '1' }, 'properties' => { 'api_key_id' => { 'type' => 'keyword' }, 'configuration' => { 'type' => 'object' }, 'error' => { 'type' => 'keyword' }, 'index_name' => { 'type' => 'keyword' }, 'language' => { 'type' => 'keyword' }, 'last_seen' => { 'type' => 'date' }, 'last_sync_error' => { 'type' => 'keyword' }, 'last_sync_status' => { 'type' => 'keyword' }, 'last_synced' => { 'type' => 'date' }, 'name' => { 'type' => 'keyword' }, 'scheduling' => { 'properties' => { 'enabled' => { 'type' => 'boolean' }, 'interval' => { 'type' => 'text' } } }, 'service_type' => { 'type' => 'keyword' }, 'status' => { 'type' => 'keyword' }, 'sync_now' => { 'type' => 'boolean' } } } } })
+        .and_return({ "#{Utility::Constants::CONNECTORS_INDEX}-v1" => { 'mappings' => { '_meta' => { 'version' => '1' }, 'properties' => { 'api_key_id' => { 'type' => 'keyword' }, 'configuration' => { 'type' => 'object' }, 'error' => { 'type' => 'keyword' }, 'index_name' => { 'type' => 'keyword' }, 'language' => { 'type' => 'keyword' }, 'last_seen' => { 'type' => 'date' }, 'last_sync_error' => { 'type' => 'keyword' }, 'last_sync_status' => { 'type' => 'keyword' }, 'last_synced' => { 'type' => 'date' }, 'name' => { 'type' => 'keyword' }, 'scheduling' => { 'properties' => { 'enabled' => { 'type' => 'boolean' }, 'interval' => { 'type' => 'text' } } }, 'service_type' => { 'type' => 'keyword' }, 'status' => { 'type' => 'keyword' }, 'sync_now' => { 'type' => 'boolean' } } } } })
     end
 
     it 'gets the meta' do
@@ -290,33 +290,32 @@ describe Core::ElasticConnectorActions do
     let(:primary_term) { 1 }
     before(:each) do
       allow(es_client).to receive(:index)
-                            .with(:index => jobs_index, :body => anything, :refresh => true)
-                            .and_return(
-                              {
-                                '_id' => job_id,
-                                'result' => 'created'
-                              }
-                            )
+        .with(:index => jobs_index, :body => anything, :refresh => true)
+        .and_return(
+          {
+            '_id' => job_id,
+            'result' => 'created'
+          }
+        )
       allow(es_client).to receive(:get)
-                            .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-                            .and_return(
-                              {
-                                '_seq_no' => seq_no,
-                                '_primary_term' => primary_term,
-                                '_source' => {
-                                  'last_sync_status' => nil
-                                }
-                              }
-                            )
+        .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+        .and_return(
+          {
+            '_seq_no' => seq_no,
+            '_primary_term' => primary_term,
+            '_source' => {
+              'last_sync_status' => nil
+            }
+          }
+        )
       allow(es_client).to receive(:get)
-                            .with(:index => jobs_index, :id => anything, :ignore => 404)
-                            .and_return(
-                              { '_id' => job_id,
-                                '_source' => {
-                                  'status' => Connectors::SyncStatus::IN_PROGRESS
-                                }
-                              }
-                            )
+        .with(:index => jobs_index, :id => anything, :ignore => 404)
+        .and_return(
+          { '_id' => job_id,
+            '_source' => {
+              'status' => Connectors::SyncStatus::IN_PROGRESS
+            } }
+        )
     end
 
     it 'updates connector status fields' do
@@ -367,14 +366,14 @@ describe Core::ElasticConnectorActions do
     context 'when connector is already syncing' do
       before(:each) do
         allow(es_client).to receive(:get)
-                              .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-                              .and_return(
-                                { '_seq_no' => seq_no,
-                                  '_primary_term' => primary_term,
-                                  '_source' => {
-                                    'last_sync_status' => Connectors::SyncStatus::IN_PROGRESS
-                                  } }
-                              )
+          .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+          .and_return(
+            { '_seq_no' => seq_no,
+              '_primary_term' => primary_term,
+              '_source' => {
+                'last_sync_status' => Connectors::SyncStatus::IN_PROGRESS
+              } }
+          )
       end
       it 'raises an error of specific type' do
         expect { described_class.claim_job(connector_id) }.to raise_error(Core::JobAlreadyRunningError)
@@ -384,8 +383,8 @@ describe Core::ElasticConnectorActions do
     context 'when connector has changed version' do
       before(:each) do
         allow(es_client).to receive(:update)
-                              .with(anything)
-                              .and_raise(Core::ConnectorVersionChangedError.new(connector_id, seq_no, primary_term))
+          .with(anything)
+          .and_raise(Core::ConnectorVersionChangedError.new(connector_id, seq_no, primary_term))
       end
       it 'raises an error of specific type' do
         expect { described_class.claim_job(connector_id) }
@@ -421,16 +420,15 @@ describe Core::ElasticConnectorActions do
 
       before(:each) do
         allow(es_client).to receive(:get)
-                              .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-                              .and_return(
-                                { '_seq_no' => seq_no,
-                                  '_primary_term' => primary_term,
-                                  '_source' => {
-                                    'last_sync_status' => nil,
-                                    'filtering' => connector_filtering
-                                  }
-                                }
-                              )
+          .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+          .and_return(
+            { '_seq_no' => seq_no,
+              '_primary_term' => primary_term,
+              '_source' => {
+                'last_sync_status' => nil,
+                'filtering' => connector_filtering
+              } }
+          )
       end
 
       it 'has filtering rules' do
@@ -817,10 +815,10 @@ describe Core::ElasticConnectorActions do
       before(:each) do
         expect(es_client)
           .to receive(:update)
-                .with(anything)
-                .and_raise(
-                  Elastic::Transport::Transport::Errors::Conflict.new
-                )
+          .with(anything)
+          .and_raise(
+            Elastic::Transport::Transport::Errors::Conflict.new
+          )
       end
       it 'raises a version changed error' do
         expect { described_class.update_connector_fields(connector_id, doc, seq_no, primary_term) }

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -5,6 +5,7 @@ require 'utility'
 
 describe Core::ElasticConnectorActions do
   let(:connector_id) { 'one-two-three' }
+  let(:job_id) { 'some-job-id' }
   let(:es_client) { double }
   let(:es_client_indices_api) { double }
   let(:connectors_index) { Utility::Constants::CONNECTORS_INDEX }
@@ -71,12 +72,12 @@ describe Core::ElasticConnectorActions do
     before(:each) do
       allow(es_client)
         .to receive(:index)
-        .with(:index => connectors_index, :body => anything)
-        .and_return(
-          {
-            '_id' => created_connector_id
-          }
-        )
+              .with(:index => connectors_index, :body => anything)
+              .and_return(
+                {
+                  '_id' => created_connector_id
+                }
+              )
     end
 
     it 'sends a index request with proper index_name and service_type' do
@@ -148,7 +149,7 @@ describe Core::ElasticConnectorActions do
     before(:each) do
       allow(es_client_indices_api)
         .to receive(:get_mapping)
-        .and_return({ "#{Utility::Constants::CONNECTORS_INDEX}-v1" => { 'mappings' => { '_meta' => { 'version' => '1' }, 'properties' => { 'api_key_id' => { 'type' => 'keyword' }, 'configuration' => { 'type' => 'object' }, 'error' => { 'type' => 'keyword' }, 'index_name' => { 'type' => 'keyword' }, 'language' => { 'type' => 'keyword' }, 'last_seen' => { 'type' => 'date' }, 'last_sync_error' => { 'type' => 'keyword' }, 'last_sync_status' => { 'type' => 'keyword' }, 'last_synced' => { 'type' => 'date' }, 'name' => { 'type' => 'keyword' }, 'scheduling' => { 'properties' => { 'enabled' => { 'type' => 'boolean' }, 'interval' => { 'type' => 'text' } } }, 'service_type' => { 'type' => 'keyword' }, 'status' => { 'type' => 'keyword' }, 'sync_now' => { 'type' => 'boolean' } } } } })
+              .and_return({ "#{Utility::Constants::CONNECTORS_INDEX}-v1" => { 'mappings' => { '_meta' => { 'version' => '1' }, 'properties' => { 'api_key_id' => { 'type' => 'keyword' }, 'configuration' => { 'type' => 'object' }, 'error' => { 'type' => 'keyword' }, 'index_name' => { 'type' => 'keyword' }, 'language' => { 'type' => 'keyword' }, 'last_seen' => { 'type' => 'date' }, 'last_sync_error' => { 'type' => 'keyword' }, 'last_sync_status' => { 'type' => 'keyword' }, 'last_synced' => { 'type' => 'date' }, 'name' => { 'type' => 'keyword' }, 'scheduling' => { 'properties' => { 'enabled' => { 'type' => 'boolean' }, 'interval' => { 'type' => 'text' } } }, 'service_type' => { 'type' => 'keyword' }, 'status' => { 'type' => 'keyword' }, 'sync_now' => { 'type' => 'boolean' } } } } })
     end
 
     it 'gets the meta' do
@@ -288,16 +289,34 @@ describe Core::ElasticConnectorActions do
     let(:seq_no) { 1 }
     let(:primary_term) { 1 }
     before(:each) do
-      allow(es_client).to receive(:index).with(:index => jobs_index, :body => anything).and_return({ '_id' => 'job-123' })
+      allow(es_client).to receive(:index)
+                            .with(:index => jobs_index, :body => anything, :refresh => true)
+                            .and_return(
+                              {
+                                '_id' => job_id,
+                                'result' => 'created'
+                              }
+                            )
       allow(es_client).to receive(:get)
-        .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-        .and_return(
-          { '_seq_no' => seq_no,
-            '_primary_term' => primary_term,
-            '_source' => {
-              'last_sync_status' => nil
-            } }
-        )
+                            .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+                            .and_return(
+                              {
+                                '_seq_no' => seq_no,
+                                '_primary_term' => primary_term,
+                                '_source' => {
+                                  'last_sync_status' => nil
+                                }
+                              }
+                            )
+      allow(es_client).to receive(:get)
+                            .with(:index => jobs_index, :id => anything, :ignore => 404)
+                            .and_return(
+                              { '_id' => job_id,
+                                '_source' => {
+                                  'status' => Connectors::SyncStatus::IN_PROGRESS
+                                }
+                              }
+                            )
     end
 
     it 'updates connector status fields' do
@@ -323,11 +342,23 @@ describe Core::ElasticConnectorActions do
       expect(es_client).to receive(:index).with(
         :index => jobs_index,
         :body => hash_including(
-          :worker_hostname,
-          :created_at,
+          :worker_hostname => anything,
+          :created_at => anything,
           :connector_id => connector_id,
-          :status => Connectors::SyncStatus::IN_PROGRESS
-        )
+          :status => Connectors::SyncStatus::IN_PROGRESS,
+          :filtering => anything
+        ),
+        :refresh => true
+      )
+
+      described_class.claim_job(connector_id)
+    end
+
+    it 're-reads a record in jobs index' do
+      expect(es_client).to receive(:get).with(
+        :index => jobs_index,
+        :id => job_id,
+        :ignore => 404
       )
 
       described_class.claim_job(connector_id)
@@ -336,14 +367,14 @@ describe Core::ElasticConnectorActions do
     context 'when connector is already syncing' do
       before(:each) do
         allow(es_client).to receive(:get)
-          .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-          .and_return(
-            { '_seq_no' => seq_no,
-              '_primary_term' => primary_term,
-              '_source' => {
-                'last_sync_status' => Connectors::SyncStatus::IN_PROGRESS
-              } }
-          )
+                              .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+                              .and_return(
+                                { '_seq_no' => seq_no,
+                                  '_primary_term' => primary_term,
+                                  '_source' => {
+                                    'last_sync_status' => Connectors::SyncStatus::IN_PROGRESS
+                                  } }
+                              )
       end
       it 'raises an error of specific type' do
         expect { described_class.claim_job(connector_id) }.to raise_error(Core::JobAlreadyRunningError)
@@ -353,8 +384,8 @@ describe Core::ElasticConnectorActions do
     context 'when connector has changed version' do
       before(:each) do
         allow(es_client).to receive(:update)
-          .with(anything)
-          .and_raise(Core::ConnectorVersionChangedError.new(connector_id, seq_no, primary_term))
+                              .with(anything)
+                              .and_raise(Core::ConnectorVersionChangedError.new(connector_id, seq_no, primary_term))
       end
       it 'raises an error of specific type' do
         expect { described_class.claim_job(connector_id) }
@@ -390,19 +421,24 @@ describe Core::ElasticConnectorActions do
 
       before(:each) do
         allow(es_client).to receive(:get)
-          .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
-          .and_return(
-            { '_seq_no' => seq_no,
-              '_primary_term' => primary_term,
-              '_source' => {
-                'last_sync_status' => nil,
-                'filtering' => connector_filtering
-              } }
-          )
+                              .with(:index => connectors_index, :id => connector_id, :refresh => true, :ignore => 404)
+                              .and_return(
+                                { '_seq_no' => seq_no,
+                                  '_primary_term' => primary_term,
+                                  '_source' => {
+                                    'last_sync_status' => nil,
+                                    'filtering' => connector_filtering
+                                  }
+                                }
+                              )
       end
 
       it 'has filtering rules' do
-        expect(es_client).to receive(:index).with(:index => jobs_index, :body => hash_including(:filtering => [job_filtering]))
+        expect(es_client).to receive(:index).with(
+          :index => jobs_index,
+          :body => hash_including(:filtering => [job_filtering]),
+          :refresh => true
+        )
         described_class.claim_job(connector_id)
       end
     end
@@ -781,10 +817,10 @@ describe Core::ElasticConnectorActions do
       before(:each) do
         expect(es_client)
           .to receive(:update)
-          .with(anything)
-          .and_raise(
-            Elastic::Transport::Transport::Errors::Conflict.new
-          )
+                .with(anything)
+                .and_raise(
+                  Elastic::Transport::Transport::Errors::Conflict.new
+                )
       end
       it 'raises a version changed error' do
         expect { described_class.update_connector_fields(connector_id, doc, seq_no, primary_term) }

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -43,7 +43,10 @@ describe Core::SyncJobRunner do
   let(:job_id) { 'job-123' }
   let(:job_definition) do
     {
-      '_id' => job_id
+      '_id' => job_id,
+      '_source' => {
+        'filtering' => filtering
+      }
     }
   end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3168 

Created a base rules parser for filtering rules and a mongo-specific implementation.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
