### PR TITLE
Make it possible to send headers to Elasticsearch clients from config

### DIFF
--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -37,6 +37,7 @@ puts "Parsing #{CONFIG_FILE} configuration file."
       optional(:log).value(:bool?)
       optional(:ca_fingerprint).value(:string)
       optional(:transport_options).value(:hash)
+      optional(:headers).value(:hash)
     end
 
     optional(:thread_pool).hash do

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -113,7 +113,7 @@ module App
       return nil
     end
 
-    headers = ent_search_config['elasticsearch.headers'] || nil
+    headers = ent_search_config['elasticsearch.headers'] || ent_search_config.dig('elasticsearch', 'headers')
 
     {
       :hosts => [

--- a/lib/app/config.rb
+++ b/lib/app/config.rb
@@ -113,6 +113,8 @@ module App
       return nil
     end
 
+    headers = ent_search_config['elasticsearch.headers'] || nil
+
     {
       :hosts => [
         {
@@ -122,7 +124,8 @@ module App
           host: uri.host,
           port: uri.port
         }
-      ]
+      ],
+      :headers => headers
     }
   end
 

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -43,6 +43,10 @@ module Utility
       configs[:transport_options] = es_config[:transport_options] if es_config[:transport_options]
       configs[:ca_fingerprint] = es_config[:ca_fingerprint] if es_config[:ca_fingerprint]
 
+      # headers
+      # these are necessary for cloud-hosted native connectors
+      configs[:headers] = es_config[:headers].to_h if es_config[:headers]
+
       # if log or trace is activated, we use the application logger
       configs[:logger] = if configs[:log] || configs[:trace]
                            Utility::Logger.logger

--- a/spec/app/config_spec.rb
+++ b/spec/app/config_spec.rb
@@ -37,7 +37,10 @@ describe App do
         {
           'elasticsearch.host' => 'http://localhost:9200',
           'elasticsearch.username' => 'elastic',
-          'elasticsearch.password' => 'changeme'
+          'elasticsearch.password' => 'changeme',
+          'elasticsearch.headers' => {
+            'x-pass-through' => true
+          }
         }
       end
 
@@ -51,7 +54,10 @@ describe App do
               host: 'localhost',
               port: 9200
             }
-          ]
+          ],
+          :headers => {
+            'x-pass-through' => true
+          }
         }
       end
 
@@ -121,7 +127,10 @@ describe App do
             'elasticsearch' => {
               'host' => 'http://localhost:9200',
               'username' => 'elastic',
-              'password' => 'changeme'
+              'password' => 'changeme',
+              'headers' => {
+                'x-pass-through' => true
+              }
             }
           }
         end

--- a/spec/utility/es_client_spec.rb
+++ b/spec/utility/es_client_spec.rb
@@ -78,4 +78,33 @@ RSpec.describe Utility::EsClient do
       end
     end
   end
+
+  describe '#connection_configs' do
+    let(:disable_warnings) { false }
+    context 'when headers are present' do
+      let(:headers) do
+        {
+          :something => 'something'
+        }
+      end
+
+      it 'configures Elasticsearch client with headers' do
+        config[:elasticsearch][:headers] = headers
+
+        result = subject.connection_configs(config[:elasticsearch])
+
+        expect(result[:headers]).to eq(headers)
+      end
+    end
+
+    context 'when headers are not present' do
+      it 'configures Elasticsearch client with headers' do
+        config[:elasticsearch][:headers] = nil
+
+        result = subject.connection_configs(config[:elasticsearch])
+
+        expect(result).to_not have_key(:headers)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## In pursuit of https://github.com/elastic/enterprise-search-team/issues/3553

From SDH https://github.com/elastic/sdh-enterprise-search/issues/1022

On cloud, we now need to pass-through the x-elastic-app-auth header.

This PR is a reflection of Python PR https://github.com/elastic/connectors-python/pull/243 and just makes it possible to specify `elasticsearch.headers` in config file. These settings are then passed to elasticsearch client when it's initialised.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

[<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->](https://github.com/elastic/connectors-python/pull/243)

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
