### PR TITLE
[8.6] Start sync when scheduling is enabled and properly configured and there's no sync before (#432)

### DIFF
--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -90,13 +90,6 @@ module Core
         return false
       end
 
-      # We want to sync when sync never actually happened
-      last_synced = connector_settings[:last_synced]
-      if last_synced.nil? || last_synced.empty?
-        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
-        return true
-      end
-
       current_schedule = scheduling_settings[:interval]
 
       # Don't sync if there is no actual scheduling interval
@@ -117,6 +110,13 @@ module Core
       unless cron_parser
         Utility::Logger.error("Unable to parse sync schedule for #{connector_settings.formatted}: expression #{current_schedule} is not a valid Quartz Cron definition.")
         return false
+      end
+
+      # We want to sync when sync never actually happened
+      last_synced = connector_settings[:last_synced]
+      if last_synced.nil? || last_synced.empty?
+        Utility::Logger.info("#{connector_settings.formatted.capitalize} has never synced yet, running initial sync.")
+        return true
       end
 
       next_trigger_time = cron_parser.next_time(Time.parse(last_synced))

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -98,12 +98,6 @@ describe Core::Scheduler do
         it_behaves_like 'does not trigger', :sync
       end
 
-      context 'when connector is never synced' do
-        let(:last_synced) { nil }
-
-        it_behaves_like 'triggers', :sync
-      end
-
       context 'when connector sync interval is not configured' do
         let(:sync_interval) { nil }
 
@@ -122,6 +116,12 @@ describe Core::Scheduler do
         let(:cron_parser) { nil }
 
         it_behaves_like 'does not trigger', :sync
+      end
+
+      context 'when connector is never synced' do
+        let(:last_synced) { nil }
+
+        it_behaves_like 'triggers', :sync
       end
 
       context 'when next trigger time is in the future' do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Start sync when scheduling is enabled and properly configured and there's no sync before (#432)](https://github.com/elastic/connectors-ruby/pull/432)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)