### PR TITLE
Fix makefile for arm64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-22
   universal-darwin-21
   universal-java-11
   x86-mingw32

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ push_gem:
 	bundle _$(shell cat .bundler-version)_ exec gem push .gems/*
 
 install:
-	rbenv install -s
+	RUBY_CFLAGS="-w" rbenv install -s
 	- gem install bundler -v $(shell cat .bundler-version) && rbenv rehash
 	bundle _$(shell cat .bundler-version)_ install --jobs 1
 


### PR DESCRIPTION
See the slack thread: https://elastic.slack.com/archives/CGRRUP4L9/p1673383147442159?thread_ts=1673380391.857499&cid=CGRRUP4L9

See the rbenv issue where this fix was found: https://github.com/rbenv/ruby-build/issues/1691#issuecomment-752802171


