### PR TITLE
Fix the bug that connector starts sync immediately when scheduled

### DIFF
--- a/lib/connectors/crawler/scheduler.rb
+++ b/lib/connectors/crawler/scheduler.rb
@@ -56,7 +56,7 @@ module Connectors
       def custom_schedule_triggered(cs)
         cs.custom_scheduling_settings.each do |key, custom_scheduling|
           identifier = "#{cs.formatted} - #{custom_scheduling[:name]}"
-          if schedule_triggered?(custom_scheduling, identifier, custom_scheduling[:last_synced])
+          if schedule_triggered?(custom_scheduling, identifier)
             return key
           end
         end


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3366

The connector will start syncing immediately if its scheduling is enabled and it's never synced.

This PR fixes this bug, and makes the job scheduling respect the crontab:

It gets the next sync time from `now`, and compares it with `now` + `poll_interval`. It will trigger the sync if the next sync time happens before the next poll. This is consistent with the python implementation.

A follow-up PR is needed to update `ent-search` gem when this is merged.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference