### PR TITLE
Update connector status after job completes

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -139,10 +139,12 @@ module Core
       job_status = job&.status || Connectors::SyncStatus::ERROR
       job_error = job.nil? ? 'Could\'t find the job' : job.error
       job_error ||= 'unknown error' if job_status == Connectors::SyncStatus::ERROR
+      connector_status = job_status == Connectors::SyncStatus::ERROR ? Connectors::ConnectorStatus::ERROR : Connectors::ConnectorStatus::CONNECTED
       doc = {
         :last_sync_status => job_status,
         :last_synced => Time.now,
         :last_sync_error => job_error,
+        :status => connector_status,
         :error => job_error
       }
       if job&.terminated?

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -8,6 +8,7 @@
 
 require 'active_support/core_ext/hash/indifferent_access'
 require 'connectors/connector_status'
+require 'connectors/sync_status'
 require 'core/elastic_connector_actions'
 require 'utility'
 

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -140,7 +140,7 @@ module Core
       job_status = job&.status || Connectors::SyncStatus::ERROR
       job_error = job.nil? ? 'Could\'t find the job' : job.error
       job_error ||= 'unknown error' if job_status == Connectors::SyncStatus::ERROR
-      connector_status = job_status == Connectors::SyncStatus::ERROR ? Connectors::ConnectorStatus::ERROR : Connectors::ConnectorStatus::CONNECTED
+      connector_status = (job_status == Connectors::SyncStatus::ERROR ? Connectors::ConnectorStatus::ERROR : Connectors::ConnectorStatus::CONNECTED)
       doc = {
         :last_sync_status => job_status,
         :last_synced => Time.now,

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -141,6 +141,7 @@ describe Core::ConnectorSettings do
     let(:terminated?) { true }
     let(:indexed_document_count) { 10 }
     let(:deleted_document_count) { 5 }
+    let(:expected_connector_status) { Connectors::ConnectorStatus::ERROR }
 
     before(:each) do
       allow(subject).to receive(:id).and_return(id)
@@ -158,6 +159,7 @@ describe Core::ConnectorSettings do
           :last_sync_status => job_status,
           :last_synced => anything,
           :last_sync_error => job_error,
+          :status => expected_connector_status,
           :error => job_error,
           :last_indexed_document_count => indexed_document_count,
           :last_deleted_document_count => deleted_document_count
@@ -188,6 +190,7 @@ describe Core::ConnectorSettings do
             :last_sync_status => Connectors::SyncStatus::ERROR,
             :last_synced => anything,
             :last_sync_error => expected_error,
+            :status => expected_connector_status,
             :error => expected_error
           )
         )


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3390

This PR will update the connector status to either `connected` or `error` after a job completes.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally