### PR TITLE
Fix: [MongoDB Connector] Missing aggregation pipeline crashes sync job

### DIFF
--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -156,7 +156,7 @@ module Connectors
         pipeline = aggregate[:pipeline] || []
         options = extract_options(aggregate)
 
-        if !pipeline.present? && !options.present?
+        if pipeline.empty? && options.empty?
           Utility::Logger.warn('\'Aggregate\' was specified with an empty pipeline and empty options.')
         end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -153,10 +153,10 @@ module Connectors
       def create_aggregate_cursor(collection)
         aggregate = @advanced_filter_config[:aggregate]
 
-        pipeline = aggregate[:pipeline]
+        pipeline = aggregate[:pipeline] || []
         options = extract_options(aggregate)
 
-        if !pipeline.nil? && pipeline.empty? && !options.present?
+        if !pipeline.present? && !options.present?
           Utility::Logger.warn('\'Aggregate\' was specified with an empty pipeline and empty options.')
         end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3487 ##

We now check if a pipeline is nil and set it to an empty array, if that's the case, so the sync job won't crash.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally