### PR TITLE
Start sync when scheduling is enabled and properly configured and there's no sync before

### DIFF
--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -119,7 +119,7 @@ module Core
         return true
       end
 
-      next_trigger_time = cron_parser.next_time(last_synced)
+      next_trigger_time = cron_parser.next_time(Time.parse(last_synced))
 
       # Sync if next trigger for the connector is in past
       if next_trigger_time < Time.now

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -112,14 +112,12 @@ module Core
         return false
       end
 
-      # We want to sync when sync never actually happened
-      last_synced = connector_settings[:last_synced]
-      if last_synced.nil? || last_synced.empty?
-        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
-        return true
+      last_synced = begin
+        Time.parse(connector_settings[:last_synced])
+      rescue StandardError
+        Time.now
       end
-
-      next_trigger_time = cron_parser.next_time(Time.parse(last_synced))
+      next_trigger_time = cron_parser.next_time(last_synced)
 
       # Sync if next trigger for the connector is in past
       if next_trigger_time < Time.now

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -90,13 +90,6 @@ module Core
         return false
       end
 
-      # We want to sync when sync never actually happened
-      last_synced = connector_settings[:last_synced]
-      if last_synced.nil? || last_synced.empty?
-        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
-        return true
-      end
-
       current_schedule = scheduling_settings[:interval]
 
       # Don't sync if there is no actual scheduling interval
@@ -117,6 +110,13 @@ module Core
       unless cron_parser
         Utility::Logger.error("Unable to parse sync schedule for #{connector_settings.formatted}: expression #{current_schedule} is not a valid Quartz Cron definition.")
         return false
+      end
+
+      # We want to sync when sync never actually happened
+      last_synced = connector_settings[:last_synced]
+      if last_synced.nil? || last_synced.empty?
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
+        return true
       end
 
       next_trigger_time = cron_parser.next_time(Time.parse(last_synced))

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -112,11 +112,13 @@ module Core
         return false
       end
 
-      last_synced = begin
-        Time.parse(connector_settings[:last_synced])
-      rescue StandardError
-        Time.now
+      # We want to sync when sync never actually happened
+      last_synced = connector_settings[:last_synced]
+      if last_synced.nil? || last_synced.empty?
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
+        return true
       end
+
       next_trigger_time = cron_parser.next_time(last_synced)
 
       # Sync if next trigger for the connector is in past

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -36,7 +36,7 @@ describe Core::Scheduler do
     context 'with sync task' do
       let(:allow_sync) { true }
       let(:sync_now) { false }
-      let(:last_synced) { 'last synced' }
+      let(:last_synced) { Time.now }
       let(:sync_enabled) { true }
       let(:sync_interval) { '0 0 * * * ?' }
       let(:scheduling_settings) do
@@ -116,12 +116,6 @@ describe Core::Scheduler do
         let(:cron_parser) { nil }
 
         it_behaves_like 'does not trigger', :sync
-      end
-
-      context 'when connector is never synced' do
-        let(:last_synced) { nil }
-
-        it_behaves_like 'triggers', :sync
       end
 
       context 'when next trigger time is in the future' do

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -36,7 +36,7 @@ describe Core::Scheduler do
     context 'with sync task' do
       let(:allow_sync) { true }
       let(:sync_now) { false }
-      let(:last_synced) { Time.now }
+      let(:last_synced) { 'last synced' }
       let(:sync_enabled) { true }
       let(:sync_interval) { '0 0 * * * ?' }
       let(:scheduling_settings) do
@@ -116,6 +116,12 @@ describe Core::Scheduler do
         let(:cron_parser) { nil }
 
         it_behaves_like 'does not trigger', :sync
+      end
+
+      context 'when connector is never synced' do
+        let(:last_synced) { nil }
+
+        it_behaves_like 'triggers', :sync
       end
 
       context 'when next trigger time is in the future' do

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -98,12 +98,6 @@ describe Core::Scheduler do
         it_behaves_like 'does not trigger', :sync
       end
 
-      context 'when connector is never synced' do
-        let(:last_synced) { nil }
-
-        it_behaves_like 'triggers', :sync
-      end
-
       context 'when connector sync interval is not configured' do
         let(:sync_interval) { nil }
 
@@ -122,6 +116,12 @@ describe Core::Scheduler do
         let(:cron_parser) { nil }
 
         it_behaves_like 'does not trigger', :sync
+      end
+
+      context 'when connector is never synced' do
+        let(:last_synced) { nil }
+
+        it_behaves_like 'triggers', :sync
       end
 
       context 'when next trigger time is in the future' do


### PR DESCRIPTION
This is a bug reported in [slack](https://elastic.slack.com/archives/C03GAPTQ2JF/p1668460076978669). An initial sync will be triggered even operator never manually clicks `Sync` button or schedule a sync job.

This PR fixes the bug, so that the initial job will be triggered, only when operators explicitly enable and configure a schedule.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally