### PR TITLE
Fix backportrc for 8.7

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,14 +1,14 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
+    "8.7",
     "8.6",
-    "8.5",
-    "8.4"
+    "8.5"
   ],
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v8.7.0$": "main",
+    "^v8.8.0$": "main",
     "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "upstream": "elastic/connectors-ruby"


### PR DESCRIPTION
Make 8.7 branch a target to backport

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference