### PR TITLE
Fix: Exclude DEFAULT simple rule from match all regex check

### DIFF
--- a/lib/core/filtering/simple_rules/validation/simple_rules_schema.rb
+++ b/lib/core/filtering/simple_rules/validation/simple_rules_schema.rb
@@ -11,7 +11,6 @@ module Core
   module Filtering
     module SimpleRules
       module Validation
-
         DEFAULT_RULE_ID = 'DEFAULT'
 
         ALLOWED_VALUE_TYPES = ->(rule_value) { rule_value.is_a?(String) || rule_value.is_a?(Integer) || rule_value.is_a?(TrueClass) || rule_value.is_a?(FalseClass) }

--- a/lib/core/filtering/simple_rules/validation/simple_rules_schema.rb
+++ b/lib/core/filtering/simple_rules/validation/simple_rules_schema.rb
@@ -11,8 +11,11 @@ module Core
   module Filtering
     module SimpleRules
       module Validation
+
+        DEFAULT_RULE_ID = 'DEFAULT'
+
         ALLOWED_VALUE_TYPES = ->(rule_value) { rule_value.is_a?(String) || rule_value.is_a?(Integer) || rule_value.is_a?(TrueClass) || rule_value.is_a?(FalseClass) }
-        MATCH_ALL_REGEX_NOT_ALLOWED = ->(simple_rule) { !(simple_rule['rule'] == Core::Filtering::SimpleRule::Rule::REGEX && (simple_rule['value'] == '(.*)' || simple_rule['value'] == '.*')) }
+        MATCH_ALL_REGEX_NOT_ALLOWED = ->(simple_rule) { simple_rule['id'] == DEFAULT_RULE_ID || !(simple_rule['rule'] == Core::Filtering::SimpleRule::Rule::REGEX && (simple_rule['value'] == '(.*)' || simple_rule['value'] == '.*')) }
 
         SINGLE_RULE_SCHEMA = {
           :fields => {

--- a/spec/core/filtering/simple_rule/single_rule_against_schema_validator_spec.rb
+++ b/spec/core/filtering/simple_rule/single_rule_against_schema_validator_spec.rb
@@ -133,7 +133,6 @@ describe Core::Filtering::SimpleRules::Validation::SingleRuleAgainstSchemaValida
 
           it_behaves_like 'simple rules are valid'
         end
-
       end
 
       context 'when regex does not have parentheses' do

--- a/spec/core/filtering/simple_rule/single_rule_against_schema_validator_spec.rb
+++ b/spec/core/filtering/simple_rule/single_rule_against_schema_validator_spec.rb
@@ -9,6 +9,7 @@ require 'core/filtering/simple_rules/validation/single_rule_against_schema_valid
 require 'core/filtering/simple_rules/simple_rule'
 
 describe Core::Filtering::SimpleRules::Validation::SingleRuleAgainstSchemaValidator do
+  let(:id) { 'id' }
   let(:field) { 'foo' }
   let(:value) { 'bar' }
   let(:order) { 1 }
@@ -18,7 +19,7 @@ describe Core::Filtering::SimpleRules::Validation::SingleRuleAgainstSchemaValida
   let(:simple_rules) do
     [
       {
-        'id' => 'test',
+        'id' => id,
         'field' => field,
         'value' => value,
         'policy' => policy,
@@ -117,7 +118,22 @@ describe Core::Filtering::SimpleRules::Validation::SingleRuleAgainstSchemaValida
           '(.*)'
         }
 
-        it_behaves_like 'simple rules are invalid'
+        context 'when rule is not the default rule' do
+          let(:id) {
+            'not the default rule'
+          }
+
+          it_behaves_like 'simple rules are invalid'
+        end
+
+        context 'when rule is the default rule' do
+          let(:id) {
+            'DEFAULT'
+          }
+
+          it_behaves_like 'simple rules are valid'
+        end
+
       end
 
       context 'when regex does not have parentheses' do
@@ -125,7 +141,21 @@ describe Core::Filtering::SimpleRules::Validation::SingleRuleAgainstSchemaValida
           '.*'
         }
 
-        it_behaves_like 'simple rules are invalid'
+        context 'when rule is not the default rule' do
+          let(:id) {
+            'not the default rule'
+          }
+
+          it_behaves_like 'simple rules are invalid'
+        end
+
+        context 'when rule is the default rule' do
+          let(:id) {
+            'DEFAULT'
+          }
+
+          it_behaves_like 'simple rules are valid'
+        end
       end
     end
   end

--- a/spec/support/shared_examples/filtering.rb
+++ b/spec/support/shared_examples/filtering.rb
@@ -6,6 +6,8 @@
 
 # frozen_string_literal: true
 
+require 'core/filtering/validation_status'
+
 shared_examples 'a schema validator' do
   it 'defines validate_against_schema method' do
     expect(described_class.method_defined?(:validate_against_schema)).to eq true


### PR DESCRIPTION
We should allow that the DEFAULT simple rule uses a match all regex.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally