### PR TITLE
Make tests more consistent

### DIFF
--- a/spec/connectors/base/adapter_spec.rb
+++ b/spec/connectors/base/adapter_spec.rb
@@ -11,7 +11,7 @@ require 'active_support/core_ext/hash'
 require 'connectors/base/adapter'
 
 describe Connectors::Base::Adapter do
-  context '.generate_id_helpers' do
+  describe '.generate_id_helpers' do
     before do
       class Dummy < Connectors::Base::Adapter
         generate_id_helpers :dummy, 'dummy'
@@ -75,7 +75,7 @@ describe Connectors::Base::Adapter do
     end
   end
 
-  describe 'es_document_from_configured_object_base' do
+  describe '.es_document_from_configured_object_base' do
     let(:object_type) { 'animal' }
     let(:field_remote) { 'RemoteFieldName' }
     let(:field_target) { 'target_field_name' }

--- a/spec/connectors/base/connector_spec.rb
+++ b/spec/connectors/base/connector_spec.rb
@@ -56,7 +56,7 @@ describe Connectors::Base::Connector do
     }
   }
 
-  context '.advanced_filter_config?' do
+  describe '#advanced_filter_config' do
     shared_examples_for 'advanced_filter_config is not present' do
       it 'returns empty object' do
         expect(subject.advanced_filter_config).to be_empty
@@ -86,7 +86,7 @@ describe Connectors::Base::Connector do
     end
   end
 
-  context '.rules' do
+  describe '#rules' do
     shared_examples_for 'rules are not present' do
       it 'returns empty array' do
         expect(subject.rules).to be_empty
@@ -116,7 +116,7 @@ describe Connectors::Base::Connector do
     end
   end
 
-  context '.filtering_present?' do
+  describe '#filtering_present?' do
     shared_examples_for 'filtering is not present' do
       it 'returns false' do
         expect(subject.filtering_present?).to eq(false)
@@ -188,102 +188,102 @@ describe Connectors::Base::Connector do
 
       it_behaves_like 'filtering is not present'
     end
+  end
 
-    context '.rules' do
+  describe '.rules' do
+    let(:rules) {
+      [
+        {
+          :id => '90owilfksdoifuw',
+          :policy => 'exclude',
+          :field => 'url',
+          :rule => 'regex',
+          :value => '.*/sample/.*\.pdf',
+          :order => 0,
+          :created_at => '2022-10-10T00:00:00Z',
+          :updated_at => '2022-10-10T00:00:00Z'
+        },
+        {
+          :id => '09wuekwisdfjslk',
+          :policy => 'include',
+          :field => 'id',
+          :rule => 'regex',
+          :value => '.*',
+          :order => 1,
+          :created_at => '2022-10-10T00:00:00Z',
+          :updated_at => '2022-10-10T00:00:00Z'
+        }
+      ]
+    }
+
+    context 'two rules are present' do
+      it 'should extract three rules from job description' do
+        extracted_rules = subject.rules
+
+        expect(extracted_rules).to_not be_nil
+        expect(extracted_rules.size).to eq(2)
+
+        expect(extracted_rules[0]).to eq(rules[0])
+        expect(extracted_rules[1]).to eq(rules[1])
+      end
+    end
+
+    shared_examples_for 'has default rules value' do
+      it 'defaults to an empty array' do
+        extracted_rules = subject.rules
+
+        expect(extracted_rules).to_not be_nil
+        expect(extracted_rules.size).to eq(0)
+      end
+    end
+
+    context 'no rules are present' do
       let(:rules) {
-        [
-          {
-            :id => '90owilfksdoifuw',
-            :policy => 'exclude',
-            :field => 'url',
-            :rule => 'regex',
-            :value => '.*/sample/.*\.pdf',
-            :order => 0,
-            :created_at => '2022-10-10T00:00:00Z',
-            :updated_at => '2022-10-10T00:00:00Z'
-          },
-          {
-            :id => '09wuekwisdfjslk',
-            :policy => 'include',
-            :field => 'id',
-            :rule => 'regex',
-            :value => '.*',
-            :order => 1,
-            :created_at => '2022-10-10T00:00:00Z',
-            :updated_at => '2022-10-10T00:00:00Z'
-          }
-        ]
+        []
       }
 
-      context 'two rules are present' do
-        it 'should extract three rules from job description' do
-          extracted_rules = subject.rules
+      it_behaves_like 'has default rules value'
+    end
 
-          expect(extracted_rules).to_not be_nil
-          expect(extracted_rules.size).to eq(2)
+    context 'rules are nil' do
+      let(:rules) {
+        nil
+      }
 
-          expect(extracted_rules[0]).to eq(rules[0])
-          expect(extracted_rules[1]).to eq(rules[1])
-        end
+      it_behaves_like 'has default rules value'
+    end
+
+    context 'advanced filter config is present' do
+      it 'extracts the advanced filter config' do
+        advanced_filter_config = subject.advanced_filter_config
+
+        expect(advanced_filter_config).to eq(advanced_snippet)
       end
+    end
 
-      shared_examples_for 'has default rules value' do
-        it 'defaults to an empty array' do
-          extracted_rules = subject.rules
+    shared_examples_for 'has default filter config value' do
+      it 'defaults to an empty hash' do
+        advanced_filter_config = subject.advanced_filter_config
 
-          expect(extracted_rules).to_not be_nil
-          expect(extracted_rules.size).to eq(0)
-        end
+        expect(advanced_filter_config).to_not be_nil
+        expect(advanced_filter_config).to eq({})
       end
+    end
 
-      context 'no rules are present' do
-        let(:rules) {
-          []
-        }
+    context 'filter config is nil' do
+      let(:advanced_snippet) {
+        nil
+      }
 
-        it_behaves_like 'has default rules value'
-      end
+      it_behaves_like 'has default filter config value'
+    end
 
-      context 'rules are nil' do
-        let(:rules) {
-          nil
-        }
+    context 'filter config is empty' do
+      let(:advanced_snippet) {
+        {}
+      }
 
-        it_behaves_like 'has default rules value'
-      end
-
-      context 'advanced filter config is present' do
-        it 'extracts the advanced filter config' do
-          advanced_filter_config = subject.advanced_filter_config
-
-          expect(advanced_filter_config).to eq(advanced_snippet)
-        end
-      end
-
-      shared_examples_for 'has default filter config value' do
-        it 'defaults to an empty hash' do
-          advanced_filter_config = subject.advanced_filter_config
-
-          expect(advanced_filter_config).to_not be_nil
-          expect(advanced_filter_config).to eq({})
-        end
-      end
-
-      context 'filter config is nil' do
-        let(:advanced_snippet) {
-          nil
-        }
-
-        it_behaves_like 'has default filter config value'
-      end
-
-      context 'filter config is empty' do
-        let(:advanced_snippet) {
-          {}
-        }
-
-        it_behaves_like 'has default filter config value'
-      end
+      it_behaves_like 'has default filter config value'
     end
   end
 end

--- a/spec/connectors/base/custom_client_spec.rb
+++ b/spec/connectors/base/custom_client_spec.rb
@@ -12,70 +12,78 @@ describe Connectors::Base::CustomClient do
   let(:base_url) { 'http://localhost' }
   let(:client) { described_class.new(:base_url => base_url) }
 
-  it '#get' do
-    get_request = stub_request(:get, 'http://localhost').to_return(:status => 200)
-    client.get('')
-    expect(get_request).to have_been_requested.at_least_once
-  end
-
-  it '#post' do
-    post_request = stub_request(:post, 'http://localhost').to_return(:status => 200)
-    client.post('', {})
-    expect(post_request).to have_been_requested.at_least_once
-  end
-
-  it '#put' do
-    put_request = stub_request(:put, 'http://localhost').to_return(:status => 200)
-    client.put('', {})
-    expect(put_request).to have_been_requested.at_least_once
-  end
-
-  it '#delete' do
-    delete_request = stub_request(:delete, 'http://localhost').to_return(:status => 200)
-    client.delete('')
-    expect(delete_request).to have_been_requested.at_least_once
-  end
-
-  context 'retries' do
-    it 'retries on timeout response' do
-      stubbed_request = stub_request(:get, 'http://localhost')
-        .to_timeout.then
-        .to_return(:status => 200)
-
+  describe '#get' do
+    it 'makes http request' do
+      get_request = stub_request(:get, 'http://localhost').to_return(:status => 200)
       client.get('')
-      expect(stubbed_request).to have_been_requested.twice
+      expect(get_request).to have_been_requested.at_least_once
     end
 
-    it 'only retries MAX_RETRIES times' do
-      max = Connectors::Base::CustomClient::MAX_RETRIES
-      stubbed_request = (max + 5).times.each_with_object(stub_request(:get, 'http://localhost')) do |_, stub|
-        stub.to_timeout.then
-      end.to_return(:status => 200)
-      expect { client.get('') }.to raise_error(Faraday::TimeoutError)
-      expect(stubbed_request).to have_been_requested.times(max + 1) # original + "retries"
+    context 'retries' do
+      it 'retries on timeout response' do
+        stubbed_request = stub_request(:get, 'http://localhost')
+          .to_timeout.then
+          .to_return(:status => 200)
+
+        client.get('')
+        expect(stubbed_request).to have_been_requested.twice
+      end
+
+      it 'only retries MAX_RETRIES times' do
+        max = Connectors::Base::CustomClient::MAX_RETRIES
+        stubbed_request = (max + 5).times.each_with_object(stub_request(:get, 'http://localhost')) do |_, stub|
+          stub.to_timeout.then
+        end.to_return(:status => 200)
+        expect { client.get('') }.to raise_error(Faraday::TimeoutError)
+        expect(stubbed_request).to have_been_requested.times(max + 1) # original + "retries"
+      end
     end
-  end
 
-  describe 'ensuring auth is fresh' do
-    let(:refresh_lambda) { ->(_client) { refresh_double.the_big_red_button } }
-    let(:refresh_double) { double(:the_big_red_button => :kaboom) }
+    context 'ensuring auth is fresh' do
+      let(:refresh_lambda) { ->(_client) { refresh_double.the_big_red_button } }
+      let(:refresh_double) { double(:the_big_red_button => :kaboom) }
 
-    it 'does not require refresh logic' do
-      expect(refresh_double).not_to receive(:the_big_red_button)
-
-      stub_request(:get, 'http://localhost').to_return(:status => 200)
-      client.get('')
-    end
-
-    context 'auth refresh logic is provided' do
-      let(:client) { described_class.new(:base_url => base_url, :ensure_fresh_auth => refresh_lambda) }
-
-      it 'will use refresh logic when supplied' do
-        expect(refresh_double).to receive(:the_big_red_button)
+      it 'does not require refresh logic' do
+        expect(refresh_double).not_to receive(:the_big_red_button)
 
         stub_request(:get, 'http://localhost').to_return(:status => 200)
         client.get('')
       end
+
+      context 'auth refresh logic is provided' do
+        let(:client) { described_class.new(:base_url => base_url, :ensure_fresh_auth => refresh_lambda) }
+
+        it 'will use refresh logic when supplied' do
+          expect(refresh_double).to receive(:the_big_red_button)
+
+          stub_request(:get, 'http://localhost').to_return(:status => 200)
+          client.get('')
+        end
+      end
+    end
+  end
+
+  describe '#post' do
+    it 'makes http request' do
+      post_request = stub_request(:post, 'http://localhost').to_return(:status => 200)
+      client.post('', {})
+      expect(post_request).to have_been_requested.at_least_once
+    end
+  end
+
+  describe '#put' do
+    it 'makes http request' do
+      put_request = stub_request(:put, 'http://localhost').to_return(:status => 200)
+      client.put('', {})
+      expect(put_request).to have_been_requested.at_least_once
+    end
+  end
+
+  describe '#delete' do
+    it 'makes http request' do
+      delete_request = stub_request(:delete, 'http://localhost').to_return(:status => 200)
+      client.delete('')
+      expect(delete_request).to have_been_requested.at_least_once
     end
   end
 

--- a/spec/connectors/example/connector_spec.rb
+++ b/spec/connectors/example/connector_spec.rb
@@ -16,13 +16,13 @@ describe Connectors::Example::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#is_healthy?' do
+  describe '#is_healthy?' do
     it 'returns ok' do
       expect(subject.is_healthy?).to eq(true)
     end
   end
 
-  context '#yield_documents' do
+  describe '#yield_documents' do
     before do
       @documents = []
 

--- a/spec/connectors/gitlab/adapter_spec.rb
+++ b/spec/connectors/gitlab/adapter_spec.rb
@@ -6,7 +6,7 @@ require 'connectors/gitlab/adapter'
 describe Connectors::GitLab::Adapter do
   let(:project_hash) { Hashie::Mash.new(JSON.parse(connectors_fixture_raw('gitlab/simple_project.json'))) }
 
-  context '#to_es_document' do
+  describe '#to_es_document' do
     it 'correctly produced the Enterprise Search ID' do
       new_id = described_class.gitlab_id_to_es_id(project_hash.id)
       expect(new_id).to include(project_hash.id.to_s)

--- a/spec/connectors/gitlab/connector_spec.rb
+++ b/spec/connectors/gitlab/connector_spec.rb
@@ -20,7 +20,7 @@ describe Connectors::GitLab::Connector do
 
   it_behaves_like 'a connector'
 
-  context '#is_healthy?' do
+  describe '#is_healthy?' do
     it 'correctly returns true on 200' do
       stub_request(:get, "#{base_url}/user")
         .to_return(:status => 200, :body => user_json)
@@ -46,7 +46,7 @@ describe Connectors::GitLab::Connector do
     end
   end
 
-  context '#yield_documents' do
+  describe '#yield_documents' do
     let(:page_count) { 3 }
     let(:page_size) { 100 }
 

--- a/spec/connectors/gitlab/extractor_spec.rb
+++ b/spec/connectors/gitlab/extractor_spec.rb
@@ -29,7 +29,7 @@ describe Connectors::GitLab::Extractor do
     Connectors::GitLab::Extractor.new(:base_url => base_url)
   end
 
-  context '#yield_projects_page' do
+  describe '#yield_projects_page' do
     it 'correctly produces one page of documents' do
       stub_request(:get, "#{base_url}/projects?order_by=id&owned=true&pagination=keyset&per_page=100&sort=desc")
         .to_return(:status => 200, :body => projects_json)
@@ -203,7 +203,7 @@ describe Connectors::GitLab::Extractor do
     end
   end
 
-  context '#deleted' do
+  describe '#deleted' do
     let(:existing_id) { 36029109 }
     let(:non_existing_ids) { [123, 234, 345] }
 
@@ -221,7 +221,7 @@ describe Connectors::GitLab::Extractor do
     end
   end
 
-  context '#permissions' do
+  describe '#permissions' do
     let(:user_id) { 1 }
     let(:user_name) { 'sytses' }
     let(:external_user_id) { 11422639 }

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -182,7 +182,7 @@ describe Connectors::MongoDB::Connector do
     end
   end
 
-  describe'#is_healthy?' do
+  describe '#is_healthy?' do
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.is_healthy? }
     end

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -182,7 +182,7 @@ describe Connectors::MongoDB::Connector do
     end
   end
 
-  context '#is_healthy?' do
+  describe'#is_healthy?' do
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.is_healthy? }
     end
@@ -194,7 +194,7 @@ describe Connectors::MongoDB::Connector do
     end
   end
 
-  context '#yield_documents' do
+  describe '#yield_documents' do
     it_behaves_like 'handles auth' do
       let(:do_test) { subject.yield_documents { |doc|; } }
     end

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -14,131 +14,133 @@ describe Connectors::MongoDB::MongoRulesParser do
 
   subject { described_class.new(rules) }
 
-  context 'with one rule' do
-    let(:rules) { [{ field: 'foo', value: 'bar', policy: policy, rule: operator }] }
-    context 'on include rule' do
-      let(:policy) { 'include' }
-      context 'equals' do
-        let(:operator) { 'Equals' }
-        it 'parses rule as equals' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => 'bar' })
+  describe '#parse' do
+    context 'with one rule' do
+      let(:rules) { [{ field: 'foo', value: 'bar', policy: policy, rule: operator }] }
+      context 'on include rule' do
+        let(:policy) { 'include' }
+        context 'equals' do
+          let(:operator) { 'Equals' }
+          it 'parses rule as equals' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => 'bar' })
+          end
+        end
+        context 'greater' do
+          let(:operator) { '>' }
+          it 'parses rule as greater' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$gt' => 'bar' } })
+          end
+        end
+        context 'less' do
+          let(:operator) { '<' }
+          it 'parses rule as less' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$lt' => 'bar' } })
+          end
         end
       end
-      context 'greater' do
-        let(:operator) { '>' }
-        it 'parses rule as greater' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => { '$gt' => 'bar' } })
+      context 'on exclude rule' do
+        let(:policy) { 'exclude' }
+        context 'equals' do
+          let(:operator) { 'Equals' }
+          it 'parses rule as not equals' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$ne' => 'bar' } })
+          end
         end
-      end
-      context 'less' do
-        let(:operator) { '<' }
-        it 'parses rule as less' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => { '$lt' => 'bar' } })
+        context 'greater' do
+          let(:operator) { '>' }
+          it 'parses rule as less or equals' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$lte' => 'bar' } })
+          end
         end
-      end
-    end
-    context 'on exclude rule' do
-      let(:policy) { 'exclude' }
-      context 'equals' do
-        let(:operator) { 'Equals' }
-        it 'parses rule as not equals' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => { '$ne' => 'bar' } })
-        end
-      end
-      context 'greater' do
-        let(:operator) { '>' }
-        it 'parses rule as less or equals' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => { '$lte' => 'bar' } })
-        end
-      end
-      context 'less' do
-        let(:operator) { '<' }
-        it 'parses rule as less or equals' do
-          result = subject.parse
-          expect(result).to match({ 'foo' => { '$gte' => 'bar' } })
+        context 'less' do
+          let(:operator) { '<' }
+          it 'parses rule as less or equals' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$gte' => 'bar' } })
+          end
         end
       end
     end
-  end
 
-  context 'with multiple rules' do
-    let(:rules) do
-      [
-        { field: 'foo', value: 'bar1', policy: 'include', rule: 'Equals' },
-        { field: 'foo', value: 'bar2', policy: 'exclude', rule: '>' }
-      ]
+    context 'with multiple rules' do
+      let(:rules) do
+        [
+          { field: 'foo', value: 'bar1', policy: 'include', rule: 'Equals' },
+          { field: 'foo', value: 'bar2', policy: 'exclude', rule: '>' }
+        ]
+      end
+      it 'parses rules as and' do
+        result = subject.parse
+        expect(result).to match({ '$and' => [{ 'foo' => 'bar1' }, { 'foo' => { '$lte' => 'bar2' } }] })
+      end
     end
-    it 'parses rules as and' do
-      result = subject.parse
-      expect(result).to match({ '$and' => [{ 'foo' => 'bar1' }, { 'foo' => { '$lte' => 'bar2' } }] })
-    end
-  end
 
-  context 'with empty rules' do
-    it 'parses rules as empty' do
-      result = subject.parse
-      expect(result).to match({})
+    context 'with empty rules' do
+      it 'parses rules as empty' do
+        result = subject.parse
+        expect(result).to match({})
+      end
     end
-  end
 
-  context 'with invalid operator' do
-    let(:rules) { [{ field: 'foo', value: 'bar', policy: 'include', rule: 'invalid' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Unknown operator/)
+    context 'with invalid operator' do
+      let(:rules) { [{ field: 'foo', value: 'bar', policy: 'include', rule: 'invalid' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Unknown operator/)
+      end
     end
-  end
 
-  context 'with invalid policy' do
-    let(:rules) { [{ field: 'foo', value: 'bar', policy: 'invalid', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Unknown policy/)
+    context 'with invalid policy' do
+      let(:rules) { [{ field: 'foo', value: 'bar', policy: 'invalid', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Unknown policy/)
+      end
     end
-  end
 
-  context 'with empty string value' do
-    let(:rules) { [{ field: 'foo', value: '', policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    context 'with empty string value' do
+      let(:rules) { [{ field: 'foo', value: '', policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+      end
     end
-  end
 
-  context 'with empty string field' do
-    let(:rules) { [{ field: '', value: '123', policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    context 'with empty string field' do
+      let(:rules) { [{ field: '', value: '123', policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+      end
     end
-  end
 
-  context 'with nil value' do
-    let(:rules) { [{ field: 'foo', value: nil, policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    context 'with nil value' do
+      let(:rules) { [{ field: 'foo', value: nil, policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+      end
     end
-  end
 
-  context 'with nil field' do
-    let(:rules) { [{ field: nil, value: '123', policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    context 'with nil field' do
+      let(:rules) { [{ field: nil, value: '123', policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+      end
     end
-  end
 
-  context 'with non-existent value' do
-    let(:rules) { [{ field: 'foo', policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+    context 'with non-existent value' do
+      let(:rules) { [{ field: 'foo', policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Value is required/)
+      end
     end
-  end
 
-  context 'with non-existent field' do
-    let(:rules) { [{ value: '123', policy: 'include', rule: 'Equals' }] }
-    it 'raises error' do
-      expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+    context 'with non-existent field' do
+      let(:rules) { [{ value: '123', policy: 'include', rule: 'Equals' }] }
+      it 'raises error' do
+        expect { subject.parse }.to raise_error(RuntimeError, /Field is required/)
+      end
     end
   end
 end

--- a/spec/connectors/registry_spec.rb
+++ b/spec/connectors/registry_spec.rb
@@ -13,15 +13,17 @@ describe Connectors::Factory do
     described_class.new
   end
 
-  it 'let us register a connector under a name' do
-    class MyConnector
-      def works
-        'works'
+  describe '#connector_class' do
+    it 'let us register a connector under a name' do
+      class MyConnector
+        def works
+          'works'
+        end
       end
-    end
 
-    factory.register('sharepoint', MyConnector)
-    connector_class = factory.connector_class('sharepoint')
-    expect(connector_class.new.works).to eq 'works'
+      factory.register('sharepoint', MyConnector)
+      connector_class = factory.connector_class('sharepoint')
+      expect(connector_class.new.works).to eq 'works'
+    end
   end
 end

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -25,7 +25,7 @@ describe Core::Configuration do
       allow(connector_class).to receive(:configurable_fields_indifferent_access).and_return(configuration.with_indifferent_access)
     end
 
-    describe ".update" do
+    describe '.update' do
       (Connectors::ConnectorStatus::STATUSES - [Connectors::ConnectorStatus::CREATED]).each do |status|
         context "when connector status is #{status}" do
           let(:connector_status) { status }

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -25,121 +25,123 @@ describe Core::Configuration do
       allow(connector_class).to receive(:configurable_fields_indifferent_access).and_return(configuration.with_indifferent_access)
     end
 
-    (Connectors::ConnectorStatus::STATUSES - [Connectors::ConnectorStatus::CREATED]).each do |status|
-      context "when connector status is #{status}" do
-        let(:connector_status) { status }
+    describe ".update" do
+      (Connectors::ConnectorStatus::STATUSES - [Connectors::ConnectorStatus::CREATED]).each do |status|
+        context "when connector status is #{status}" do
+          let(:connector_status) { status }
+          it 'updates nothing' do
+            expect(Core::ElasticConnectorActions).to_not receive(:update_connector_fields)
+
+            described_class.update(connector_settings, param_service_type)
+          end
+        end
+      end
+
+      context 'when connector class is not supported' do
+        let(:connector_class) { nil }
         it 'updates nothing' do
           expect(Core::ElasticConnectorActions).to_not receive(:update_connector_fields)
 
           described_class.update(connector_settings, param_service_type)
         end
       end
-    end
 
-    context 'when connector class is not supported' do
-      let(:connector_class) { nil }
-      it 'updates nothing' do
-        expect(Core::ElasticConnectorActions).to_not receive(:update_connector_fields)
-
-        described_class.update(connector_settings, param_service_type)
-      end
-    end
-
-    it 'updates configuration and status' do
-      expect(Core::ElasticConnectorActions)
-        .to receive(:update_connector_fields)
-        .with(connector_id,
-              hash_including(:configuration => configuration,
-                             :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
-
-      described_class.update(connector_settings)
-    end
-
-    context 'when all configurable fields are set with symbols' do
-      let(:configuration) { { :foo => { :value => 'bar' } } }
-
-      it 'updates status to configured' do
+      it 'updates configuration and status' do
         expect(Core::ElasticConnectorActions)
           .to receive(:update_connector_fields)
           .with(connector_id,
-                hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+                hash_including(:configuration => configuration,
+                               :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
-        described_class.update(connector_settings, param_service_type)
+        described_class.update(connector_settings)
       end
-    end
 
-    context 'when all configurable fields are set with strings' do
-      let(:configuration) { { 'foo' => { 'value' => 'bar' } } }
+      context 'when all configurable fields are set with symbols' do
+        let(:configuration) { { :foo => { :value => 'bar' } } }
 
-      it 'updates status to configured' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id,
-                hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+        it 'updates status to configured' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id,
+                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
-        described_class.update(connector_settings, param_service_type)
+          described_class.update(connector_settings, param_service_type)
+        end
       end
-    end
 
-    context 'when all configurable fields are set with a mix of strings and symbols' do
-      let(:configuration) {
-        {
-          'foo' => {
-            'value' => 'Foo'
-          },
-          :bar => {
-            :value => 'Bar'
+      context 'when all configurable fields are set with strings' do
+        let(:configuration) { { 'foo' => { 'value' => 'bar' } } }
+
+        it 'updates status to configured' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id,
+                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+
+          described_class.update(connector_settings, param_service_type)
+        end
+      end
+
+      context 'when all configurable fields are set with a mix of strings and symbols' do
+        let(:configuration) {
+          {
+            'foo' => {
+              'value' => 'Foo'
+            },
+            :bar => {
+              :value => 'Bar'
+            }
           }
         }
-      }
 
-      it 'updates status to configured' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id,
-                hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+        it 'updates status to configured' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id,
+                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
 
-        described_class.update(connector_settings, param_service_type)
+          described_class.update(connector_settings, param_service_type)
+        end
       end
-    end
 
-    context 'when not all configurable fields are set (with strings)' do
-      let(:configuration) { { 'foo' => { 'value' => nil } } }
+      context 'when not all configurable fields are set (with strings)' do
+        let(:configuration) { { 'foo' => { 'value' => nil } } }
 
-      it 'updates status to configured' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id,
-                hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
+        it 'updates status to configured' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id,
+                  hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
-        described_class.update(connector_settings, param_service_type)
+          described_class.update(connector_settings, param_service_type)
+        end
       end
-    end
 
-    context 'when not all configurable fields are set (with symbols)' do
-      let(:configuration) { { :foo => { :value => nil } } }
+      context 'when not all configurable fields are set (with symbols)' do
+        let(:configuration) { { :foo => { :value => nil } } }
 
-      it 'updates status to configured' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id,
-                hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
+        it 'updates status to configured' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id,
+                  hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
 
-        described_class.update(connector_settings, param_service_type)
+          described_class.update(connector_settings, param_service_type)
+        end
       end
-    end
 
-    context 'when in non-native mode' do
-      let(:service_type) { nil }
-      let(:param_service_type) { 'mongo' }
-      let(:needs_service_type) { true }
+      context 'when in non-native mode' do
+        let(:service_type) { nil }
+        let(:param_service_type) { 'mongo' }
+        let(:needs_service_type) { true }
 
-      it 'updates service type' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id, hash_including(:service_type => param_service_type))
+        it 'updates service type' do
+          expect(Core::ElasticConnectorActions)
+            .to receive(:update_connector_fields)
+            .with(connector_id, hash_including(:service_type => param_service_type))
 
-        described_class.update(connector_settings, param_service_type)
+          described_class.update(connector_settings, param_service_type)
+        end
       end
     end
   end

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -62,7 +62,7 @@ describe Core::ConnectorSettings do
     end
   end
 
-  context '.filtering' do
+  describe '#filtering' do
     context 'filtering is present' do
       let(:elasticsearch_response) {
         {
@@ -98,7 +98,7 @@ describe Core::ConnectorSettings do
     end
   end
 
-  context '.fetch_native_connectors' do
+  describe '#fetch_native_connectors' do
     let(:connectors_meta) {
       {
         :pipeline => {

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -30,7 +30,7 @@ describe Core::ElasticConnectorActions do
     Core::ElasticConnectorActions.instance_variable_set(:@client, nil)
   end
 
-  context '#force_sync' do
+  describe '#force_sync' do
     it 'updates sync_now flag' do
       # { :body => { :doc => { :sync_now => true } } }
       expect(es_client).to receive(:update).with(
@@ -64,7 +64,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#create_connector' do
+  describe '#create_connector' do
     let(:data_index_name) { 'some-data-index-v1-23' }
     let(:service_type) { 'some-service-type' }
     let(:created_connector_id) { 'just-created-this-connector-id-1' }
@@ -111,7 +111,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#get_connector' do
+  describe '#get_connector' do
     before(:each) do
       allow(es_client).to receive(:get).and_return({ '_id' => '123', 'something' => 'something' })
     end
@@ -145,7 +145,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#connectors_meta' do
+  describe '#connectors_meta' do
     before(:each) do
       allow(es_client_indices_api)
         .to receive(:get_mapping)
@@ -157,7 +157,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#search_connectors' do
+  describe '#search_connectors' do
     let(:connector_one) { { '_id' => '123', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
     let(:connector_two) { { '_id' => '456', '_source' => { 'something' => 'something', 'is_native' => true } }.with_indifferent_access }
     let(:query) { { :term => { :is_native => true } } }
@@ -195,7 +195,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#enable_connector_scheduling' do
+  describe '#enable_connector_scheduling' do
     let(:cron_expression) { '0 * * * * *' }
 
     it 'updates connector scheduling.enabled to true' do
@@ -237,7 +237,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#disable_connector_scheduling' do
+  describe '#disable_connector_scheduling' do
     it 'updates connector scheduling.enabled to false' do
       # { :body => { :doc => { :scheduling => { :enabled => true, :something => something} } } }
       expect(es_client).to receive(:update).with(
@@ -258,7 +258,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#set_configurable_field' do
+  describe '#set_configurable_field' do
     let(:field_name) { 'api_key' }
     let(:field_label) { 'API Key' }
     let(:field_value) { 'super secret one!' }
@@ -285,7 +285,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#claim_job' do
+  describe '#claim_job' do
     let(:seq_no) { 1 }
     let(:primary_term) { 1 }
     before(:each) do
@@ -443,7 +443,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#convert_connector_filtering_to_job_filtering' do
+  describe '#convert_connector_filtering_to_job_filtering' do
     shared_examples_for 'job filtering' do
       it 'has the right filtering rules' do
         expect(described_class.convert_connector_filtering_to_job_filtering(connector_filtering)).to eq(job_filtering)
@@ -502,7 +502,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#update_connector_status' do
+  describe '#update_connector_status' do
     let(:expected_payload) do
       {
         :index => connectors_index,
@@ -545,7 +545,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#update_sync' do
+  describe '#update_sync' do
     let(:job_id) { 'update-job-1' }
     let(:metadata) { { :indexed_document_count => 1, :indexed_document_volume => 233, :deleted_document_count => 0 } }
 
@@ -567,7 +567,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#complete_sync' do
+  describe '#complete_sync' do
     let(:job_id) { 'completed-job-1' }
     let(:metadata) { { :indexed_document_count => 1, :indexed_document_volume => 233, :deleted_document_count => 0 } }
     let(:error) { nil }
@@ -636,7 +636,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#fetch_document_ids' do
+  describe '#fetch_document_ids' do
     let(:data_index_name) { 'some-data-index' }
     let(:pit_id) { 'bottomless-pit' }
     let(:first_page_ids) { (1..1000).to_a }
@@ -722,7 +722,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#ensure_index_exists' do
+  describe '#ensure_index_exists' do
     let(:data_index_name) { 'was-i-created-or-not' }
     let(:index_mappings) { {} }
     let(:index_exists) { false }
@@ -786,7 +786,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#ensure_content_index_exists' do
+  describe '#ensure_content_index_exists' do
     let(:index_name) { 'some-cool-index' }
     let(:use_icu_locale) { true }
     let(:language_code) { 'it-IT' }
@@ -806,7 +806,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context '#update_connector_fields' do
+  describe '#update_connector_fields' do
     let(:doc) { {} }
 
     context 'when no doc is passed' do
@@ -852,7 +852,7 @@ describe Core::ElasticConnectorActions do
     end
   end
 
-  context 'get latest index in alias' do
+  describe '.get_latest_index_in_alias' do
     let(:alias_name) { '.ent-search-connectors' }
     let(:indices) { 11.times.collect { |i| ".ent-search-connectors-v#{i}" }.to_a }
 

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -27,7 +27,7 @@ describe Core::Heartbeat do
 
         described_class.send(connector_settings)
       end
-    
+
       context 'when it is configured' do
         let(:configured) { true }
         context 'when remote source is up' do

--- a/spec/core/heartbeat_spec.rb
+++ b/spec/core/heartbeat_spec.rb
@@ -21,46 +21,48 @@ describe Core::Heartbeat do
       allow(connector_instance).to receive(:is_healthy?).and_return(is_healthy)
     end
 
-    it 'updates last_seen' do
-      expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:last_seen => anything))
+    describe '.send' do
+      it 'updates last_seen' do
+        expect(Core::ElasticConnectorActions).to receive(:update_connector_fields).with(connector_id, hash_including(:last_seen => anything))
 
-      described_class.send(connector_settings)
-    end
-
-    context 'when it is configured' do
-      let(:configured) { true }
-      context 'when remote source is up' do
-        let(:is_healthy) { true }
-
-        it 'updates status' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(
-              connector_id,
-              hash_including(
-                :status => Connectors::ConnectorStatus::CONNECTED
-              )
-            )
-
-          described_class.send(connector_settings)
-        end
+        described_class.send(connector_settings)
       end
+    
+      context 'when it is configured' do
+        let(:configured) { true }
+        context 'when remote source is up' do
+          let(:is_healthy) { true }
 
-      context 'when remote source is down' do
-        let(:is_healthy) { false }
-
-        it 'updates status' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(
-              connector_id,
-              hash_including(
-                :status => Connectors::ConnectorStatus::ERROR,
-                :error => /Health check for 3d party service failed/
+          it 'updates status' do
+            expect(Core::ElasticConnectorActions)
+              .to receive(:update_connector_fields)
+              .with(
+                connector_id,
+                hash_including(
+                  :status => Connectors::ConnectorStatus::CONNECTED
+                )
               )
-            )
 
-          described_class.send(connector_settings)
+            described_class.send(connector_settings)
+          end
+        end
+
+        context 'when remote source is down' do
+          let(:is_healthy) { false }
+
+          it 'updates status' do
+            expect(Core::ElasticConnectorActions)
+              .to receive(:update_connector_fields)
+              .with(
+                connector_id,
+                hash_including(
+                  :status => Connectors::ConnectorStatus::ERROR,
+                  :error => /Health check for 3d party service failed/
+                )
+              )
+
+            described_class.send(connector_settings)
+          end
         end
       end
     end

--- a/spec/core/ingestion/console_sink_spec.rb
+++ b/spec/core/ingestion/console_sink_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Core::Ingestion::ConsoleSink do
   subject { described_class.new }
 
-  context '.ingest' do
+  describe '#ingest' do
     let(:doc) { { :id => 1, :something => :else } }
 
     it 'outputs a doc into stdout' do
@@ -13,7 +13,7 @@ describe Core::Ingestion::ConsoleSink do
     end
   end
 
-  context '.delete' do
+  describe '#delete' do
     let(:id) { 15 }
 
     it 'outputs deleted id into stdout' do
@@ -21,7 +21,7 @@ describe Core::Ingestion::ConsoleSink do
     end
   end
 
-  context '.flush' do
+  describe '#flush' do
     it 'outputs flush fact into stdout' do
       expect { subject.flush }.to output(/Flush/).to_stdout
     end

--- a/spec/core/ingestion/es_sink_spec.rb
+++ b/spec/core/ingestion/es_sink_spec.rb
@@ -30,7 +30,7 @@ describe Core::Ingestion::EsSink do
     allow(serializer).to receive(:dump).and_return('')
   end
 
-  context '.ingest' do
+  describe '#ingest' do
     let(:document) do
       {
         :id => 1,
@@ -103,7 +103,7 @@ describe Core::Ingestion::EsSink do
     end
   end
 
-  context '.delete' do
+  describe '#delete' do
     context('when bulk queue still has capacity') do
       let(:id) { 15 }
 
@@ -162,7 +162,7 @@ describe Core::Ingestion::EsSink do
     end
   end
 
-  context '.flush' do
+  describe '#flush' do
     let(:operation) { 'bulk: delete something \n insert something else' }
 
     before(:each) do

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -103,7 +103,7 @@ describe Core::SyncJobRunner do
     extracted_documents.each { |document| allow_statement.and_yield(document) }
   end
 
-  context '.execute' do
+  describe '#execute' do
     let(:ingestion_stats) { { :indexed_document_count => 1, :indexed_document_volume => 233, :deleted_document_count => 0 } }
     before(:each) do
       allow(ingester).to receive(:ingestion_stats).and_return(ingestion_stats)

--- a/spec/utility/bulk_queue_spec.rb
+++ b/spec/utility/bulk_queue_spec.rb
@@ -11,7 +11,7 @@ describe Utility::BulkQueue do
   let(:count_threshold) { 50 }
   let(:size_threshold) { 999999999 } # super high default
 
-  context '.add' do
+  describe '#add' do
     before(:each) do
       allow(subject).to receive(:will_fit?)
         .and_return(true)
@@ -53,7 +53,7 @@ describe Utility::BulkQueue do
     end
   end
 
-  context '.will_fit?' do
+  describe '#will_fit?' do
     let(:op) { 'hello: world' }
 
     context 'when thresholds are not reached' do
@@ -99,7 +99,7 @@ describe Utility::BulkQueue do
     end
   end
 
-  context '.pop_all' do
+  describe '#pop_all' do
     context 'when queue is empty' do
       it 'returns empty string' do
         expect(subject.pop_all).to eq('')
@@ -121,7 +121,7 @@ describe Utility::BulkQueue do
     end
   end
 
-  context '.current_stats' do
+  describe '#current_stats' do
     let(:op_count) { 15 }
     let(:big_operation) { 'this_is: a big operation' }
     let(:big_operation_bytesize) { 300 }

--- a/spec/utility/common_spec.rb
+++ b/spec/utility/common_spec.rb
@@ -9,7 +9,7 @@
 require 'utility/common'
 
 RSpec.describe Utility::Common do
-  context '.return_if_present' do
+  describe '.return_if_present' do
     context 'no argument is present' do
       it 'returns nil' do
         expect(Utility::Common.return_if_present).to be_nil

--- a/spec/utility/exception_tracking_spec.rb
+++ b/spec/utility/exception_tracking_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Utility::ExceptionTracking do
   let(:message) { 'this is a test message' }
   let(:exception) { StandardError.new(message) }
 
-  it 'can log an exception' do
-    expect { described_class.log_exception(exception) }.to output(/#{message}/).to_stdout_from_any_process
+  describe '.log_exception' do
+    it 'can log an exception' do
+      expect { described_class.log_exception(exception) }.to output(/#{message}/).to_stdout_from_any_process
+    end
   end
 end

--- a/spec/utility/logger_spec.rb
+++ b/spec/utility/logger_spec.rb
@@ -22,35 +22,39 @@ RSpec.describe Utility::Logger do
     allow(described_class).to receive(:logger).and_return(logger)
   end
 
-  it 'can give the connectors logger' do
-    expect { described_class.info(message) }.to output(/#{message}/).to_stdout_from_any_process
+  describe '.info' do
+    it 'can give the connectors logger' do
+      expect { described_class.info(message) }.to output(/#{message}/).to_stdout_from_any_process
+    end
+
+    context 'with ecs logging' do
+      let(:logger) { EcsLogging::Logger.new(STDOUT) }
+
+      it 'outputs ecs fields' do
+        expect { described_class.info(message) }.to output(/@timestamp/).to_stdout_from_any_process
+        expect { described_class.info(message) }.to output(/ecs\.version/).to_stdout_from_any_process
+      end
+    end
   end
 
-  it 'can shorten a long message' do
-    expect(described_class.abbreviated_message(long_message).length).to eq(100)
-  end
+  describe '.abbreviated_message' do
+    it 'can shorten a long message' do
+      expect(described_class.abbreviated_message(long_message).length).to eq(100)
+    end
 
-  it 'can clean line breaks' do
-    expect(described_class.abbreviated_message(message_with_breaks).match(/\n/)).to be_falsey
-  end
+    it 'can clean line breaks' do
+      expect(described_class.abbreviated_message(message_with_breaks).match(/\n/)).to be_falsey
+    end
 
-  it 'can clean tabs' do
-    expect(described_class.abbreviated_message(message_with_tabs).match(/\t/)).to be_falsey
-  end
+    it 'can clean tabs' do
+      expect(described_class.abbreviated_message(message_with_tabs).match(/\t/)).to be_falsey
+    end
 
-  it 'can clean extra spaces' do
-    msg = described_class.abbreviated_message(message_with_many_spaces)
-    expect(msg.match(/\s{2,}/)).to be_falsey
-    expect(msg.match(/^\s/)).to be_falsey
-    expect(msg.match(/\s$/)).to be_falsey
-  end
-
-  context 'with ecs logging' do
-    let(:logger) { EcsLogging::Logger.new(STDOUT) }
-
-    it 'outputs ecs fields' do
-      expect { described_class.info(message) }.to output(/@timestamp/).to_stdout_from_any_process
-      expect { described_class.info(message) }.to output(/ecs\.version/).to_stdout_from_any_process
+    it 'can clean extra spaces' do
+      msg = described_class.abbreviated_message(message_with_many_spaces)
+      expect(msg.match(/\s{2,}/)).to be_falsey
+      expect(msg.match(/^\s/)).to be_falsey
+      expect(msg.match(/\s$/)).to be_falsey
     end
   end
 


### PR DESCRIPTION
As discussed in https://github.com/elastic/connectors-ruby/pull/389, some of our tests are not following best practices.

Changes implemented here:

- Change `context` to `describe` if the context is mentioning a particular method
- Double check `#method` and `.method` - see if they actually call class or instance methods and fix it
- Group methods that are not under any `describe` to actually be under `describe '#method'` or `describe '.method'` 