### PR TITLE
Fix a problem with error monitor and max_error_ratio being incorrectly handled

### DIFF
--- a/lib/utility/error_monitor.rb
+++ b/lib/utility/error_monitor.rb
@@ -93,7 +93,7 @@ module Utility
     end
 
     def num_errors_in_window
-      @window_errors.count { |e| e == true } .to_f
+      @window_errors.count(true).to_f
     end
 
     def increment_window_index

--- a/lib/utility/error_monitor.rb
+++ b/lib/utility/error_monitor.rb
@@ -51,6 +51,7 @@ module Utility
     def note_success
       @consecutive_error_count = 0
       @success_count += 1
+      @window_errors[@window_index] = false
       increment_window_index
     end
 
@@ -92,10 +93,31 @@ module Utility
     end
 
     def num_errors_in_window
-      @window_errors.count(&:itself).to_f
+      @window_errors.count { |e| e == true } .to_f
     end
 
     def increment_window_index
+      # We keep the errors array of the size @window_size this way, imagine @window_size = 5
+      # Error array inits as falses:
+      # [ false, false, false, false, false ]
+      # Third document raises an error:
+      # [ false, false, true,  false, false ]
+      #                 ^^^^ 
+      #                 2 % 5 == 2
+      # Fifth document raises an error:
+      # [ false, false, true,  false, true  ]
+      #                               ^^^^
+      #                               4 % 5 == 4
+      # Sixth document raises an error:
+      # [ true, false, true,   false, true  ]
+      #   ^^^^
+      #   5 % 5 == 0
+      #
+      # Eigth document is successful:
+      # [ true, false, false,  false, true  ]
+      #                ^^^^^
+      #                7 % 5 == 2
+      # And so on.
       @window_index = (@window_index + 1) % @window_size
     end
 

--- a/spec/utility/error_monitor_spec.rb
+++ b/spec/utility/error_monitor_spec.rb
@@ -17,6 +17,84 @@ describe Utility::ErrorMonitor do
     expect(monitor.instance_variable_get('@window_size')).to eq(100)
   end
 
+  it 'raises an error after too many errors in a window' do
+    monitor = Utility::ErrorMonitor.new(:max_error_ratio => 0.15, window_size: 100) 
+
+    10.times do
+      monitor.note_error(StandardError.new)
+    end
+
+    84.times do 
+      monitor.note_success
+    end
+
+    5.times do
+      monitor.note_error(StandardError.new)
+    end
+
+    expect { monitor.note_error(StandardError.new) }.to raise_error(Utility::ErrorMonitor::MaxErrorsInWindowExceededError)
+  end
+
+  context 'when successes and failures were reported before' do
+    # Regression test.
+    # Problem fixed was that monitor incorrectly calculates max_error_ratio - it never
+    # actually considered either ratio or window size - it was always raising an error if
+    # window_size * max_error_ratio errors happened, which is 15 in case of this setup.
+    # What it should do is really consider the window and error ratio, e.g:
+    # 85 documents were correctly ingested, 15 failed. Window will be: 85 x success, 15 x failure,
+    # error_ratio = 0.15, but condition to raise is max_error_ratio < error_ratio - it's false, so
+    # no error is raised.
+    #
+    # Then 90 documents were ingested correctly, window moves and will be: 10 x failure, 90 x success,
+    # error_ratio = 0.1; Then 10 errors happen, but error_ratio will stay the same because window will be
+    # 90 x success, 10 x failure.
+    let(:monitor) { Utility::ErrorMonitor.new(:max_error_ratio => 0.15, window_size: 100, max_consecutive_errors: 100) }
+    before(:each) do
+      # Setup is 100 triggers:
+      # 5 x failure; 40 x success; 5 x failure; 40 x success, error_ratio = 0.1
+      2.times do
+        5.times do
+          monitor.note_error(StandardError.new)
+        end
+
+        40.times do 
+          monitor.note_success
+        end
+      end
+    end
+
+    it 'raises an error after too many errors in a window' do
+      expect {
+        # Before:
+        # 5 x failure; 40 x success; 5 x failure; 40 x success, real error_ratio = 0.1
+        # After:
+        # 40 x success; 5 x failure; 40 x success; 5 x failure, real error_ratio = 0.1
+        5.times do
+          monitor.note_error(StandardError.new)
+        end
+
+        # Before:
+        # 40 x success; 5 x failure; 40 x success; 5 x failure, real error_ratio = 0.1
+        # After:
+        # 1 x success; 5x failure; 94 x success, real_error_ratio = 0.05
+        94.times do 
+          monitor.note_success
+        end
+
+        # Before:
+        # 1 x success; 5 x failure; 94 x success, real_error_ratio = 0.05
+        # After:
+        # 85 x success, 15 x failure, real_error_ratio = 0.15.
+        # Any error within next 85 documents should trigger the MaxErrorsInWindowExceededError
+        15.times do
+          monitor.note_error(StandardError.new)
+        end
+      }.to_not raise_error
+
+      expect { monitor.note_error(StandardError.new) }.to raise_error(Utility::ErrorMonitor::MaxErrorsInWindowExceededError)
+    end
+  end
+
   it 'raises an error after too many failures in a row' do
     monitor = Utility::ErrorMonitor.new(:max_consecutive_errors => 3)
     expect { add_errors(monitor, 4) }.to raise_error do |e|

--- a/spec/utility/error_monitor_spec.rb
+++ b/spec/utility/error_monitor_spec.rb
@@ -18,13 +18,13 @@ describe Utility::ErrorMonitor do
   end
 
   it 'raises an error after too many errors in a window' do
-    monitor = Utility::ErrorMonitor.new(:max_error_ratio => 0.15, window_size: 100) 
+    monitor = Utility::ErrorMonitor.new(:max_error_ratio => 0.15, window_size: 100)
 
     10.times do
       monitor.note_error(StandardError.new)
     end
 
-    84.times do 
+    84.times do
       monitor.note_success
     end
 
@@ -57,7 +57,7 @@ describe Utility::ErrorMonitor do
           monitor.note_error(StandardError.new)
         end
 
-        40.times do 
+        40.times do
           monitor.note_success
         end
       end
@@ -77,7 +77,7 @@ describe Utility::ErrorMonitor do
         # 40 x success; 5 x failure; 40 x success; 5 x failure, real error_ratio = 0.1
         # After:
         # 1 x success; 5x failure; 94 x success, real_error_ratio = 0.05
-        94.times do 
+        94.times do
           monitor.note_success
         end
 


### PR DESCRIPTION
Found a problem with error monitor class: instead of raising an error when number of errors in the window exceeds max_error_ratio, currently it just raises an error when number of errors that happened is equal to `window_size * max_error_ratio`.

Bug happened because the window of errors never considered successful documents as a part of equation - successful document was not reported into the window ever.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally