### PR TITLE
Don't delete content indices used by existing connectors

### DIFF
--- a/lib/app/dispatcher.rb
+++ b/lib/app/dispatcher.rb
@@ -72,7 +72,7 @@ module App
       end
 
       def job_cleanup_timer
-        @job_cleanup_timer ||= Concurrent::TimerTask.new(:execution_interval => JOB_CLEANUP_INTERVAL) do
+        @job_cleanup_timer ||= Concurrent::TimerTask.new(:execution_interval => JOB_CLEANUP_INTERVAL, :run_now => true) do
           connector_id = App::Config.native_mode ? nil : App::Config.connector_id
           Core::JobCleanUp.execute(connector_id)
         end

--- a/lib/core/connector_job.rb
+++ b/lib/core/connector_job.rb
@@ -36,8 +36,7 @@ module Core
       fetch_jobs_by_query(query, page_size)
     end
 
-    def self.orphaned_jobs(page_size = DEFAULT_PAGE_SIZE)
-      connector_ids = ConnectorSettings.fetch_all_connectors.map(&:id)
+    def self.orphaned_jobs(connector_ids = [], page_size = DEFAULT_PAGE_SIZE)
       query = { bool: { must_not: { terms: { 'connector.id': connector_ids } } } }
       fetch_jobs_by_query(query, page_size)
     end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -531,8 +531,8 @@ module Core
       end
 
       def document_count(index_name)
-        client.indices.refresh(:index => index_name)
-        client.count(:index => index_name)['count']
+        client.indices.refresh(:index => index_name, :ignore_unavailable => true)
+        client.count(:index => index_name, :ignore_unavailable => true)['count']
       end
 
       private

--- a/lib/core/jobs/consumer.rb
+++ b/lib/core/jobs/consumer.rb
@@ -37,7 +37,7 @@ module Core
       end
 
       def subscribe!(index_name:)
-        Utility::Logger.info("Starting a new consumer for #{@index_name} index")
+        Utility::Logger.info("Starting a new consumer for #{index_name} index")
 
         @index_name = index_name
         start_timer_task!

--- a/spec/core/job_cleanup_spec.rb
+++ b/spec/core/job_cleanup_spec.rb
@@ -10,12 +10,14 @@ require 'core'
 
 describe Core::JobCleanUp do
   describe '.execute' do
+    let(:connectors) { [] }
     let(:orphaned_jobs) { [] }
     let(:stuck_jobs) { [] }
     let(:job1) { double }
     let(:job2) { double }
 
     before(:each) do
+      allow(Core::ConnectorSettings).to receive(:fetch_all_connectors).and_return(connectors)
       allow(Core::ConnectorJob).to receive(:orphaned_jobs).and_return(orphaned_jobs)
       allow(Core::ConnectorJob).to receive(:stuck_jobs).and_return(stuck_jobs)
     end


### PR DESCRIPTION
This PR ensures that the content indices of existing connectors are not deleted, when cleaning up orphaned jobs.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference