### PR TITLE
Reset last_sync_error when claiming a job

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -157,12 +157,18 @@ module Core
         )
       end
 
-      def update_connector_last_sync_status(connector_id, last_sync_status)
+      def update_connector_sync_start(connector_id)
         doc = connector_with_concurrency_control(connector_id)
+
+        body = {
+            last_sync_status: Connectors::SyncStatus::IN_PROGRESS,
+            last_sync_error: nil,
+            status: Connectors::ConnectorStatus::CONNECTED
+        }
 
         update_connector_fields(
           connector_id,
-          { last_sync_status: last_sync_status },
+          body,
           doc[:seq_no],
           doc[:primary_term]
         )

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -202,7 +202,7 @@ module Core
       end
 
       begin
-        Core::ElasticConnectorActions.update_connector_last_sync_status(@connector_id, Connectors::SyncStatus::IN_PROGRESS)
+        Core::ElasticConnectorActions.update_connector_sync_start(@connector_id)
 
         @job.make_running!
 

--- a/spec/core/sync_job_runner_spec.rb
+++ b/spec/core/sync_job_runner_spec.rb
@@ -107,7 +107,7 @@ describe Core::SyncJobRunner do
 
     allow(Core::ElasticConnectorActions).to receive(:fetch_document_ids).and_return(existing_document_ids)
     allow(Core::ElasticConnectorActions).to receive(:update_connector_status)
-    allow(Core::ElasticConnectorActions).to receive(:update_connector_last_sync_status)
+    allow(Core::ElasticConnectorActions).to receive(:update_connector_sync_start)
 
     allow(Connectors::REGISTRY).to receive(:connector_class).and_return(connector_class)
     allow(Core::Ingestion::EsSink).to receive(:new).and_return(sink)
@@ -158,7 +158,7 @@ describe Core::SyncJobRunner do
   describe '#execute' do
     shared_examples_for 'claims the job' do
       it '' do
-        expect(Core::ElasticConnectorActions).to receive(:update_connector_last_sync_status)
+        expect(Core::ElasticConnectorActions).to receive(:update_connector_sync_start)
         expect(job).to receive(:make_running!)
 
         subject.execute
@@ -226,7 +226,7 @@ describe Core::SyncJobRunner do
 
     context 'when failing to make connector running' do
       before(:each) do
-        allow(Core::ElasticConnectorActions).to receive(:update_connector_last_sync_status).and_raise(StandardError)
+        allow(Core::ElasticConnectorActions).to receive(:update_connector_sync_start).and_raise(StandardError)
       end
 
       it_behaves_like 'does not run a sync'


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3384

This PR resets `last_sync_error`, and update `status` to `connected` when claiming a job

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference