### PR TITLE
Add more fatal exceptions

### DIFF
--- a/lib/connectors/tolerable_error_helper.rb
+++ b/lib/connectors/tolerable_error_helper.rb
@@ -36,7 +36,11 @@ module Connectors
 
     def fatal_exception_classes
       [
-        Utility::ErrorMonitor::MonitoringError
+        Utility::ErrorMonitor::MonitoringError,
+        Core::ConnectorNotFoundError,
+        Core::ConnectorJobNotFoundError,
+        Core::ConnectorJobCanceledError,
+        Core::ConnectorJobNotRunningError
       ]
     end
   end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3483

Add the following exceptions to `fatal_exception_classes`

1. Core::ConnectorNotFoundError
2. Core::ConnectorJobNotFoundError
3. Core::ConnectorJobCanceledError
4. Core::ConnectorJobNotRunningError


## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally