### PR TITLE
Update elasticsearcy client to 8.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'httpclient', '~> 2.8.3'
 gem 'attr_extras', '~> 6.2.5'
 gem 'hashie', '~> 5.0.0'
 gem 'concurrent-ruby', '~> 1.1.9'
-gem 'elasticsearch', '~> 8.5.0'
+gem 'elasticsearch', '~> 8.6.0'
 
 # Dependencies for oauth
 gem 'signet', '~> 0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,10 +61,10 @@ GEM
     elastic-transport (8.1.0)
       faraday (< 3)
       multi_json
-    elasticsearch (8.5.0)
+    elasticsearch (8.6.0)
       elastic-transport (~> 8)
-      elasticsearch-api (= 8.5.0)
-    elasticsearch-api (8.5.0)
+      elasticsearch-api (= 8.6.0)
+    elasticsearch-api (8.6.0)
       multi_json
     et-orbi (1.2.7)
       tzinfo
@@ -220,7 +220,7 @@ DEPENDENCIES
   dry-schema (= 1.8.0)
   dry-validation (= 1.7.0)
   ecs-logging (~> 1.0.0)
-  elasticsearch (~> 8.5.0)
+  elasticsearch (~> 8.6.0)
   faraday (~> 1.10.0)
   faraday_middleware (= 1.0.0)
   forwardable (~> 1.3.2)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3217

This PR will updata `elasticsearch` client to the latest public version 8.6.0

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
