### PR TITLE
Use connector data in job during execution

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
                     lib/core/connector_settings.rb
                     lib/core/connector_job.rb
                     lib/core/filtering/validation_status.rb
+                    lib/connectors/job_trigger_method.rb
                   ]
   s.license     = 'Elastic-2.0'
   s.add_dependency 'activesupport', '~>5.2.6'

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -283,7 +283,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   started_at: date; -> The date/time when the job is started
   status: string; -> Job status Enum, see below
   total_document_count: number; -> Number of documents in the index after the job completes
-  trigger_method: string; -> How the job is triggered. Possible values are on-demand, scheduled.
+  trigger_method: string; -> How the job is triggered. Possible values are on_demand, scheduled.
   worker_hostname: string; -> The hostname of the worker to run the job
 }
 ```

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -86,13 +86,13 @@ module App
         scheduler.when_triggered do |connector_settings, task|
           case task
           when :sync
-            # enqueue job before reset sync_now flag, to fill in the trigger_method
-            Core::Jobs::Producer.enqueue_job(job_type: :sync, connector_settings: connector_settings)
             # TODO: #update_connector_sync_now should be moved to Core::ConnectorSettings,
             # there should not be any business logic related code in Core::ElasticConnectorActions.
             # #update_connector_sync_now should not update `last_synced` after https://github.com/elastic/enterprise-search-team/issues/3366 is resolved,
             # schedule should not based on `last_synced`
             Core::ElasticConnectorActions.update_connector_sync_now(connector_settings.id, false)
+
+            Core::Jobs::Producer.enqueue_job(job_type: :sync, connector_settings: connector_settings)
           when :heartbeat
             start_heartbeat_task(connector_settings)
           when :configuration

--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -86,10 +86,13 @@ module App
         scheduler.when_triggered do |connector_settings, task|
           case task
           when :sync
-            # update connector sync_now flag
-            Core::ElasticConnectorActions.update_connector_sync_now(connector_settings.id, false)
-
+            # enqueue job before reset sync_now flag, to fill in the trigger_method
             Core::Jobs::Producer.enqueue_job(job_type: :sync, connector_settings: connector_settings)
+            # TODO: #update_connector_sync_now should be moved to Core::ConnectorSettings,
+            # there should not be any business logic related code in Core::ElasticConnectorActions.
+            # #update_connector_sync_now should not update `last_synced` after https://github.com/elastic/enterprise-search-team/issues/3366 is resolved,
+            # schedule should not based on `last_synced`
+            Core::ElasticConnectorActions.update_connector_sync_now(connector_settings.id, false)
           when :heartbeat
             start_heartbeat_task(connector_settings)
           when :configuration

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -65,7 +65,7 @@ module Connectors
         error_monitor = Utility::ErrorMonitor.new
         @tolerable_error_helper = Connectors::TolerableErrorHelper.new(error_monitor)
 
-        @configuration = configuration.dup || {}
+        @configuration = job_description&.configuration&.dup || configuration&.dup || {}
         @job_description = job_description&.dup
 
         filtering = Utility::Filtering.extract_filter(@job_description&.filtering)

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -45,8 +45,8 @@ module Connectors
         super
 
         @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => configuration.dig(:base_url, :value),
-          :api_token => configuration.dig(:api_token, :value)
+          :base_url => @configuration.dig(:base_url, :value),
+          :api_token => @configuration.dig(:api_token, :value)
         )
       end
 

--- a/lib/connectors/job_trigger_method.rb
+++ b/lib/connectors/job_trigger_method.rb
@@ -1,0 +1,14 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+module Connectors
+  class JobTriggerMethod
+    ON_DEMAND = 'on_demand'
+    SCHEDULED = 'scheduled'
+  end
+end

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -59,12 +59,12 @@ module Connectors
       def initialize(configuration: {}, job_description: nil)
         super
 
-        @host = configuration.dig(:host, :value)
-        @database = configuration.dig(:database, :value)
-        @collection = configuration.dig(:collection, :value)
-        @user = configuration.dig(:user, :value)
-        @password = configuration.dig(:password, :value)
-        @direct_connection = configuration.dig(:direct_connection, :value)
+        @host = @configuration.dig(:host, :value)
+        @database = @configuration.dig(:database, :value)
+        @collection = @configuration.dig(:collection, :value)
+        @user = @configuration.dig(:user, :value)
+        @password = @configuration.dig(:password, :value)
+        @direct_connection = @configuration.dig(:direct_connection, :value)
       end
 
       def yield_documents

--- a/lib/connectors_utility.rb
+++ b/lib/connectors_utility.rb
@@ -9,9 +9,11 @@
 require_relative 'utility'
 
 require_relative 'connectors/connector_status'
-require_relative 'connectors/sync_status'
-require_relative 'core/scheduler'
-require_relative 'core/elastic_connector_actions'
-require_relative 'core/connector_job'
-
 require_relative 'connectors/crawler/scheduler'
+require_relative 'connectors/job_trigger_method'
+require_relative 'connectors/sync_status'
+require_relative 'core/connector_job'
+require_relative 'core/connector_settings'
+require_relative 'core/elastic_connector_actions'
+require_relative 'core/filtering/validation_status'
+require_relative 'core/scheduler'

--- a/lib/core/connector_job.rb
+++ b/lib/core/connector_job.rb
@@ -142,7 +142,19 @@ module Core
     end
 
     def pipeline
-      connector_snapshot[:pipeline]
+      connector_snapshot[:pipeline] || {}
+    end
+
+    def extract_binary_content?
+      pipeline[:extract_binary_content]
+    end
+
+    def reduce_whitespace?
+      pipeline[:reduce_whitespace]
+    end
+
+    def run_ml_inference?
+      pipeline[:run_ml_inference]
     end
 
     def connector

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -103,18 +103,6 @@ module Core
       Utility::Common.return_if_present(@elasticsearch_response.dig(:_source, :pipeline, :name), @connectors_meta.dig(:pipeline, :default_name), DEFAULT_REQUEST_PIPELINE)
     end
 
-    def extract_binary_content?
-      Utility::Common.return_if_present(@elasticsearch_response.dig(:_source, :pipeline, :extract_binary_content), @connectors_meta.dig(:pipeline, :default_extract_binary_content), DEFAULT_EXTRACT_BINARY_CONTENT)
-    end
-
-    def reduce_whitespace?
-      Utility::Common.return_if_present(@elasticsearch_response.dig(:_source, :pipeline, :reduce_whitespace), @connectors_meta.dig(:pipeline, :default_reduce_whitespace), DEFAULT_REDUCE_WHITESPACE)
-    end
-
-    def run_ml_inference?
-      Utility::Common.return_if_present(@elasticsearch_response.dig(:_source, :pipeline, :run_ml_inference), @connectors_meta.dig(:pipeline, :default_run_ml_inference), DEFAULT_RUN_ML_INFERENCE)
-    end
-
     def formatted
       properties = ["ID: #{id}"]
       properties << "Service type: #{service_type}" if service_type

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -88,6 +88,10 @@ module Core
       self[:scheduling]
     end
 
+    def sync_now?
+      self[:sync_now] == true
+    end
+
     def filtering
       # assume for now, that first object in filtering array or a filter object itself is the only filtering object
       filtering = @elasticsearch_response.dig(:_source, :filtering)

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -8,6 +8,7 @@
 #
 require 'active_support/core_ext/hash'
 require 'connectors/connector_status'
+require 'connectors/job_trigger_method'
 require 'connectors/sync_status'
 require 'utility'
 require 'elastic-transport'
@@ -189,7 +190,7 @@ module Core
           status: Connectors::SyncStatus::PENDING,
           created_at: Time.now,
           last_seen: Time.now,
-          trigger_method: connector_settings.sync_now? ? 'on-demand' : 'scheduled',
+          trigger_method: connector_settings.sync_now? ? Connectors::JobTriggerMethod::ON_DEMAND : Connectors::JobTriggerMethod::SCHEDULED,
           connector: {
             id: connector_settings.id,
             filtering: convert_connector_filtering_to_job_filtering(connector_settings.filtering),

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -189,13 +189,15 @@ module Core
           status: Connectors::SyncStatus::PENDING,
           created_at: Time.now,
           last_seen: Time.now,
+          trigger_method: connector_settings.sync_now? ? 'on-demand' : 'scheduled',
           connector: {
             id: connector_settings.id,
             filtering: convert_connector_filtering_to_job_filtering(connector_settings.filtering),
             index_name: connector_settings.index_name,
             language: connector_settings[:language],
             pipeline: connector_settings[:pipeline],
-            service_type: connector_settings.service_type
+            service_type: connector_settings.service_type,
+            configuration: connector_settings.configuration
           }
         }
 

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -78,7 +78,7 @@ module Core
       end
 
       # Sync when sync_now flag is true for the connector
-      if connector_settings[:sync_now] == true
+      if connector_settings.sync_now?
         Utility::Logger.info("#{connector_settings.formatted.capitalize} is manually triggered to sync now.")
         return true
       end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -208,10 +208,11 @@ module Core
     end
 
     def add_ingest_metadata(document)
+      return document unless @job
       document.tap do |it|
-        it['_extract_binary_content'] = @job&.extract_binary_content? if @job&.extract_binary_content?
-        it['_reduce_whitespace'] = @job&.reduce_whitespace? if @job&.reduce_whitespace?
-        it['_run_ml_inference'] = @job&.run_ml_inference? if @job&.run_ml_inference?
+        it['_extract_binary_content'] = @job.extract_binary_content? if @job.extract_binary_content?
+        it['_reduce_whitespace'] = @job.reduce_whitespace? if @job.reduce_whitespace?
+        it['_run_ml_inference'] = @job.run_ml_inference? if @job.run_ml_inference?
       end
     end
 

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -51,11 +51,12 @@ module Core
     def initialize(connector_settings, job, max_ingestion_queue_size, max_ingestion_queue_bytes)
       @connector_settings = connector_settings
       @connector_id = connector_settings.id
-      @index_name = connector_settings.index_name
+      @index_name = job.index_name
+      @service_type = job.service_type
       @job = job
       @job_id = job.id
       @sink = Core::Ingestion::EsSink.new(
-        connector_settings.index_name,
+        @index_name,
         @connector_settings.request_pipeline,
         Utility::BulkQueue.new(
           max_ingestion_queue_size,
@@ -63,7 +64,7 @@ module Core
         ),
         max_ingestion_queue_bytes
       )
-      @connector_class = Connectors::REGISTRY.connector_class(connector_settings.service_type)
+      @connector_class = Connectors::REGISTRY.connector_class(@service_type)
     end
 
     def execute
@@ -81,7 +82,7 @@ module Core
         validate_filtering(@job.filtering)
         Utility::Logger.debug("Active filtering for sync job #{@job_id} for connector #{@connector_id} is valid.")
 
-        @connector_instance = Connectors::REGISTRY.connector(@connector_settings.service_type, @connector_settings.configuration, job_description: @job)
+        @connector_instance = Connectors::REGISTRY.connector(@service_type, @connector_settings.configuration, job_description: @job)
         @connector_instance.do_health_check!
 
         @sync_status = nil
@@ -208,17 +209,17 @@ module Core
 
     def add_ingest_metadata(document)
       document.tap do |it|
-        it['_extract_binary_content'] = @connector_settings.extract_binary_content? if @connector_settings.extract_binary_content?
-        it['_reduce_whitespace'] = @connector_settings.reduce_whitespace? if @connector_settings.reduce_whitespace?
-        it['_run_ml_inference'] = @connector_settings.run_ml_inference? if @connector_settings.run_ml_inference?
+        it['_extract_binary_content'] = @job&.extract_binary_content? if @job&.extract_binary_content?
+        it['_reduce_whitespace'] = @job&.reduce_whitespace? if @job&.reduce_whitespace?
+        it['_run_ml_inference'] = @job&.run_ml_inference? if @job&.run_ml_inference?
       end
     end
 
     def validate_configuration!
       expected_fields = @connector_class.configurable_fields.keys.map(&:to_s).sort
-      actual_fields = @connector_settings.configuration.keys.map(&:to_s).sort
+      actual_fields = @job.configuration.keys.map(&:to_s).sort
 
-      raise IncompatibleConfigurableFieldsError.new(@connector_class.service_type, expected_fields, actual_fields) if expected_fields != actual_fields
+      raise IncompatibleConfigurableFieldsError.new(@service_type, expected_fields, actual_fields) if expected_fields != actual_fields
     end
 
     def validate_filtering(filtering)

--- a/spec/connectors/base/connector_spec.rb
+++ b/spec/connectors/base/connector_spec.rb
@@ -9,7 +9,7 @@
 require 'connectors/base/connector'
 
 describe Connectors::Base::Connector do
-  subject { described_class.new(job_description: job_description) }
+  subject { described_class.new(configuration: connector_configuration, job_description: job_description) }
 
   let(:advanced_snippet_validator_class) { double }
 
@@ -55,10 +55,27 @@ describe Connectors::Base::Connector do
   }
 
   let(:job_description) { double }
+  let(:job_configuration) { { :job_key => 'value' } }
+  let(:connector_configuration) { { :connector_key => 'value' } }
 
   before(:each) do
     allow(job_description).to receive(:dup).and_return(job_description)
+    allow(job_description).to receive(:configuration).and_return(job_configuration)
     allow(job_description).to receive(:filtering).and_return(filtering)
+  end
+
+  describe '.initialize' do
+    it 'uses job configuration' do
+      expect(subject.instance_variable_get('@configuration')).to eq(job_configuration)
+    end
+
+    context 'when job configuration is not provided' do
+      let(:job_configuration) { nil }
+
+      it 'uses connector configuration' do
+        expect(subject.instance_variable_get('@configuration')).to eq(connector_configuration)
+      end
+    end
   end
 
   describe '#advanced_filter_config' do

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -129,6 +129,7 @@ describe Connectors::MongoDB::Connector do
 
   before(:each) do
     allow(job_description).to receive(:dup).and_return(job_description)
+    allow(job_description).to receive(:configuration).and_return(configuration)
     allow(job_description).to receive(:filtering).and_return(filtering)
 
     allow(Mongo::Client).to receive(:new).and_yield(mongo_client)

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -48,28 +48,19 @@ describe Core::ConnectorSettings do
   context 'pipeline settings' do
     it 'has defaults' do
       expect(subject.request_pipeline).to eq(Core::ConnectorSettings::DEFAULT_REQUEST_PIPELINE)
-      expect(subject.extract_binary_content?).to eq(Core::ConnectorSettings::DEFAULT_EXTRACT_BINARY_CONTENT)
-      expect(subject.reduce_whitespace?).to eq(Core::ConnectorSettings::DEFAULT_REDUCE_WHITESPACE)
-      expect(subject.run_ml_inference?).to eq(Core::ConnectorSettings::DEFAULT_RUN_ML_INFERENCE)
     end
 
     context 'global meta defaults are present' do
       let(:connectors_meta) {
         {
           :pipeline => {
-            :default_name => 'foo',
-            :default_extract_binary_content => false,
-            :default_reduce_whitespace => false,
-            :default_run_ml_inference => true
+            :default_name => 'foo'
           }
         }
       }
 
       it 'defers to globals' do
         expect(subject.request_pipeline).to eq('foo')
-        expect(subject.extract_binary_content?).to eq(false)
-        expect(subject.reduce_whitespace?).to eq(false)
-        expect(subject.run_ml_inference?).to eq(true)
       end
 
       context 'index specific values are present' do
@@ -77,10 +68,7 @@ describe Core::ConnectorSettings do
           {
             :_source => {
               :pipeline => {
-                :name => 'bar',
-                :extract_binary_content => true,
-                :reduce_whitespace => false,
-                :run_ml_inference => true
+                :name => 'bar'
               }
             }
           }
@@ -88,9 +76,6 @@ describe Core::ConnectorSettings do
 
         it 'defers to index specific' do
           expect(subject.request_pipeline).to eq('bar')
-          expect(subject.extract_binary_content?).to eq(true)
-          expect(subject.reduce_whitespace?).to eq(false)
-          expect(subject.run_ml_inference?).to eq(true)
         end
       end
     end

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -56,7 +56,7 @@ describe Core::Scheduler do
         allow(connector_settings).to receive(:connector_status_allows_sync?).and_return(allow_sync)
         allow(connector_settings).to receive(:id).and_return('123')
         allow(connector_settings).to receive(:connector_status).and_return('configured')
-        allow(connector_settings).to receive(:[]).with(:sync_now).and_return(sync_now)
+        allow(connector_settings).to receive(:sync_now?).and_return(sync_now)
         allow(connector_settings).to receive(:[]).with(:last_synced).and_return(last_synced)
         allow(connector_settings).to receive(:scheduling_settings).and_return(scheduling_settings)
         allow(connector_settings).to receive(:valid_index_name?).and_return(valid_index_name)

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -95,6 +95,12 @@ describe Core::SyncJobRunner do
     allow(job).to receive(:error!)
     allow(job).to receive(:canceling?).and_return(job_canceling)
     allow(job).to receive(:in_progress?).and_return(job_in_progress)
+    allow(job).to receive(:index_name).and_return(output_index_name)
+    allow(job).to receive(:service_type).and_return(service_type)
+    allow(job).to receive(:extract_binary_content?).and_return(extract_binary_content)
+    allow(job).to receive(:reduce_whitespace?).and_return(reduce_whitespace)
+    allow(job).to receive(:run_ml_inference?).and_return(run_ml_inference)
+    allow(job).to receive(:configuration).and_return(connector_stored_configuration)
 
     allow(Core::ElasticConnectorActions).to receive(:fetch_document_ids).and_return(existing_document_ids)
     allow(Core::ElasticConnectorActions).to receive(:update_connector_status)
@@ -108,18 +114,12 @@ describe Core::SyncJobRunner do
     allow(sink).to receive(:ingestion_stats).and_return(ingestion_stats)
 
     allow(connector_settings).to receive(:id).and_return(connector_id)
-    allow(connector_settings).to receive(:service_type).and_return(service_type)
-    allow(connector_settings).to receive(:index_name).and_return(output_index_name)
     allow(connector_settings).to receive(:configuration).and_return(connector_stored_configuration)
     allow(connector_settings).to receive(:request_pipeline).and_return(request_pipeline)
-    allow(connector_settings).to receive(:extract_binary_content?).and_return(extract_binary_content)
-    allow(connector_settings).to receive(:reduce_whitespace?).and_return(reduce_whitespace)
-    allow(connector_settings).to receive(:run_ml_inference?).and_return(run_ml_inference)
     allow(connector_settings).to receive(:running?).and_return(connector_running)
     allow(connector_settings).to receive(:update_last_sync!)
 
     allow(connector_class).to receive(:configurable_fields).and_return(connector_default_configuration)
-    allow(connector_class).to receive(:service_type).and_return(service_type)
     allow(connector_class).to receive(:validate_filtering).and_return(filtering_validation_result)
     allow(connector_class).to receive(:new).and_return(connector_instance)
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3283
## Closes https://github.com/elastic/enterprise-search-team/issues/3191

This PR
1. adds `trigger_method` when creating a connector job
2. adds `configuration` when creating a connector job
3. Use `configuration`, `pipeline`, `index_name`, and `service_type` from job entity during job execution

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally