### PR TITLE
Make it possible to specify maximum size/volume of ingestion queue

### DIFF
--- a/config/connectors.yml.example
+++ b/config/connectors.yml.example
@@ -29,3 +29,5 @@ native_mode: true
 connector_id: CHANGEME
 service_type: CHANGEME
 
+max_ingestion_queue_size: 500
+max_ingestion_queue_bytes: 5242880

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -31,6 +31,8 @@ cp config/connectors.yml.example config/connectors.yml
 - `native_mode`: Whether to run the application in `native mode`. Defaults to `true`.
 - `connector_id`: The ID of the connector that the application will sync data for. This is required when `native_mode` is `false`.
 - `service_type`: The service type of the connector that the application will sync data for. This is required when `native_mode` is `false`. 
+- `max_ingestion_queue_size`: When number of documents in bulk operation exceeds this number, a bulk request is issued to Elasticsearch. Defaults to `500`.
+- `max_ingestion_queue_bytes`: When byte size of bulk operation exceeds this number, a bulk request is issued to Elasticsearch. Defaults to `5242880`.
 
 ## Run the connector service on Elastic Cloud
 

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -54,6 +54,9 @@ puts "Parsing #{CONFIG_FILE} configuration file."
     optional(:poll_interval).value(:integer)
     optional(:termination_timeout).value(:integer)
     optional(:heartbeat_interval).value(:integer)
+
+    optional(:max_ingestion_queue_size).value(:integer) # items
+    optional(:max_ingestion_queue_bytes).value(:integer) # bytes
   end
 end
 

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -21,6 +21,8 @@ module App
     MIN_THREADS = (App::Config.dig(:thread_pool, :min_threads) || 0).to_i
     MAX_THREADS = (App::Config.dig(:thread_pool, :max_threads) || 5).to_i
     MAX_QUEUE = (App::Config.dig(:thread_pool, :max_queue) || 100).to_i
+    MAX_INGESTION_QUEUE_SIZE = (App::Config.max_ingestion_queue_size || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE).to_i 
+    MAX_INGESTION_QUEUE_BYTES = (App::Config.max_ingestion_queue_bytes || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES).to_i
 
     @running = Concurrent::AtomicBoolean.new(false)
 
@@ -90,6 +92,26 @@ module App
         end
       rescue StandardError => e
         Utility::ExceptionTracking.log_exception(e, 'The connector service failed due to unexpected error.')
+      end
+
+      def start_sync_task(connector_settings)
+        start_heartbeat_task(connector_settings)
+        pool.post do
+          Utility::Logger.info("Initiating a sync job for #{connector_settings.formatted}...")
+          Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
+          job_runner = Core::SyncJobRunner.new(
+            connector_settings,
+            MAX_INGESTION_QUEUE_SIZE,
+            MAX_INGESTION_QUEUE_BYTES
+          )
+          job_runner.execute
+        rescue Core::JobAlreadyRunningError
+          Utility::Logger.info("Sync job for #{connector_settings.formatted} is already running, skipping.")
+        rescue Core::ConnectorVersionChangedError => e
+          Utility::Logger.info("Could not start the job because #{connector_settings.formatted} has been updated externally. Message: #{e.message}")
+        rescue StandardError => e
+          Utility::ExceptionTracking.log_exception(e, "Sync job for #{connector_settings.formatted} failed due to unexpected error.")
+        end
       end
 
       def start_heartbeat_task(connector_settings)

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -21,8 +21,6 @@ module App
     MIN_THREADS = (App::Config.dig(:thread_pool, :min_threads) || 0).to_i
     MAX_THREADS = (App::Config.dig(:thread_pool, :max_threads) || 5).to_i
     MAX_QUEUE = (App::Config.dig(:thread_pool, :max_queue) || 100).to_i
-    MAX_INGESTION_QUEUE_SIZE = (App::Config.max_ingestion_queue_size || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE).to_i 
-    MAX_INGESTION_QUEUE_BYTES = (App::Config.max_ingestion_queue_bytes || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES).to_i
 
     @running = Concurrent::AtomicBoolean.new(false)
 
@@ -101,8 +99,8 @@ module App
           Core::ElasticConnectorActions.ensure_content_index_exists(connector_settings.index_name)
           job_runner = Core::SyncJobRunner.new(
             connector_settings,
-            MAX_INGESTION_QUEUE_SIZE,
-            MAX_INGESTION_QUEUE_BYTES
+            (App::Config.max_ingestion_queue_size || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE).to_i,
+            (App::Config.max_ingestion_queue_bytes || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES).to_i
           )
           job_runner.execute
         rescue Core::JobAlreadyRunningError

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -133,7 +133,8 @@ module App
           min_threads: MIN_THREADS,
           max_threads: MAX_THREADS,
           max_queue: MAX_QUEUE,
-          app_config: App::Config,
+          max_ingestion_queue_size: (App::Config.max_ingestion_queue_size || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE).to_i,
+          max_ingestion_queue_bytes: (App::Config.max_ingestion_queue_bytes || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES).to_i,
           scheduler: scheduler
         )
 

--- a/lib/core/ingestion/es_sink.rb
+++ b/lib/core/ingestion/es_sink.rb
@@ -21,7 +21,7 @@ require 'elasticsearch/api'
 module Core
   module Ingestion
     class EsSink
-      def initialize(index_name, request_pipeline, bulk_queue = Utility::BulkQueue.new, max_allowed_document_size = 5 * 1024 * 1024)
+      def initialize(index_name, request_pipeline, bulk_queue = Utility::BulkQueue.new, max_allowed_document_size = Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES)
         @client = Utility::EsClient.new(App::Config[:elasticsearch])
         @index_name = index_name
         @request_pipeline = request_pipeline

--- a/lib/core/jobs/consumer.rb
+++ b/lib/core/jobs/consumer.rb
@@ -11,15 +11,25 @@ require 'utility/constants'
 module Core
   module Jobs
     class Consumer
-      def initialize(scheduler:, app_config:, poll_interval: 3, termination_timeout: 60, min_threads: 1, max_threads: 5, max_queue: 100, idle_time: 5)
+      def initialize(scheduler:,
+                     max_ingestion_queue_size:,
+                     max_ingestion_queue_bytes:,
+                     poll_interval: 3,
+                     termination_timeout: 60,
+                     min_threads: 1,
+                     max_threads: 5,
+                     max_queue: 100,
+                     idle_time: 5)
         @scheduler = scheduler
-        @app_config = app_config
         @poll_interval = poll_interval
         @termination_timeout = termination_timeout
         @min_threads = min_threads
         @max_threads = max_threads
         @max_queue = max_queue
         @idle_time = idle_time
+
+        @max_ingestion_queue_size = max_ingestion_queue_size
+        @max_ingestion_queue_bytes = max_ingestion_queue_bytes
 
         @running = Concurrent::AtomicBoolean.new(false)
       end
@@ -82,8 +92,8 @@ module Core
                 job_runner = Core::SyncJobRunner.new(
                   connector_settings,
                   job,
-                  (@app_config.max_ingestion_queue_size || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE).to_i,
-                  (@app_config.max_ingestion_queue_bytes || Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES).to_i
+                  @max_ingestion_queue_size,
+                  @max_ingestion_queue_bytes
                 )
                 job_runner.execute
               rescue Core::JobAlreadyRunningError

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -29,7 +29,7 @@ module Core
         connector_settings.index_name,
         @connector_settings.request_pipeline,
         Utility::BulkQueue.new(
-          max_ingestion_queue_size, 
+          max_ingestion_queue_size,
           max_ingestion_queue_bytes
         ),
         max_ingestion_queue_bytes

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -23,9 +23,17 @@ module Core
   class SyncJobRunner
     JOB_REPORTING_INTERVAL = 10
 
-    def initialize(connector_settings, job)
+    def initialize(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_bytes)
       @connector_settings = connector_settings
-      @sink = Core::Ingestion::EsSink.new(connector_settings.index_name, @connector_settings.request_pipeline)
+      @sink = Core::Ingestion::EsSink.new(
+        connector_settings.index_name,
+        @connector_settings.request_pipeline,
+        Utility::BulkQueue.new(
+          max_ingestion_queue_size, 
+          max_ingestion_queue_bytes
+        ),
+        max_ingestion_queue_bytes
+      )
       @connector_class = Connectors::REGISTRY.connector_class(connector_settings.service_type)
       @sync_finished = false
       @sync_error = nil

--- a/lib/utility/bulk_queue.rb
+++ b/lib/utility/bulk_queue.rb
@@ -6,12 +6,14 @@
 
 require 'json'
 
+require 'utility/constants'
+
 module Utility
   class BulkQueue
     class QueueOverflowError < StandardError; end
 
     # 500 items or 5MB
-    def initialize(operation_count_threshold = 500, size_threshold = 5 * 1024 * 1024)
+    def initialize(operation_count_threshold = Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_LENGTH, size_threshold = Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES)
       @operation_count_threshold = operation_count_threshold.freeze
       @size_threshold = size_threshold.freeze
 

--- a/lib/utility/constants.rb
+++ b/lib/utility/constants.rb
@@ -18,5 +18,10 @@ module Utility
     CRAWLER_SERVICE_TYPE = 'elastic-crawler'
     FILTERING_RULES_FEATURE = 'filtering_rules'
     FILTERING_ADVANCED_FEATURE = 'filtering_advanced_config'
+
+    # Maximum number of operations in BULK Elasticsearch operation that will ingest the data
+    DEFAULT_MAX_INGESTION_QUEUE_SIZE = 500
+    # Maximum size of either whole BULK Elasticsearch operation or one document in it
+    DEFAULT_MAX_INGESTION_QUEUE_BYTES = 5 * 1024 * 1024
   end
 end

--- a/spec/app/dispatcher_spec.rb
+++ b/spec/app/dispatcher_spec.rb
@@ -16,8 +16,6 @@ describe App::Dispatcher do
   let(:filter_validation_job_runner) { double }
   let(:connector_id) { 123 }
   let(:info_message) { nil }
-  let(:max_ingestion_queue_size) { 123 }
-  let(:max_ingestion_queue_bytes) { 123456789 }
 
   before(:each) do
     allow(described_class).to receive(:scheduler).and_return(scheduler)
@@ -42,9 +40,6 @@ describe App::Dispatcher do
     stub_const('App::Dispatcher::MIN_THREADS', 0)
     stub_const('App::Dispatcher::MAX_THREADS', 5)
     stub_const('App::Dispatcher::MAX_QUEUE', 100)
-
-    allow(App::Config).to receive(:max_ingestion_queue_size).and_return(max_ingestion_queue_size)
-    allow(App::Config).to receive(:max_ingestion_queue_bytes).and_return(max_ingestion_queue_bytes)
   end
 
   after(:each) do
@@ -113,33 +108,6 @@ describe App::Dispatcher do
           allow(connector_settings).to receive(:service_type).and_return('')
           allow(connector_settings).to receive(:index_name).and_return('')
           allow(connector_settings).to receive(:id).and_return('connector_id')
-        end
-
-        context 'when config has max_ingestion_* settings overridden' do
-          it 'creates sync job runner with settings from config' do
-            expect(Core::SyncJobRunner).to receive(:new).with(anything, max_ingestion_queue_size, max_ingestion_queue_bytes)
-
-            described_class.start!
-          end
-        end
-
-        context 'when config has not provided max_ingestion_* settings' do
-          let(:max_ingestion_queue_size) { nil }
-          let(:max_ingestion_queue_bytes) { nil }
-
-          let(:default_max_ingestion_queue_size) { 1 }
-          let(:default_max_ingestion_queue_bytes) { 10 }
-
-          before(:each) do
-            stub_const('Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE', default_max_ingestion_queue_size)
-            stub_const('Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES', default_max_ingestion_queue_bytes)
-          end
-
-          it 'creates sync job runner with settings from config' do
-            expect(Core::SyncJobRunner).to receive(:new).with(anything, default_max_ingestion_queue_size, default_max_ingestion_queue_bytes)
-
-            described_class.start!
-          end
         end
 
         shared_examples_for 'sync' do

--- a/spec/app/dispatcher_spec.rb
+++ b/spec/app/dispatcher_spec.rb
@@ -16,6 +16,8 @@ describe App::Dispatcher do
   let(:filter_validation_job_runner) { double }
   let(:connector_id) { 123 }
   let(:info_message) { nil }
+  let(:max_ingestion_queue_size) { 123 }
+  let(:max_ingestion_queue_bytes) { 123456789 }
 
   before(:each) do
     allow(described_class).to receive(:scheduler).and_return(scheduler)
@@ -40,6 +42,9 @@ describe App::Dispatcher do
     stub_const('App::Dispatcher::MIN_THREADS', 0)
     stub_const('App::Dispatcher::MAX_THREADS', 5)
     stub_const('App::Dispatcher::MAX_QUEUE', 100)
+
+    allow(App::Config).to receive(:max_ingestion_queue_size).and_return(max_ingestion_queue_size)
+    allow(App::Config).to receive(:max_ingestion_queue_bytes).and_return(max_ingestion_queue_bytes)
   end
 
   after(:each) do
@@ -108,6 +113,33 @@ describe App::Dispatcher do
           allow(connector_settings).to receive(:service_type).and_return('')
           allow(connector_settings).to receive(:index_name).and_return('')
           allow(connector_settings).to receive(:id).and_return('connector_id')
+        end
+
+        context 'when config has max_ingestion_* settings overridden' do
+          it 'creates sync job runner with settings from config' do
+            expect(Core::SyncJobRunner).to receive(:new).with(anything, max_ingestion_queue_size, max_ingestion_queue_bytes)
+
+            described_class.start!
+          end
+        end
+
+        context 'when config has not provided max_ingestion_* settings' do
+          let(:max_ingestion_queue_size) { nil }
+          let(:max_ingestion_queue_bytes) { nil }
+
+          let(:default_max_ingestion_queue_size) { 1 }
+          let(:default_max_ingestion_queue_bytes) { 10 }
+
+          before(:each) do
+            stub_const('Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_SIZE', default_max_ingestion_queue_size)
+            stub_const('Utility::Constants::DEFAULT_MAX_INGESTION_QUEUE_BYTES', default_max_ingestion_queue_bytes)
+          end
+
+          it 'creates sync job runner with settings from config' do
+            expect(Core::SyncJobRunner).to receive(:new).with(anything, default_max_ingestion_queue_size, default_max_ingestion_queue_bytes)
+
+            described_class.start!
+          end
         end
 
         shared_examples_for 'sync' do

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -86,7 +86,10 @@ describe Core::SyncJobRunner do
     }
   end
 
-  subject { described_class.new(connector_settings, job) }
+  let(:max_ingestion_queue_size) { 123 }
+  let(:max_ingestion_queue_volume) { 123456789 }
+
+  subject { described_class.new(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_volume) }
 
   before(:each) do
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -89,7 +89,7 @@ describe Core::SyncJobRunner do
   let(:max_ingestion_queue_size) { 123 }
   let(:max_ingestion_queue_bytes) { 123456789 }
 
-  subject { described_class.new(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_volume) }
+  subject { described_class.new(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_bytes) }
 
   before(:each) do
     allow(Core::ConnectorSettings).to receive(:fetch).with(connector_id).and_return(connector_settings)
@@ -148,7 +148,7 @@ describe Core::SyncJobRunner do
       expect(Core::Ingestion::EsSink).to receive(:new)
         .with(anything, anything, bulk_queue, max_ingestion_queue_bytes)
 
-      described_class.new(connector_settings, max_ingestion_queue_size, max_ingestion_queue_bytes)
+      described_class.new(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_bytes)
     end
   end
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3097
## Part of https://github.com/elastic/enterprise-search-team/issues/3096

Now it's possible to specify maximum size/volume of ingestion queue.

```
max_ingestion_queue_size: X - data from the connector will be sent to Elasticsearch once X items were extracted
max_ingestion_queue_bytes: Y - data from the connector will be sent to Elasticsearch once bulk operation reaches Y bytes
```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
