### PR TITLE
Add more tests for fields constraints and unify two method calls

### DIFF
--- a/lib/connectors/base/advanced_snippet_against_schema_validator.rb
+++ b/lib/connectors/base/advanced_snippet_against_schema_validator.rb
@@ -42,7 +42,7 @@ module Connectors
 
         return unexpected_field(schema_field_names, snippet_field_names) if unexpected_field_present?(snippet_field_names, schema_field_names)
 
-        return fields_constraint_violation(config_schema[:fields]) if fields_constraints_violated?(config_schema, advanced_snippet)
+        return fields_constraint_violation(config_schema[:fields]) if fields_constraints_violated?(config_schema[:fields], advanced_snippet)
 
         schema_fields.each do |field|
           name = field[:name]
@@ -67,10 +67,10 @@ module Connectors
         valid_snippet
       end
 
-      def fields_constraints_violated?(config_schema, advanced_snippet)
-        return false unless config_schema[:fields].is_a?(Hash)
+      def fields_constraints_violated?(fields, advanced_snippet)
+        return false if !fields.present? || !fields.is_a?(Hash)
 
-        constraints = config_schema.dig(:fields, :constraints)
+        constraints = fields[:constraints]
         constraints = constraints.is_a?(Array) ? constraints : [constraints]
 
         constraints.each do |constraint|

--- a/spec/connectors/base/advanced_snippet_against_schema_validator_spec.rb
+++ b/spec/connectors/base/advanced_snippet_against_schema_validator_spec.rb
@@ -22,7 +22,7 @@ describe Connectors::Base::AdvancedSnippetAgainstSchemaValidator do
   it_behaves_like 'an advanced snippet validator'
 
   describe '#is_snippet_valid?' do
-    context 'fields constraint is present' do
+    context 'fields constraints are present' do
       let(:constraints) {
         [false]
       }
@@ -48,18 +48,35 @@ describe Connectors::Base::AdvancedSnippetAgainstSchemaValidator do
       }
 
       context 'only one field allowed' do
-        let(:constraints) {
-          [->(fields) { fields.size == 1 }]
-        }
-
-        let(:advanced_snippet) {
-          {
-            :field_one => 'value one',
-            :field_two => 'value two'
+        context 'constraint is not wrapped in an array' do
+          let(:constraints) {
+            ->(fields) { fields.size == 1 }
           }
-        }
 
-        it_behaves_like 'advanced snippet is invalid'
+          let(:advanced_snippet) {
+            {
+              :field_one => 'value one',
+              :field_two => 'value two'
+            }
+          }
+
+          it_behaves_like 'advanced snippet is invalid'
+        end
+
+        context 'constraint is wrapped in an array' do
+          let(:constraints) {
+            [->(fields) { fields.size == 1 }]
+          }
+
+          let(:advanced_snippet) {
+            {
+              :field_one => 'value one',
+              :field_two => 'value two'
+            }
+          }
+
+          it_behaves_like 'advanced snippet is invalid'
+        end
       end
 
       context 'two fields allowed' do
@@ -75,6 +92,41 @@ describe Connectors::Base::AdvancedSnippetAgainstSchemaValidator do
         }
 
         it_behaves_like 'advanced snippet is valid'
+      end
+
+      context 'two fields are allowed and their key must be equal to their value' do
+        let(:constraints) {
+          [
+            ->(fields) { fields.size == 2 },
+            lambda { |fields|
+              fields.each { |field_name, field_value|
+                return false unless field_name.to_s == field_value
+              }
+            }
+          ]
+        }
+
+        context 'the value of the second field is not the same as the field name' do
+          let(:advanced_snippet) {
+            {
+              :field_one => 'field_one',
+              :field_two => 'wrong value'
+            }
+          }
+
+          it_behaves_like 'advanced snippet is invalid'
+        end
+
+        context 'both field names equal their value' do
+          let(:advanced_snippet) {
+            {
+              :field_one => 'field_one',
+              :field_two => 'field_two'
+            }
+          }
+
+          it_behaves_like 'advanced snippet is valid'
+        end
       end
     end
 


### PR DESCRIPTION
This PR adds some more tests for fields constraints:
- Multiple fields constraints present
- Single constraint wrapped in an array
- Single constraint not wrapped in an array

Also unified the calls to `fields_constraint_violation` and `fields_constraints_violated?`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally