### PR TITLE
Add method for updating custom_scheduling last_synced

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -168,6 +168,25 @@ module Core
         )
       end
 
+      def update_connector_custom_scheduling_last_synced(connector_id, schedule_key)
+        doc = connector_with_concurrency_control(connector_id)
+
+        body = {
+          :custom_scheduling => {
+            schedule_key => {
+              :last_synced => Time.now
+            }
+          }
+        }
+
+        update_connector_fields(
+          connector_id,
+          body,
+          doc[:seq_no],
+          doc[:primary_term]
+        )
+      end
+
       def connector_with_concurrency_control(connector_id)
         seq_no = nil
         primary_term = nil
@@ -317,6 +336,7 @@ module Core
           :properties => {
             :api_key_id => { :type => :keyword },
             :configuration => { :type => :object },
+            :custom_schedule => { :type => :object },
             :description => { :type => :text },
             :error => { :type => :keyword },
             :features => {


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/3594

Add method to update `custom_scheduling.[key].last_synced` value with current time.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
