### PR TITLE
Bump rack to 2.2.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       slop (~> 3.0)
     public_suffix (4.0.6)
     raabro (1.4.0)
-    rack (2.2.4)
+    rack (2.2.6.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.1.1)


### PR DESCRIPTION
Bump rack to 2.2.6.2

Resolves the following dependabot issues:

- https://github.com/elastic/connectors-ruby/security/dependabot/12
- https://github.com/elastic/connectors-ruby/security/dependabot/13
- https://github.com/elastic/connectors-ruby/security/dependabot/14

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## For Elastic Internal Use Only
- [x] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
