### PR TITLE
Fix: Implementation for MongoDB simple rules pre-processing for 'starts_with', 'ends_with' and 'contains' missing

### DIFF
--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -32,6 +32,12 @@ module Connectors
           parse_less_than(rule)
         when Core::Filtering::SimpleRule::Rule::REGEX
           parse_regex(rule)
+        when Core::Filtering::SimpleRule::Rule::STARTS_WITH
+          parse_starts_with(rule)
+        when Core::Filtering::SimpleRule::Rule::ENDS_WITH
+          parse_ends_with(rule)
+        when Core::Filtering::SimpleRule::Rule::CONTAINS
+          parse_contains(rule)
         else
           raise "Unknown operator: #{op}"
         end
@@ -74,6 +80,30 @@ module Connectors
           { rule.field => /#{rule.value}/ }
         else
           { rule.field => { '$not' => /#{rule.value}/ } }
+        end
+      end
+
+      def parse_starts_with(rule)
+        if rule.is_include?
+          { rule.field => /^#{rule.value}/ }
+        else
+          { rule.field => { '$not' => /^#{rule.value}/ } }
+        end
+      end
+
+      def parse_ends_with(rule)
+        if rule.is_include?
+          { rule.field => /#{rule.value}$/ }
+        else
+          { rule.field => { '$not' => /#{rule.value}$/ } }
+        end
+      end
+
+      def parse_contains(rule)
+        if rule.is_include?
+          { rule.field => /.*#{rule.value}.*/ }
+        else
+          { rule.field => { '$not' => /.*#{rule.value}.*/ } }
         end
       end
     end

--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -13,33 +13,32 @@ require 'core/filtering/simple_rule'
 module Connectors
   module MongoDB
     class MongoRulesParser < Connectors::Base::SimpleRulesParser
-      def parse_rule(rule)
-        field = rule.field
-        value = rule.value
-        unless value.present?
-          raise "value is required for field: #{field}"
-        end
-        unless field.present?
-          raise "field is required for rule: #{rule}"
-        end
-        op = rule.rule
-        case op
+      def parse_rule(simple_rule)
+        field = simple_rule.field
+        value = simple_rule.value
+
+        raise "value is required for field: #{field}" unless value.present?
+
+        raise "field is required for simple rule: #{simple_rule}" unless field.present?
+
+        rule = simple_rule.rule
+        case rule
         when Core::Filtering::SimpleRule::Rule::EQUALS
-          parse_equals(rule)
+          parse_equals(simple_rule)
         when Core::Filtering::SimpleRule::Rule::GREATER_THAN
-          parse_greater_than(rule)
+          parse_greater_than(simple_rule)
         when Core::Filtering::SimpleRule::Rule::LESS_THAN
-          parse_less_than(rule)
+          parse_less_than(simple_rule)
         when Core::Filtering::SimpleRule::Rule::REGEX
-          parse_regex(rule)
+          parse_regex(simple_rule)
         when Core::Filtering::SimpleRule::Rule::STARTS_WITH
-          parse_starts_with(rule)
+          parse_starts_with(simple_rule)
         when Core::Filtering::SimpleRule::Rule::ENDS_WITH
-          parse_ends_with(rule)
+          parse_ends_with(simple_rule)
         when Core::Filtering::SimpleRule::Rule::CONTAINS
-          parse_contains(rule)
+          parse_contains(simple_rule)
         else
-          raise "Unknown operator: #{op}"
+          raise "Unknown rule: #{rule}"
         end
       end
 

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -218,7 +218,7 @@ describe Connectors::MongoDB::MongoRulesParser do
     context 'with invalid operator' do
       let(:operator) { 'invalid' }
       it 'raises error' do
-        expect { subject.parse }.to raise_error(RuntimeError, /Unknown operator/)
+        expect { subject.parse }.to raise_error(RuntimeError, /Unknown rule/)
       end
     end
 

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -33,27 +33,66 @@ describe Connectors::MongoDB::MongoRulesParser do
   describe '#parse' do
     context 'with one rule' do
       context 'on include rule' do
-        context Core::Filtering::SimpleRule::Rule::EQUALS do
+        context 'equals' do
           it 'parses rule as equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => 'bar' })
           end
         end
-        context 'greater' do
+
+        context 'greater than' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::GREATER_THAN }
           it 'parses rule as greater' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$gt' => 'bar' } })
           end
         end
-        context 'less' do
+
+        context 'less than' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::LESS_THAN }
           it 'parses rule as less' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$lt' => 'bar' } })
           end
         end
+
+        context 'regex' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::REGEX }
+
+          it 'parses rule as a regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => /bar/ })
+          end
+        end
+
+        context 'starts with' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::STARTS_WITH }
+
+          it 'parses rule as a starts with regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => /^bar/ })
+          end
+        end
+
+        context 'ends with' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::ENDS_WITH }
+
+          it 'parses rule as an ends with regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => /bar$/ })
+          end
+        end
+
+        context 'contains' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::CONTAINS }
+
+          it 'parses rule as a contains regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => /.*bar.*/ })
+          end
+        end
       end
+
       context 'on exclude rule' do
         let(:policy) { Core::Filtering::SimpleRule::Policy::EXCLUDE }
         context Core::Filtering::SimpleRule::Rule::EQUALS do
@@ -62,18 +101,56 @@ describe Connectors::MongoDB::MongoRulesParser do
             expect(result).to match({ 'foo' => { '$ne' => 'bar' } })
           end
         end
-        context 'greater' do
+
+        context 'greater than' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::GREATER_THAN }
           it 'parses rule as less or equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$lte' => 'bar' } })
           end
         end
-        context 'less' do
+
+        context 'less than' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::LESS_THAN }
           it 'parses rule as less or equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$gte' => 'bar' } })
+          end
+        end
+
+        context 'regex' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::REGEX }
+
+          it 'parses rule as a not regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$not' => /bar/ } })
+          end
+        end
+
+        context 'starts with' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::STARTS_WITH }
+
+          it 'parses rule as a not starting with regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$not' => /^bar/ } })
+          end
+        end
+
+        context 'ends with' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::ENDS_WITH }
+
+          it 'parses rule as a not ending with regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$not' => /bar$/ } })
+          end
+        end
+
+        context 'contains' do
+          let(:operator) { Core::Filtering::SimpleRule::Rule::CONTAINS }
+
+          it 'parses rule as a not containing regex' do
+            result = subject.parse
+            expect(result).to match({ 'foo' => { '$not' => /.*bar.*/ } })
           end
         end
       end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3394 ##

This PR adds the missing implementation for MongoDB pre-processing simple rules for the rules 'starts_with', 'ends_with' and 'contains'. This fixes the bug that a user can select these rules in the UI, but a corresponding sync won't be started as the backend throws an error that the selected rule is unknown.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally