### PR TITLE
Fix backportrc for 8.6

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,14 +1,14 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
+    "8.6",
     "8.5",
-    "8.4",
-    "8.3"
+    "8.4"
   ],
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v8.6.0$": "main",
+    "^v8.7.0$": "main",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "upstream": "elastic/connectors-ruby"


### PR DESCRIPTION
Forgot to do during bump from 8.6 to 8.5 😿 