### PR TITLE
Add checkpoints to the connectors protocol

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -278,7 +278,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
     }
   ];
   checkpoint: {
-    <service_type>: object; -> free-form checkpoint data for the job that can be used to restart the crashed job
+    data: object; -> free-form checkpoint data for the job that can be used to restart the crashed job
     restart_attempts: number; -> number of times the job was attempted to continue from the checkpoint
   };
   created_at: date; -> The date/time when the job is created

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -277,6 +277,10 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
       service_type: string;   -> Service type of the connector
     }
   ];
+  checkpoint: {
+    <service_type>: object; -> free-form checkpoint data for the job that can be used to restart the crashed job
+    restart_attempts: number; -> number of times the job was attempted to continue from the checkpoint
+  };
   created_at: date; -> The date/time when the job is created
   deleted_document_count: number; -> Number of documents deleted in the job
   error: string; -> Optional error message
@@ -297,7 +301,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
 - `in_progress` -> A job is successfully started.
 - `canceling` -> The cancelation of the job is initiated.
 - `canceled` -> A job is canceled.
-- `suspended` -> A job is successfully started.
+- `suspended` -> A job has been suspended and will attempt to continue execution later.
 - `completed` -> A job is successfully completed.
 - `error` -> A job failed.
 

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -301,7 +301,7 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
 - `in_progress` -> A job is successfully started.
 - `canceling` -> The cancelation of the job is initiated.
 - `canceled` -> A job is canceled.
-- `suspended` -> A job has been suspended and will attempt to continue execution later.
+- `suspended` -> A job has been suspended and may attempt to continue execution later.
 - `completed` -> A job is successfully completed.
 - `error` -> A job failed.
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3569

Aim of this PR is to discuss and finalise the protocol for job resilience - checkpoints.

A checkpoint is a moment of sync that connector can continue job from in case of crash. Each connector can define checkpoint individually based on internal implementation.

For example, if connector is using paging to fetch data then the checkpoint can be the following:

```
{
  "table_A": { "is_finished": true },
  "table_B": { "is_finished": false, skip: 5000 }
}
```

We also need to store number of attempts we tried to continue from this particular checkpoint so that we could terminate a job if it tries too many times but cannot reach a different checkpoint.

⚠️  Additional note about `suspended` status. It had incorrect description, so I added the description based on my understanding of it, but I'm not 100% sure in the correctness of it.