### PR TITLE
gemspecs: drop dependency on app/config

### DIFF
--- a/connectors_service.gemspec
+++ b/connectors_service.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_service'
-  s.version     = File.read('VERSION')
+  s.version     = File.read('VERSION').strip
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing Elastic connectors service'
   s.description = ''

--- a/connectors_service.gemspec
+++ b/connectors_service.gemspec
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'lib/app/config'
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_service'
-  s.version     = App::Config[:version]
+  s.version     = File.read('VERSION')
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing Elastic connectors service'
   s.description = ''

--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -1,15 +1,14 @@
-require_relative 'lib/app/config'
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_utility'
-  s.version     = App::Config[:version]
+  s.version     = File.read('VERSION')
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing shared Connector Services libraries'
   s.description = ''
   s.authors     = ['Elastic']
   s.metadata    = {
-    "revision" => App::Config[:revision],
-    "repository" => App::Config[:repository]
+    "revision" => `git rev-parse HEAD`
+    "repository" => 'https://github.com/elastic/connectors-ruby'
   }
   s.email       = 'ent-search-dev@elastic.co'
   s.files       = %w[

--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -1,13 +1,13 @@
 
 Gem::Specification.new do |s|
   s.name        = 'connectors_utility'
-  s.version     = File.read('VERSION')
+  s.version     = File.read('VERSION').strip
   s.homepage    = 'https://github.com/elastic/connectors-ruby'
   s.summary     = 'Gem containing shared Connector Services libraries'
   s.description = ''
   s.authors     = ['Elastic']
   s.metadata    = {
-    "revision" => `git rev-parse HEAD`
+    "revision" => `git rev-parse HEAD`.strip,
     "repository" => 'https://github.com/elastic/connectors-ruby'
   }
   s.email       = 'ent-search-dev@elastic.co'


### PR DESCRIPTION
Removes the usage of `lib/app/config` in gem spec, so we can bundle install the package directly using github

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Tested the changes locally

## For Elastic Internal Use Only
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
