### PR TITLE
MongoDB connector syncs no items with default filtering rules setting

### DIFF
--- a/lib/connectors/base/simple_rules_parser.rb
+++ b/lib/connectors/base/simple_rules_parser.rb
@@ -6,17 +6,17 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/object/blank'
 
 module Connectors
   module Base
     class SimpleRulesParser
       def initialize(rules)
-        @rules = (rules || []).sort_by { |r| r[:order] }
+        @rules = (rules || []).map(&:with_indifferent_access).filter { |r| r[:id] != 'DEFAULT' }.sort_by { |r| r[:order] }
       end
 
       def parse
         merge_rules(@rules.map do |rule|
-          rule = rule.with_indifferent_access
           unless is_include?(rule) || is_exclude?(rule)
             raise "Unknown policy: #{rule[:policy]}"
           end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -172,7 +172,7 @@ module Connectors
           filter = parser.parse
         end
         Utility::Logger.info("Filtering with simple rules filter: #{filter}")
-        collection.find(filter)
+        filter.present? ? collection.find(filter) : collection.find
       end
 
       def extract_options(mongodb_function)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3302

The issue was happening due to default rule having been applied as is, thus producing a condition:

`{ '_': /.*/ }`

This condition ofc matches no documents. 🤦 

Resolution: skip the default rule when parsing simple rules.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally

## Related Pull Requests

* introduced by https://github.com/elastic/connectors-ruby/pull/410
