### PR TITLE
Mark "find.filter" in the advanced snippet (MongoDB) as optional

### DIFF
--- a/lib/connectors/base/advanced_snippet_against_schema_validator.rb
+++ b/lib/connectors/base/advanced_snippet_against_schema_validator.rb
@@ -60,7 +60,7 @@ module Connectors
           if field[:fields].present?
             validation_result = validate_against_schema(field, snippet_field_value, recursion_depth + 1)
 
-            return validation_result unless validation_result[:is_valid]
+            return validation_result unless validation_result[:state] == Core::Filtering::ValidationStatus::VALID
           end
         end
 

--- a/lib/connectors/mongodb/mongo_advanced_snippet_schema.rb
+++ b/lib/connectors/mongodb/mongo_advanced_snippet_schema.rb
@@ -265,7 +265,8 @@ module Connectors
 
       FIND_FILTER = {
         :name => 'filter',
-        :type => FILTER
+        :type => FILTER,
+        :optional => true
       }
 
       FIND = {

--- a/spec/connectors/base/advanced_snippet_against_schema_validator_spec.rb
+++ b/spec/connectors/base/advanced_snippet_against_schema_validator_spec.rb
@@ -209,6 +209,14 @@ describe Connectors::Base::AdvancedSnippetAgainstSchemaValidator do
 
             it_behaves_like 'advanced snippet is invalid'
           end
+
+          context 'advanced snippet is empty' do
+            let(:advanced_snippet) {
+              {}
+            }
+
+            it_behaves_like 'advanced snippet is invalid'
+          end
         end
       end
 

--- a/spec/connectors/mongodb/mongo_advanced_snippet_against_schema_validator_spec.rb
+++ b/spec/connectors/mongodb/mongo_advanced_snippet_against_schema_validator_spec.rb
@@ -17,6 +17,24 @@ describe Connectors::MongoDB::MongoAdvancedSnippetAgainstSchemaValidator do
   subject { described_class.new(advanced_snippet) }
 
   describe '#is_snippet_valid?' do
+    context 'advanced snippet is not present' do
+      context 'advanced snippet is nil' do
+        let(:advanced_snippet) {
+          nil
+        }
+
+        it_behaves_like 'advanced snippet is valid'
+      end
+
+      context 'advanced snippet is empty' do
+        let(:advanced_snippet) {
+          {}
+        }
+
+        it_behaves_like 'advanced snippet is valid'
+      end
+    end
+
     context 'aggregate and find present' do
       let(:advanced_snippet) {
         {
@@ -27,6 +45,96 @@ describe Connectors::MongoDB::MongoAdvancedSnippetAgainstSchemaValidator do
 
       it_behaves_like 'advanced snippet is invalid'
     end
+
+    context 'find' do
+      context 'find is not present' do
+        context 'find is nil' do
+          let(:advanced_snippet) {
+            {
+              :find => nil
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+
+        context 'find is empty' do
+          let(:advanced_snippet) {
+            {
+              :find => {}
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+      end
+
+      context 'filter is not present' do
+        context 'filter is nil' do
+          let(:advanced_snippet) {
+            {
+              :find => {
+                :filter => nil
+              }
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+
+        context 'filter is empty' do
+          let(:advanced_snippet) {
+            {
+              :find => {
+                :filter => {}
+              }
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+      end
+
+      context 'options are not present' do
+        context 'options are nil' do
+          let(:advanced_snippet) {
+            {
+              :find => {
+                :options => nil
+              }
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+
+        context 'options are empty' do
+          let(:advanced_snippet) {
+            {
+              :find => {
+                :options => {}
+              }
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
+      end
+
+      context 'filter and options are empty' do
+        let(:advanced_snippet) {
+          {
+            :find => {
+              :filter => {},
+              :options => {}
+            }
+          }
+        }
+
+        it_behaves_like 'advanced snippet is valid'
+      end
+    end
+
 
     context 'aggregate' do
       context 'options' do

--- a/spec/connectors/mongodb/mongo_advanced_snippet_against_schema_validator_spec.rb
+++ b/spec/connectors/mongodb/mongo_advanced_snippet_against_schema_validator_spec.rb
@@ -135,7 +135,6 @@ describe Connectors::MongoDB::MongoAdvancedSnippetAgainstSchemaValidator do
       end
     end
 
-
     context 'aggregate' do
       context 'options' do
         context 'snippet with every option' do


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3349 ##

This PR marks the "find.filter" field in the advanced snippet for MongoDB as optional so we don't return an invalid result, when it's missing.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally