### PR TITLE
Update connector service to adopt the index mapping change

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -159,7 +159,6 @@ module Core
         )
 
         body = {
-          :connector_id => connector_id,
           :status => Connectors::SyncStatus::IN_PROGRESS,
           :worker_hostname => Socket.gethostname,
           :created_at => Time.now,

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -165,7 +165,10 @@ module Core
           :created_at => Time.now,
           :started_at => Time.now,
           :last_seen => Time.now,
-          :filtering => convert_connector_filtering_to_job_filtering(connector_record.dig('_source', 'filtering'))
+          :connector => {
+            :id => connector_id,
+            :filtering => convert_connector_filtering_to_job_filtering(connector_record.dig('_source', 'filtering'))
+          }
         }
 
         index_response = client.index(:index => Utility::Constants::JOB_INDEX, :body => body, :refresh => true)

--- a/spec/core/elastic_connector_actions_spec.rb
+++ b/spec/core/elastic_connector_actions_spec.rb
@@ -660,9 +660,11 @@ describe Core::ElasticConnectorActions do
           :worker_hostname,
           :created_at,
           :started_at,
-          :connector_id => connector_id,
           :status => Connectors::SyncStatus::IN_PROGRESS,
-          :filtering => anything
+          :connector => {
+            :id => connector_id,
+            :filtering => anything
+          }
         ),
         :refresh => true
       )
@@ -751,7 +753,7 @@ describe Core::ElasticConnectorActions do
       it 'has filtering rules' do
         expect(es_client).to receive(:index).with(
           :index => jobs_index,
-          :body => hash_including(:filtering => [job_filtering]),
+          :body => hash_including(:connector => hash_including(:filtering => [job_filtering])),
           :refresh => true
         )
         described_class.claim_job(connector_id)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3283

Update the connector service to adopt the new index mapping of job index, where all connector data are group under key `connector`.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally