### PR TITLE
Add id to connector indices + dynamic: false

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -134,7 +134,6 @@ This is our main communication index, used to communicate the connector's config
   },
   "dynamic": false,
   "properties" : {
-    "id": { "type": "keyword" },
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
     "custom_scheduling" : { "type" : "object" },

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -30,7 +30,6 @@ All communication will need to go through Elasticsearch. We've created a connect
 This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.
 ```
 {
-  id: string; -> Id of the connector
   api_key_id: string;   -> ID of the current API key in use
   configuration: {
     [key]: {
@@ -255,7 +254,6 @@ This is our main communication index, used to communicate the connector's config
 In addition to the connector index `.elastic-connectors`, we have an additional index to log all jobs run by connectors. This is the `.elastic-connectors-sync-jobs` index. Each JSON document will have the following structure:
 ```
 {
-  id: string; -> Id of the job
   cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
   canceled_at: date; -> The date/time when the job is canceled
   completed_at: date; -> The data/time when the job is completed
@@ -328,7 +326,6 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   },
   "dynamic": false,
   "properties" : {
-    "id": { "type": "keyword" },
     "cancelation_requested_at" : { "type" : "date" },
     "canceled_at" : { "type" : "date" },
     "completed_at" : { "type" : "date" },

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -30,6 +30,7 @@ All communication will need to go through Elasticsearch. We've created a connect
 This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.
 ```
 {
+  id: string; -> Id of the connector
   api_key_id: string;   -> ID of the current API key in use
   configuration: {
     [key]: {
@@ -132,7 +133,9 @@ This is our main communication index, used to communicate the connector's config
     },
     "version" : "1"
   },
+  "dynamic": false,
   "properties" : {
+    "id": { "type": "keyword" },
     "api_key_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
     "custom_scheduling" : { "type" : "object" },
@@ -252,6 +255,7 @@ This is our main communication index, used to communicate the connector's config
 In addition to the connector index `.elastic-connectors`, we have an additional index to log all jobs run by connectors. This is the `.elastic-connectors-sync-jobs` index. Each JSON document will have the following structure:
 ```
 {
+  id: string; -> Id of the job
   cancelation_requested_at: date; -> The date/time when the cancelation of the job is requested
   canceled_at: date; -> The date/time when the job is canceled
   completed_at: date; -> The data/time when the job is completed
@@ -322,7 +326,9 @@ In addition to the connector index `.elastic-connectors`, we have an additional 
   "_meta" : {
     "version" : 1
   },
+  "dynamic": false,
   "properties" : {
+    "id": { "type": "keyword" },
     "cancelation_requested_at" : { "type" : "date" },
     "canceled_at" : { "type" : "date" },
     "completed_at" : { "type" : "date" },

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -339,6 +339,7 @@ module Core
       # Creation of connector index should be handled by Kibana, this method is only used by ftest.rb
       def ensure_connectors_index_exists
         mappings = {
+          :dynamic => false,
           :properties => {
             :api_key_id => { :type => :keyword },
             :configuration => { :type => :object },
@@ -460,6 +461,7 @@ module Core
       # Creation of job index should be handled by Kibana, this method is only used by ftest.rb
       def ensure_job_index_exists
         mappings = {
+          :dynamic => false,
           :properties => {
             :cancelation_requested_at => { :type => :date },
             :canceled_at => { :type => :date },


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3729

Connected to issue https://github.com/elastic/enterprise-search-team/issues/3729

Updating connectors protocol to reflect the changes in the PR:

- adding "dynamic: false" to both indices