### PR TITLE
Add custom_scheduling to connector protocol

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -131,48 +131,6 @@ This is our main communication index, used to communicate the connector's config
     },
     "version" : "1"
   },
-  "dynamic_templates": [
-    {
-      "custom_scheduling": {
-        "path_match": "custom_scheduling.*",
-        "mapping": {
-          "type": "object"
-        }
-      }
-    },
-    {
-      "custom_scheduling_configuration_overrides": {
-        "path_match": "custom_scheduling.*.configuration_overrides",
-        "mapping": {
-          "type": "object"
-        }
-      }
-    },
-    {
-      "custom_scheduling_enabled": {
-        "path_match": "custom_scheduling.*.enabled",
-        "mapping": {
-          "type": "boolean"
-        }
-      }
-    },
-    {
-      "custom_scheduling_interval": {
-        "path_match": "custom_scheduling.*.interval",
-        "mapping": {
-          "type": "text"
-        }
-      }
-    },
-    {
-      "custom_scheduling_name": {
-        "path_match": "custom_scheduling.*.name",
-        "mapping": {
-          "type": "text"
-        }
-      }
-    }
-  ]
   "properties" : {
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },


### PR DESCRIPTION
## Issue: https://github.com/elastic/enterprise-search-team/issues/3592

Update the connector protocol to support `custom_scheduling`.
These are being introduced here: https://github.com/elastic/ent-search/pull/7201

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally

## Related Pull Requests

* https://github.com/elastic/ent-search/pull/7201

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
