### PR TITLE
Only return supported connectors in native mode

### DIFF
--- a/lib/app/preflight_check.rb
+++ b/lib/app/preflight_check.rb
@@ -23,6 +23,7 @@ module App
         check_es_connection!
         check_es_version!
         check_system_indices!
+        check_single_connector!
       end
 
       private
@@ -57,6 +58,16 @@ module App
           :retry_interval => STARTUP_RETRY_INTERVAL,
           :retry_timeout => STARTUP_RETRY_TIMEOUT
         )
+      end
+
+      #-------------------------------------------------------------------------------------------------
+      # Ensures the connector is supported when running in non-native mode
+      def check_single_connector!
+        if App::Config.native_mode
+          Utility::Logger.info('Skip single connector check for native mode.')
+        elsif !Connectors::REGISTRY.registered?(App::Config.service_type)
+          fail_check!("The service type #{App::Config.service_type} is not supported. Terminating...")
+        end
       end
 
       def check_es_connection_with_retries!(retry_interval:, retry_timeout:)

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -8,6 +8,7 @@
 
 require 'active_support/core_ext/hash/indifferent_access'
 require 'connectors/connector_status'
+require 'connectors/registry'
 require 'core/elastic_connector_actions'
 require 'utility'
 
@@ -35,7 +36,14 @@ module Core
     end
 
     def self.fetch_native_connectors(page_size = DEFAULT_PAGE_SIZE)
-      query = { term: { is_native: true } }
+      query = {
+        bool: {
+          filter: [
+            { term: { is_native: true } },
+            { terms: { service_type: Connectors::REGISTRY.registered_connectors } }
+          ]
+        }
+      }
       fetch_connectors_by_query(query, page_size)
     end
 

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -66,8 +66,6 @@ module Core
     private
 
     def sync_triggered?(connector_settings)
-      return false unless connector_registered?(connector_settings.service_type)
-
       unless connector_settings.valid_index_name?
         Utility::Logger.warn("The index name of #{connector_settings.formatted} is invalid.")
         return false
@@ -133,8 +131,6 @@ module Core
     end
 
     def heartbeat_triggered?(connector_settings)
-      return false unless connector_registered?(connector_settings.service_type)
-
       last_seen = connector_settings[:last_seen]
       return true if last_seen.nil? || last_seen.empty?
       last_seen = begin
@@ -148,16 +144,10 @@ module Core
     end
 
     def configuration_triggered?(connector_settings)
-      if connector_settings.needs_service_type? || connector_registered?(connector_settings.service_type)
-        return connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
-      end
-
-      false
+      connector_settings.needs_service_type? || connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
     end
 
     def filtering_validation_triggered?(connector_settings)
-      return false unless connector_registered?(connector_settings.service_type)
-
       filtering = connector_settings.filtering
 
       unless filtering.present?


### PR DESCRIPTION
This PR made the following changes:
1. When running in native mode, only supported native connectors will be returned when querying ES
2. When running in single mode, an additional check is added in the pre-flight check to make sure the service type in config is supported


## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
