### PR TITLE
Include connector_job

### DIFF
--- a/lib/connectors_utility.rb
+++ b/lib/connectors_utility.rb
@@ -12,5 +12,6 @@ require_relative 'connectors/connector_status'
 require_relative 'connectors/sync_status'
 require_relative 'core/scheduler'
 require_relative 'core/elastic_connector_actions'
+require_relative 'core/connector_job'
 
 require_relative 'connectors/crawler/scheduler'


### PR DESCRIPTION
## Refs https://github.com/elastic/ent-search/pull/7095/files#r1027610073

We need to use `Core::ConnectorJob` in ent-search so the file will be added to `utility.rb`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Make sure `Core::ConnectorJob` is available in ent-search runtime

<img width="367" alt="image" src="https://user-images.githubusercontent.com/314956/203359670-bc96fdb1-78a6-446d-aefe-c7c66239278f.png">

