### PR TITLE
Revert "Fix: Implementation for MongoDB simple rules pre-processing f…

### DIFF
--- a/lib/connectors/mongodb/mongo_rules_parser.rb
+++ b/lib/connectors/mongodb/mongo_rules_parser.rb
@@ -13,32 +13,27 @@ require 'core/filtering/simple_rule'
 module Connectors
   module MongoDB
     class MongoRulesParser < Connectors::Base::SimpleRulesParser
-      def parse_rule(simple_rule)
-        field = simple_rule.field
-        value = simple_rule.value
-
-        raise "value is required for field: #{field}" unless value.present?
-
-        raise "field is required for simple rule: #{simple_rule}" unless field.present?
-
-        rule = simple_rule.rule
-        case rule
+      def parse_rule(rule)
+        field = rule.field
+        value = rule.value
+        unless value.present?
+          raise "value is required for field: #{field}"
+        end
+        unless field.present?
+          raise "field is required for rule: #{rule}"
+        end
+        op = rule.rule
+        case op
         when Core::Filtering::SimpleRule::Rule::EQUALS
-          parse_equals(simple_rule)
+          parse_equals(rule)
         when Core::Filtering::SimpleRule::Rule::GREATER_THAN
-          parse_greater_than(simple_rule)
+          parse_greater_than(rule)
         when Core::Filtering::SimpleRule::Rule::LESS_THAN
-          parse_less_than(simple_rule)
+          parse_less_than(rule)
         when Core::Filtering::SimpleRule::Rule::REGEX
-          parse_regex(simple_rule)
-        when Core::Filtering::SimpleRule::Rule::STARTS_WITH
-          parse_starts_with(simple_rule)
-        when Core::Filtering::SimpleRule::Rule::ENDS_WITH
-          parse_ends_with(simple_rule)
-        when Core::Filtering::SimpleRule::Rule::CONTAINS
-          parse_contains(simple_rule)
+          parse_regex(rule)
         else
-          raise "Unknown rule: #{rule}"
+          raise "Unknown operator: #{op}"
         end
       end
 
@@ -79,30 +74,6 @@ module Connectors
           { rule.field => /#{rule.value}/ }
         else
           { rule.field => { '$not' => /#{rule.value}/ } }
-        end
-      end
-
-      def parse_starts_with(rule)
-        if rule.is_include?
-          { rule.field => /^#{rule.value}/ }
-        else
-          { rule.field => { '$not' => /^#{rule.value}/ } }
-        end
-      end
-
-      def parse_ends_with(rule)
-        if rule.is_include?
-          { rule.field => /#{rule.value}$/ }
-        else
-          { rule.field => { '$not' => /#{rule.value}$/ } }
-        end
-      end
-
-      def parse_contains(rule)
-        if rule.is_include?
-          { rule.field => /.*#{rule.value}.*/ }
-        else
-          { rule.field => { '$not' => /.*#{rule.value}.*/ } }
         end
       end
     end

--- a/spec/connectors/mongodb/mongo_rules_parser_spec.rb
+++ b/spec/connectors/mongodb/mongo_rules_parser_spec.rb
@@ -33,66 +33,27 @@ describe Connectors::MongoDB::MongoRulesParser do
   describe '#parse' do
     context 'with one rule' do
       context 'on include rule' do
-        context 'equals' do
+        context Core::Filtering::SimpleRule::Rule::EQUALS do
           it 'parses rule as equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => 'bar' })
           end
         end
-
-        context 'greater than' do
+        context 'greater' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::GREATER_THAN }
           it 'parses rule as greater' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$gt' => 'bar' } })
           end
         end
-
-        context 'less than' do
+        context 'less' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::LESS_THAN }
           it 'parses rule as less' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$lt' => 'bar' } })
           end
         end
-
-        context 'regex' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::REGEX }
-
-          it 'parses rule as a regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => /bar/ })
-          end
-        end
-
-        context 'starts with' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::STARTS_WITH }
-
-          it 'parses rule as a starts with regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => /^bar/ })
-          end
-        end
-
-        context 'ends with' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::ENDS_WITH }
-
-          it 'parses rule as an ends with regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => /bar$/ })
-          end
-        end
-
-        context 'contains' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::CONTAINS }
-
-          it 'parses rule as a contains regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => /.*bar.*/ })
-          end
-        end
       end
-
       context 'on exclude rule' do
         let(:policy) { Core::Filtering::SimpleRule::Policy::EXCLUDE }
         context Core::Filtering::SimpleRule::Rule::EQUALS do
@@ -101,56 +62,18 @@ describe Connectors::MongoDB::MongoRulesParser do
             expect(result).to match({ 'foo' => { '$ne' => 'bar' } })
           end
         end
-
-        context 'greater than' do
+        context 'greater' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::GREATER_THAN }
           it 'parses rule as less or equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$lte' => 'bar' } })
           end
         end
-
-        context 'less than' do
+        context 'less' do
           let(:operator) { Core::Filtering::SimpleRule::Rule::LESS_THAN }
           it 'parses rule as less or equals' do
             result = subject.parse
             expect(result).to match({ 'foo' => { '$gte' => 'bar' } })
-          end
-        end
-
-        context 'regex' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::REGEX }
-
-          it 'parses rule as a not regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => { '$not' => /bar/ } })
-          end
-        end
-
-        context 'starts with' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::STARTS_WITH }
-
-          it 'parses rule as a not starting with regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => { '$not' => /^bar/ } })
-          end
-        end
-
-        context 'ends with' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::ENDS_WITH }
-
-          it 'parses rule as a not ending with regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => { '$not' => /bar$/ } })
-          end
-        end
-
-        context 'contains' do
-          let(:operator) { Core::Filtering::SimpleRule::Rule::CONTAINS }
-
-          it 'parses rule as a not containing regex' do
-            result = subject.parse
-            expect(result).to match({ 'foo' => { '$not' => /.*bar.*/ } })
           end
         end
       end
@@ -218,7 +141,7 @@ describe Connectors::MongoDB::MongoRulesParser do
     context 'with invalid operator' do
       let(:operator) { 'invalid' }
       it 'raises error' do
-        expect { subject.parse }.to raise_error(RuntimeError, /Unknown rule/)
+        expect { subject.parse }.to raise_error(RuntimeError, /Unknown operator/)
       end
     end
 


### PR DESCRIPTION
…or 'starts_with', 'ends_with' and 'contains' missing (#458)"

This reverts commit cb5d798195e5e73f72ff4066892e73c04797b3b3.

## Closes https://github.com/elastic/connectors-ruby/issues/###


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
