### PR TITLE
[8.7] Fix the bug that connector starts sync immediately when scheduled (#531)

### DIFF
--- a/lib/connectors/crawler/scheduler.rb
+++ b/lib/connectors/crawler/scheduler.rb
@@ -56,7 +56,7 @@ module Connectors
       def custom_schedule_triggered(cs)
         cs.custom_scheduling_settings.each do |key, custom_scheduling|
           identifier = "#{cs.formatted} - #{custom_scheduling[:name]}"
-          if schedule_triggered?(custom_scheduling, identifier, custom_scheduling[:last_synced])
+          if schedule_triggered?(custom_scheduling, identifier)
             return key
           end
         end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fix the bug that connector starts sync immediately when scheduled (#531)](https://github.com/elastic/connectors-ruby/pull/531)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)