### PR TITLE
Fix: Sync rules not showing up for native connectors

### DIFF
--- a/lib/connectors/connector_status.rb
+++ b/lib/connectors/connector_status.rb
@@ -27,5 +27,10 @@ module Connectors
       CONNECTED,
       ERROR
     ]
+
+    STATUSES_NEEDING_CONFIGURATION = [
+      CREATED,
+      NEEDS_CONFIGURATION
+    ]
   end
 end

--- a/lib/core/configuration.rb
+++ b/lib/core/configuration.rb
@@ -17,33 +17,55 @@ module Core
     class << self
 
       def update(connector_settings, service_type = nil)
-        if connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
+        if connector_settings.needs_configuration?
           connector_class = Connectors::REGISTRY.connector_class(connector_settings.service_type || service_type)
+
           unless connector_class
             Utility::Logger.error("Couldn't find connector for service type #{connector_settings.service_type || service_type}")
             return
           end
-          configuration = connector_class.configurable_fields_indifferent_access
+
           features = connector_class.kibana_features.each_with_object({}) { |feature, hsh| hsh[feature] = true }
+          configurable_fields = connector_class.configurable_fields_indifferent_access
           doc = {
-            :configuration => configuration,
             :features => features
           }
 
           doc[:service_type] = service_type if service_type && connector_settings.needs_service_type?
 
-          # We want to set connector to CONFIGURED status if all configurable fields have default values
-          new_connector_status = if configuration.values.all? { |setting| setting[:value].present? }
-                                   Utility::Logger.debug("All connector configurable fields provided default values for #{connector_settings.formatted}.")
-                                   Connectors::ConnectorStatus::CONFIGURED
-                                 else
-                                   Connectors::ConnectorStatus::NEEDS_CONFIGURATION
-                                 end
+          if configurable_fields_defaults_present?(configurable_fields, connector_settings)
+            doc[:configuration] = configurable_fields
+            doc[:status] = Connectors::ConnectorStatus::CONFIGURED
+          elsif configuration_fully_set?(connector_settings)
+            # We don't want to override the existing fully set configuration with default values
+            doc[:status] = Connectors::ConnectorStatus::CONFIGURED
+          else
+            doc[:status] = Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+          end
 
-          doc[:status] = new_connector_status
-          Utility::Logger.info("Changing connector status to #{new_connector_status} for #{connector_settings.formatted}.")
+          Utility::Logger.info("Changing connector status to #{doc[:status]} for #{connector_settings.formatted}.")
           Core::ElasticConnectorActions.update_connector_fields(connector_settings.id, doc)
         end
+      end
+
+      private
+
+      def configurable_fields_defaults_present?(configurable_fields, connector_settings)
+        if configurable_fields.values.all? { |setting| setting[:value].present? }
+          Utility::Logger.debug("All connector configurable fields provided default values for #{connector_settings.formatted}.")
+          return true
+        end
+
+        false
+      end
+
+      def configuration_fully_set?(connector_settings)
+        if connector_settings.configuration.with_indifferent_access.values.all? { |setting| setting[:value].present? }
+          Utility::Logger.debug("All connector configurable fields were set for #{connector_settings.formatted}.")
+          return true
+        end
+
+        false
       end
     end
   end

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -131,6 +131,13 @@ module Core
         connector_status_allows_sync?
     end
 
+    def needs_configuration?
+      # Regression bug!!!
+      # We need to trigger configuration for the connector that was created with no service_type.
+      # Otherwise on-prem connectors won't be able to start the flow at all.
+      needs_service_type? || Connectors::ConnectorStatus::STATUSES_NEEDING_CONFIGURATION.include?(connector_status)
+    end
+
     def running?
       @elasticsearch_response[:_source][:last_sync_status] == Connectors::SyncStatus::IN_PROGRESS
     end

--- a/lib/core/scheduler.rb
+++ b/lib/core/scheduler.rb
@@ -144,7 +144,7 @@ module Core
     end
 
     def configuration_triggered?(connector_settings)
-      connector_settings.needs_service_type? || connector_settings.connector_status == Connectors::ConnectorStatus::CREATED
+      connector_settings.needs_configuration?
     end
 
     def filtering_validation_triggered?(connector_settings)

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -14,6 +14,8 @@ describe Core::Configuration do
     let(:param_service_type) { nil }
     let(:needs_service_type) { false }
     let(:configuration) { { :foo => {} } }
+    let(:configurable_fields) { { :foo => {} } }
+    let(:needs_configuration) { true }
 
     before(:each) do
       allow(Core::ElasticConnectorActions).to receive(:update_connector_fields)
@@ -21,135 +23,148 @@ describe Core::Configuration do
       allow(connector_settings).to receive(:id).and_return(connector_id)
       allow(connector_settings).to receive(:service_type).and_return(service_type)
       allow(connector_settings).to receive(:connector_status).and_return(connector_status)
+      allow(connector_settings).to receive(:configuration).and_return(configuration)
       allow(connector_settings).to receive(:needs_service_type?).and_return(needs_service_type)
       allow(connector_settings).to receive(:formatted).and_return('')
-      allow(connector_class).to receive(:configurable_fields).and_return(configuration)
-      allow(connector_class).to receive(:configurable_fields_indifferent_access).and_return(configuration.with_indifferent_access)
+      allow(connector_settings).to receive(:needs_configuration?).and_return(needs_configuration)
+      allow(connector_class).to receive(:configurable_fields).and_return(configurable_fields)
+      allow(connector_class).to receive(:configurable_fields_indifferent_access).and_return(configurable_fields.with_indifferent_access)
       allow(connector_class).to receive(:kibana_features).and_return(Connectors::Base::Connector.kibana_features)
     end
 
     describe '.update' do
-      (Connectors::ConnectorStatus::STATUSES - [Connectors::ConnectorStatus::CREATED]).each do |status|
-        context "when connector status is #{status}" do
-          let(:connector_status) { status }
-          it 'updates nothing' do
-            expect(Core::ElasticConnectorActions).to_not receive(:update_connector_fields)
-
-            described_class.update(connector_settings, param_service_type)
-          end
-        end
-      end
-
-      context 'when connector class is not supported' do
-        let(:connector_class) { nil }
-        it 'updates nothing' do
+      shared_examples_for 'updates nothing' do
+        it '' do
           expect(Core::ElasticConnectorActions).to_not receive(:update_connector_fields)
 
           described_class.update(connector_settings, param_service_type)
         end
       end
 
-      it 'updates configuration and status' do
-        expect(Core::ElasticConnectorActions)
-          .to receive(:update_connector_fields)
-          .with(connector_id,
-                hash_including(
-                  :configuration => configuration,
-                  :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION,
-                  :features => {
-                    Utility::Constants::FILTERING_RULES_FEATURE => true,
-                    Utility::Constants::FILTERING_ADVANCED_FEATURE => true
-                  }
-                ))
+      shared_examples_for 'updates status' do |expected_status, expected_configuration|
+        it "updates to #{expected_status}" do
+          expected_hash = { :status => expected_status }.tap do |expected_doc|
+            expected_doc[:configuration] = expected_configuration if expected_configuration.present?
+          end
 
-        described_class.update(connector_settings)
-      end
-
-      context 'when all configurable fields are set with symbols' do
-        let(:configuration) { { :foo => { :value => 'bar' } } }
-
-        it 'updates status to configured' do
           expect(Core::ElasticConnectorActions)
             .to receive(:update_connector_fields)
             .with(connector_id,
-                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
+                  hash_including(expected_hash))
 
           described_class.update(connector_settings, param_service_type)
         end
       end
 
-      context 'when all configurable fields are set with strings' do
-        let(:configuration) { { 'foo' => { 'value' => 'bar' } } }
+      context 'when connector does not need configuration' do
+        let(:needs_configuration) { false }
 
-        it 'updates status to configured' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(connector_id,
-                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
-
-          described_class.update(connector_settings, param_service_type)
-        end
+        it_behaves_like 'updates nothing'
       end
 
-      context 'when all configurable fields are set with a mix of strings and symbols' do
-        let(:configuration) {
-          {
-            'foo' => {
-              'value' => 'Foo'
-            },
-            :bar => {
-              :value => 'Bar'
+      context 'when connector class is not supported' do
+        let(:connector_class) { nil }
+
+        it_behaves_like 'updates nothing'
+      end
+
+      context 'when connectors needs configuration' do
+        let(:needs_configuration) { true }
+
+        context 'when all configurable fields are set with symbols' do
+          let(:configurable_fields) { { :foo => { :value => 'bar' } } }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED, { :foo => { :value => 'bar' } }
+        end
+
+        context 'when all configurable fields are set with strings' do
+          let(:configurable_fields) { { 'foo' => { 'value' => 'bar' } } }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED, { 'foo' => { 'value' => 'bar' } }
+        end
+
+        context 'when all configurable fields are set with a mix of strings and symbols' do
+          let(:configurable_fields) {
+            {
+              'foo' => {
+                'value' => 'Foo'
+              },
+              :bar => {
+                :value => 'Bar'
+              }
             }
           }
-        }
 
-        it 'updates status to configured' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(connector_id,
-                  hash_including(:status => Connectors::ConnectorStatus::CONFIGURED))
-
-          described_class.update(connector_settings, param_service_type)
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED, { 'foo' => { 'value' => 'Foo' }, :bar => { :value => 'Bar' } }
         end
-      end
 
-      context 'when not all configurable fields are set (with strings)' do
-        let(:configuration) { { 'foo' => { 'value' => nil } } }
+        context 'when configuration is not set (with strings)' do
+          let(:configurable_fields) { { 'foo' => { 'value' => nil } } }
+          let(:configuration) { { 'foo' => { 'value' => nil } } }
 
-        it 'updates status to configured' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(connector_id,
-                  hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
-
-          described_class.update(connector_settings, param_service_type)
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::NEEDS_CONFIGURATION
         end
-      end
 
-      context 'when not all configurable fields are set (with symbols)' do
-        let(:configuration) { { :foo => { :value => nil } } }
+        context 'when configuration is not set (with symbols)' do
+          let(:configurable_fields) { { 'foo' => { 'value' => nil } } }
+          let(:configuration) { { :foo => { :value => nil } } }
 
-        it 'updates status to configured' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(connector_id,
-                  hash_including(:status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION))
-
-          described_class.update(connector_settings, param_service_type)
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::NEEDS_CONFIGURATION
         end
-      end
 
-      context 'when in non-native mode' do
-        let(:service_type) { nil }
-        let(:param_service_type) { 'mongo' }
-        let(:needs_service_type) { true }
+        context 'when configuration is set with symbols' do
+          let(:configurable_fields) { { 'foo' => { 'value' => nil } } }
+          let(:configuration) { { :foo => { :value => 'bar' } } }
 
-        it 'updates service type' do
-          expect(Core::ElasticConnectorActions)
-            .to receive(:update_connector_fields)
-            .with(connector_id, hash_including(:service_type => param_service_type))
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED
+        end
 
-          described_class.update(connector_settings, param_service_type)
+        context 'when configuration is set with strings' do
+          let(:configurable_fields) { { 'foo' => { 'value' => nil } } }
+          let(:configuration) { { 'foo' => { 'value' => 'bar' } } }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED
+        end
+
+        context 'when all configurable fields are set with a mix of strings and symbols' do
+          let(:configurable_fields) {
+            {
+              'foo' => {
+                'value' => 'Foo'
+              },
+              :bar => {
+                :value => 'Bar'
+              }
+            }
+          }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::CONFIGURED
+        end
+
+        context 'when not all configurable fields are set (with strings)' do
+          let(:configurable_fields) { { 'foo' => { 'value' => nil } } }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+        end
+
+        context 'when not all configurable fields are set (with symbols)' do
+          let(:configurable_fields) { { :foo => { :value => nil } } }
+
+          it_behaves_like 'updates status', Connectors::ConnectorStatus::NEEDS_CONFIGURATION
+        end
+
+        context 'when in non-native mode' do
+          let(:service_type) { nil }
+          let(:param_service_type) { 'mongo' }
+          let(:needs_service_type) { true }
+
+          it 'updates service type' do
+            expect(Core::ElasticConnectorActions)
+              .to receive(:update_connector_fields)
+              .with(connector_id, hash_including(:service_type => param_service_type))
+
+            described_class.update(connector_settings, param_service_type)
+          end
         end
       end
     end

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -283,4 +283,63 @@ describe Core::ConnectorSettings do
       end
     end
   end
+
+  describe '.needs_configuration?' do
+    let(:connector_status) {
+      Connectors::ConnectorStatus::CONNECTED
+    }
+
+    before do
+      allow(subject).to receive(:connector_status).and_return(connector_status)
+      allow(subject).to receive(:needs_service_type?).and_return(false)
+    end
+
+    shared_examples_for 'needs configuration' do
+      it '' do
+        expect(subject.needs_configuration?).to be_truthy
+      end
+    end
+
+    shared_examples_for 'does not need configuration' do
+      it '' do
+        expect(subject.needs_configuration?).to be_falsey
+      end
+    end
+
+    context 'when service type is not needed' do
+      before do
+        allow(subject).to receive(:needs_service_type?).and_return(false)
+      end
+
+      it_behaves_like 'does not need configuration'
+    end
+
+    context 'when service type is needed' do
+      before do
+        allow(subject).to receive(:needs_service_type?).and_return(true)
+      end
+
+      it_behaves_like 'needs configuration'
+    end
+
+    Connectors::ConnectorStatus::STATUSES_NEEDING_CONFIGURATION.each do |status|
+      context "when connector has status #{status}" do
+        let(:connector_status) {
+          status
+        }
+
+        it_behaves_like 'needs configuration'
+      end
+    end
+
+    (Connectors::ConnectorStatus::STATUSES - Connectors::ConnectorStatus::STATUSES_NEEDING_CONFIGURATION).each do |status|
+      context "when connector has status #{status}" do
+        let(:connector_status) {
+          status
+        }
+
+        it_behaves_like 'does not need configuration'
+      end
+    end
+  end
 end

--- a/spec/core/scheduler_spec.rb
+++ b/spec/core/scheduler_spec.rb
@@ -173,32 +173,26 @@ describe Core::Scheduler do
 
     context 'with configuration task' do
       let(:connector_status) { Connectors::ConnectorStatus::CREATED }
-      let(:needs_service_type) { false }
+      let(:needs_configuration) { false }
+
       before(:each) do
         allow(subject).to receive(:sync_triggered?).with(connector_settings).and_return(false)
         allow(subject).to receive(:heartbeat_triggered?).with(connector_settings).and_return(false)
         allow(subject).to receive(:filtering_validation_triggered?).with(connector_settings).and_return(false)
         allow(connector_settings).to receive(:connector_status).and_return(connector_status)
-        allow(connector_settings).to receive(:needs_service_type?).and_return(needs_service_type)
+        allow(connector_settings).to receive(:needs_configuration?).and_return(needs_configuration)
       end
 
-      it_behaves_like 'triggers', :configuration
-
-      # Regression bug!!!
-      # We need to trigger configuration for the connector that was created with no service_type.
-      # Otherwise on-prem connectors won't be able to start the flow at all.
-      context 'when connector has no service_type' do
-        let(:needs_service_type) { true }
+      context 'when connector needs configuration' do
+        let(:needs_configuration) { true }
 
         it_behaves_like 'triggers', :configuration
       end
 
-      (Connectors::ConnectorStatus::STATUSES - [Connectors::ConnectorStatus::CREATED]).each do |status|
-        context "when connector status is #{status}" do
-          let(:connector_status) { status }
+      context 'when connector does not need configuration' do
+        let(:needs_configuration) { false }
 
-          it_behaves_like 'does not trigger', :configuration
-        end
+        it_behaves_like 'does not trigger', :configuration
       end
     end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3386 ##

This PR fixes the bug that sync rules do not appear for native connectors. This happens, because the native connectors are created in status `NEEDS_CONFIGURATION`, which didn't trigger the configuration task (which adds the features to the corresponding connector entry in .elastic-connectors). Therefore I've moved the logic for checking if a connector needs configuration to the connector settings so we can reuse it.

I've also changed the logic, which handles when to set a connector to `CONFIGURED`. This only happened, when all configurable fields had defaults set, but this should also happen if all fields were set by the user. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally