### PR TITLE
Extending RELEASING.md to add instructions about logging into rubygems.

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,6 +23,14 @@ To release the connector service:
 
 Two Gems will be published to RubyGems: [connectors_service](https://rubygems.org/gems/connectors_service) and [connectors_utility](https://rubygems.org/gems/connectors_utility)
 
+> Note: you should be logged into rubygems (your_gem_account_name is the ent-search email from vault under `ent-search-team/rubygem`)
+
+```shell
+curl -u {your_gem_account_name} https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
+Enter host password for user '{your_gem_account_name}': {your_password}
+
+```
+
 Take care of the branching (minor releases only):
 
 - Increment the VERSION on main to match the next minor release


### PR DESCRIPTION
## [Slack thread](https://elastic.slack.com/archives/C01795T48LQ/p1669036388138709)

To help people not run into this:

```
bundle _2.3.15_ exec gem push .gems/*
Pushing gem to https://rubygems.org/...
You do not have permission to push to this gem. Ask an owner to add you with: gem owner connectors_service --add m.***@gmail.com
make: *** [push_gem] Error 1
```
