### PR TITLE
Fix: Advanced snippet is not applied during filtering

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -71,7 +71,7 @@ module Connectors
         filtering = Utility::Filtering.extract_filter(@job_description&.filtering)
 
         @rules = filtering[:rules] || []
-        @advanced_filter_config = filtering.dig(:advanced_snippet, :value) || {}
+        @advanced_filter_config = filtering[:advanced_snippet] || {}
       end
 
       def yield_documents; end

--- a/lib/core/filtering/validation_job_runner.rb
+++ b/lib/core/filtering/validation_job_runner.rb
@@ -11,8 +11,6 @@ require 'connectors/registry'
 
 module Core
   module Filtering
-    DEFAULT_DOMAIN = 'DEFAULT'
-
     class ValidationJobRunner
       def initialize(connector_settings)
         @connector_settings = connector_settings
@@ -27,7 +25,7 @@ module Core
         validation_result = @connector_class.validate_filtering(@connector_settings.filtering[:draft])
 
         # currently only used for connectors -> DEFAULT domain can be assumed (will be changed with the integration of crawler)
-        ElasticConnectorActions.update_filtering_validation(@connector_settings.id, { DEFAULT_DOMAIN => validation_result })
+        ElasticConnectorActions.update_filtering_validation(@connector_settings.id, { Core::Filtering::DEFAULT_DOMAIN => validation_result })
 
         @validation_finished = true
       rescue StandardError => e

--- a/spec/connectors/base/connector_spec.rb
+++ b/spec/connectors/base/connector_spec.rb
@@ -17,12 +17,6 @@ describe Connectors::Base::Connector do
 
   let(:advanced_snippet) {
     {
-      :value => advanced_snippet_value
-    }
-  }
-
-  let(:advanced_snippet_value) {
-    {
       :find => {
         :filter => {
           :$text => {
@@ -76,12 +70,12 @@ describe Connectors::Base::Connector do
 
     context 'advanced filter config is present' do
       it 'returns advanced filter config' do
-        expect(subject.advanced_filter_config).to eq(advanced_snippet_value)
+        expect(subject.advanced_filter_config).to eq(advanced_snippet)
       end
     end
 
     context 'advanced filter config is nil' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         nil
       }
 
@@ -89,7 +83,7 @@ describe Connectors::Base::Connector do
     end
 
     context 'advanced filter config is empty' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         {}
       }
 
@@ -161,7 +155,7 @@ describe Connectors::Base::Connector do
     end
 
     context 'only advanced filter config is empty' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         {}
       }
 
@@ -169,7 +163,7 @@ describe Connectors::Base::Connector do
     end
 
     context 'only advanced filter config is nil' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         nil
       }
 
@@ -181,7 +175,7 @@ describe Connectors::Base::Connector do
         []
       }
 
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         {}
       }
 
@@ -193,7 +187,7 @@ describe Connectors::Base::Connector do
         nil
       }
 
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         nil
       }
 
@@ -268,7 +262,7 @@ describe Connectors::Base::Connector do
       it 'extracts the advanced filter config' do
         advanced_filter_config = subject.advanced_filter_config
 
-        expect(advanced_filter_config).to eq(advanced_snippet_value)
+        expect(advanced_filter_config).to eq(advanced_snippet)
       end
     end
 
@@ -282,7 +276,7 @@ describe Connectors::Base::Connector do
     end
 
     context 'filter config is nil' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         nil
       }
 
@@ -290,7 +284,7 @@ describe Connectors::Base::Connector do
     end
 
     context 'filter config is empty' do
-      let(:advanced_snippet_value) {
+      let(:advanced_snippet) {
         {}
       }
 

--- a/spec/connectors/mongodb/connector_spec.rb
+++ b/spec/connectors/mongodb/connector_spec.rb
@@ -103,9 +103,7 @@ describe Connectors::MongoDB::Connector do
   let(:filtering) {
     {
       :rules => rules,
-      :advanced_snippet => {
-        :value => advanced_snippet
-      }
+      :advanced_snippet => advanced_snippet
     }
   }
 
@@ -201,84 +199,6 @@ describe Connectors::MongoDB::Connector do
       expect(Mongo::Client).to receive(:new).with(mongodb_host, hash_including(:database => mongodb_database))
 
       subject.is_healthy?
-    end
-  end
-
-  describe '#validate_filtering' do
-    context 'filtering is not present' do
-      let(:filtering) {
-        {}
-      }
-
-      it_behaves_like 'filtering is valid'
-    end
-
-    context 'find is present' do
-      let(:advanced_snippet) {
-        {
-          :find => {}
-        }
-      }
-
-      it_behaves_like 'filtering is valid'
-    end
-
-    context 'aggregate is present' do
-      let(:advanced_snippet) {
-        {
-          :aggregate => {}
-        }
-      }
-
-      it_behaves_like 'filtering is valid'
-    end
-
-    context 'advanced config is empty' do
-      let(:advanced_snippet) {
-        {}
-      }
-
-      it_behaves_like 'filtering is valid'
-    end
-
-    context 'advanced config is nil' do
-      let(:advanced_snippet) {
-        nil
-      }
-
-      it_behaves_like 'filtering is valid'
-    end
-
-    context 'aggregate and find are present' do
-      let(:advanced_snippet) {
-        {
-            :aggregate => {},
-            :find => {}
-        }
-      }
-
-      it_behaves_like 'filtering is invalid'
-    end
-
-    context 'aggregate and one wrong key are present' do
-      let(:advanced_snippet) {
-        {
-          :aggregate => {},
-          :wrong_key => {}
-        }
-      }
-
-      it_behaves_like 'filtering is invalid'
-    end
-
-    context 'wrong key is present' do
-      let(:advanced_snippet) {
-        {
-          :wrong_key_one => {}
-        }
-      }
-
-      it_behaves_like 'filtering is invalid'
     end
   end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3377 ##

The advanced snippet lives under "filtering.advanced_snippet" in a sync job. We've used "filtering.active.advanced_snippet", which reflects the connector mapping, but not the connector-sync-jobs mapping.

This PR also removes redundant tests as advanced snippet validation (MongoDB) should be only tested in `mongo_advanced_snippet_against_schema_validator_spec.rb`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally