### PR TITLE
Fix: Add nil guard to advanced snippet in transformation

### DIFF
--- a/lib/connectors/mongodb/mongo_advanced_snippet_snake_case_transformer.rb
+++ b/lib/connectors/mongodb/mongo_advanced_snippet_snake_case_transformer.rb
@@ -23,7 +23,7 @@ module Connectors
       private
 
       def snake_case_filter(advanced_snippet, transformed_filter = {})
-        advanced_snippet.each do |key, value|
+        advanced_snippet&.each do |key, value|
           snake_case_key = key.to_s.underscore
 
           value = value.is_a?(Hash) ? snake_case_filter(value, {}) : value

--- a/spec/connectors/mongodb/mongo_advanced_snippet_snake_case_transformer_spec.rb
+++ b/spec/connectors/mongodb/mongo_advanced_snippet_snake_case_transformer_spec.rb
@@ -9,7 +9,7 @@
 require 'connectors/mongodb/mongo_advanced_snippet_snake_case_transformer'
 
 describe Connectors::MongoDB::MongoAdvancedSnippetSnakeCaseTransformer do
-  let(:filter) {
+  let(:advanced_snippet) {
     {
       'allowDiskUse' => false,
       'nested' => {
@@ -31,9 +31,33 @@ describe Connectors::MongoDB::MongoAdvancedSnippetSnakeCaseTransformer do
     }
   }
 
-  subject { described_class.new(filter) }
+  subject { described_class.new(advanced_snippet) }
 
   describe '#transform' do
+    shared_examples_for 'does not throw error' do
+      it '' do
+        expect { subject.transform }.to_not raise_exception
+      end
+    end
+
+    context 'when advanced snippet is empty' do
+      context 'when advanced snippet is nil' do
+        let(:advanced_snippet) {
+          nil
+        }
+
+        it_behaves_like 'does not throw error'
+      end
+
+      context 'when advanced snippet is nil' do
+        let(:advanced_snippet) {
+          {}
+        }
+
+        it_behaves_like 'does not throw error'
+      end
+    end
+
     context 'when filter contains camel case keys' do
       it 'transforms all keys to snake_case' do
         expect(subject.transform).to eq({


### PR DESCRIPTION
Encountered a small bug, if advanced snippet is nil or empty. Added the needed safe guard.


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
