### PR TITLE
Ignore large documents when ingesting the data

### DIFF
--- a/spec/core/ingestion/ingester_spec.rb
+++ b/spec/core/ingestion/ingester_spec.rb
@@ -63,6 +63,24 @@ describe Core::Ingestion::Ingester do
           subject.ingest(document)
         end
       end
+
+      context 'when ingested document is too big' do
+        let(:document_id) { 15 }
+        let(:document) { { 'id' => document_id, 'something' => 'something' } }
+        let(:serialized_document) { 'id: 15, something: something' }
+        let(:max_allowed_document_size) { 5 } # 5 bytes
+        subject { described_class.new(sink, max_allowed_document_size) }
+
+        before(:each) do
+          allow(sink).to receive(:serialize).with(document).and_return(serialized_document)
+        end
+
+        it 'does not ingest the document' do
+          expect(sink).to_not receive(:ingest)
+
+          subject.ingest(document)
+        end
+      end
     end
 
     context '#ingest_multiple' do

--- a/spec/core/ingestion/ingester_spec.rb
+++ b/spec/core/ingestion/ingester_spec.rb
@@ -80,6 +80,12 @@ describe Core::Ingestion::Ingester do
 
           subject.ingest(document)
         end
+
+        it 'produces a warn statement' do
+          expect(Utility::Logger).to receive(:warn).with(/#{document_id}/)
+
+          subject.ingest(document)
+        end
       end
     end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3097

Adding simple logic to ignore documents that are bigger than allowed. If such document is encountered, it's ignored and a `warn` statement is produced.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Release Note

Now connectors ignore the documents that are too large without attempting to ingest them.
