### PR TITLE
Fix the extraction of the dependencies in the gemspec

### DIFF
--- a/connectors_service.gemspec
+++ b/connectors_service.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     if dep.latest_version?
       s.add_dependency dep.name
     else
-      s.add_dependency dep.name, dep.requirement
+      s.add_dependency dep.name, dep.requirement.as_list
     end
   end
 end


### PR DESCRIPTION
```
Fetching git@github.com:elastic/connectors-ruby

[!] There was an error while loading `connectors_service.gemspec`: Illformed requirement [#<Gem::Requirement:0x5da1a97f @requirements=[["~>", #<Gem::Version "1.0">], [">=", #<Gem::Version "1.0.1">]], @_sorted_requirements=[[">=", #<Gem::Version "1.0.1">], ["~>", #<Gem::Version "1.0">]], @_tilde_requirements=[["~>", #<Gem::Version "1.0">]]>]. Bundler cannot continue.

 #  from /Users/tarekziade/Dev/ent-search/vendor/bundle/jruby/2.6.0/bundler/gems/connectors-ruby-7331cbf40964/connectors_service.gemspec:22
 #  -------------------------------------------
 #      else
 >        s.add_dependency dep.name, dep.requirement
 #      end
 #  -------------------------------------------

ERROR: Bundle command failed!
```


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
