### PR TITLE
Implement nested features

### DIFF
--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -55,8 +55,11 @@ This is our main communication index, used to communicate the connector's config
   description: string;  -> The description of the connector
   error: string;        -> Optional error message
   features: {
-    filtering_advanced_config: boolean; -> Whether to display filtering advanced config in the Kibana UI
-    filtering_rules: boolean;           -> Whether to display filtering rules in the Kibana UI
+    [feature_name]: {
+        [subfeature_name]: {
+            enabled: boolean; -> Whether this feature is enabled
+        }
+    };                                  -> Features to enable/disable for this connector
   };
   filtering: [          -> Array of filtering rules, connectors use the first entry by default
     {          

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -44,8 +44,8 @@ module Connectors
 
       def self.kibana_features
         [
-          Utility::Constants::FILTERING_RULES_FEATURE,
-          Utility::Constants::FILTERING_ADVANCED_FEATURE
+          { :feature => :sync_rules, :subfeature => :basic, :enabled => true },
+          { :feature => :sync_rules, :subfeature => :advanced, :enabled => true }
         ]
       end
 

--- a/lib/core/configuration.rb
+++ b/lib/core/configuration.rb
@@ -24,7 +24,19 @@ module Core
             return
           end
           configuration = connector_class.configurable_fields_indifferent_access
-          features = connector_class.kibana_features.each_with_object({}) { |feature, hsh| hsh[feature] = true }
+
+          features = {}
+
+          connector_class.kibana_features.each do |feature_definition, _hsh|
+            feature = feature_definition[:feature]
+            subfeature = feature_definition[:subfeature]
+            enabled = feature_definition[:enabled]
+
+            features[feature] = {} unless features.key?(feature)
+
+            features[feature][subfeature] = { :enabled => enabled }
+          end
+
           doc = {
             :configuration => configuration,
             :features => features

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -68,12 +68,14 @@ module Core
       self[:features] || {}
     end
 
-    # being defensive here to avoid regressions, will be subject to change in the near future
+    # .dig version is the modern features way of doing things,
+    # Right-hand of OR operator is legacy features support
+    # When this is fixed with a migration, we can go ahead
     def filtering_rule_feature_enabled?
-      !!features[:filtering_rules]
+      !!features.dig(:sync_rules, :basic, :enabled) || !!features[:filtering_rules]
     end
     def filtering_advanced_config_feature_enabled?
-      !!features[:filtering_advanced_config]
+      !!features.dig(:sync_rules, :advanced, :enabled) || !!features[:filtering_advanced_config]
     end
 
     def any_filtering_feature_enabled?

--- a/lib/utility/constants.rb
+++ b/lib/utility/constants.rb
@@ -16,8 +16,6 @@ module Utility
     JOB_INDEX = '.elastic-connectors-sync-jobs'
     CONTENT_INDEX_PREFIX = 'search-'
     CRAWLER_SERVICE_TYPE = 'elastic-crawler'
-    FILTERING_RULES_FEATURE = 'filtering_rules'
-    FILTERING_ADVANCED_FEATURE = 'filtering_advanced_config'
 
     # Maximum number of operations in BULK Elasticsearch operation that will ingest the data
     DEFAULT_MAX_INGESTION_QUEUE_SIZE = 500

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -57,8 +57,10 @@ describe Core::Configuration do
                   :configuration => configuration,
                   :status => Connectors::ConnectorStatus::NEEDS_CONFIGURATION,
                   :features => {
-                    Utility::Constants::FILTERING_RULES_FEATURE => true,
-                    Utility::Constants::FILTERING_ADVANCED_FEATURE => true
+                    :sync_rules => {
+                      :basic => { :enabled => true },
+                      :advanced => { :enabled => true }
+                    }
                   }
                 ))
 

--- a/spec/core/connector_settings_spec.rb
+++ b/spec/core/connector_settings_spec.rb
@@ -304,8 +304,10 @@ describe Core::ConnectorSettings do
 
     let(:features) {
       {
-        :filtering_rules => filtering_rules_feature_enabled,
-        :filtering_advanced_config => filtering_advanced_config_feature_enabled
+        :sync_rules => {
+          :basic => { :enabled => filtering_rules_feature_enabled },
+          :advanced => { :enabled => filtering_advanced_config_feature_enabled }
+        }
       }
     }
 
@@ -366,6 +368,33 @@ describe Core::ConnectorSettings do
     end
 
     context 'when features are present' do
+      context 'when features are in legacy format' do
+        let(:features) {
+          {
+            :filtering_rules => filtering_rules_feature_enabled,
+            :filtering_advanced_config => filtering_advanced_config_feature_enabled
+          }
+        }
+
+        context 'when filtering rule feature is disabled' do
+          let(:filtering_rules_feature_enabled) {
+            false
+          }
+
+          it_behaves_like 'filtering rule feature is disabled'
+        end
+
+        context 'when filtering rule feature is enabled' do
+          let(:filtering_rules_feature_enabled) {
+            true
+          }
+
+          it 'returns enabled' do
+            expect(subject.filtering_rule_feature_enabled?).to be_truthy
+          end
+        end
+      end
+
       context 'when filtering rule feature is disabled' do
         let(:filtering_rules_feature_enabled) {
           false
@@ -408,6 +437,33 @@ describe Core::ConnectorSettings do
     end
 
     context 'when features are present' do
+      context 'when features are in legacy format' do
+        let(:features) {
+          {
+            :filtering_rules => filtering_rules_feature_enabled,
+            :filtering_advanced_config => filtering_advanced_config_feature_enabled
+          }
+        }
+
+        context 'when filtering advanced config feature is disabled' do
+          let(:filtering_advanced_config_feature_enabled) {
+            false
+          }
+
+          it_behaves_like 'filtering advanced config feature is disabled'
+        end
+
+        context 'when filtering advanced config feature is enabled' do
+          let(:filtering_advanced_config_feature_enabled) {
+            true
+          }
+
+          it 'returns enabled' do
+            expect(subject.filtering_advanced_config_feature_enabled?).to be_truthy
+          end
+        end
+      end
+
       context 'when filtering advanced config feature is disabled' do
         let(:filtering_advanced_config_feature_enabled) {
           false


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3653

This PR implements new connector features structure:

```
{
"features": {
  "sync_rules": {
    "basic" : { "enabled" : true },
    "advanced": {"enabled":true }
  }
}
```

While this structure is also implemented and used, old structure is still maintained and used for backwards compatibility.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## For Elastic Internal Use Only
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)