### PR TITLE
[8.7] Rename stuck jobs to idle jobs (#535)

### DIFF
--- a/lib/core/connector_job.rb
+++ b/lib/core/connector_job.rb
@@ -15,7 +15,7 @@ require 'utility'
 module Core
   class ConnectorJob
     DEFAULT_PAGE_SIZE = 100
-    STUCK_THRESHOLD = 60
+    IDLE_THRESHOLD = 60
 
     def self.fetch_by_id(job_id)
       es_response = ElasticConnectorActions.get_job(job_id)
@@ -46,7 +46,7 @@ module Core
       ElasticConnectorActions.delete_jobs_by_query(query)
     end
 
-    def self.stuck_jobs(connector_id = nil, page_size = DEFAULT_PAGE_SIZE)
+    def self.idle_jobs(connector_id = nil, page_size = DEFAULT_PAGE_SIZE)
       connector_ids = if connector_id
                         [connector_id]
                       else
@@ -57,7 +57,7 @@ module Core
           filter: [
               { terms: { 'connector.id': connector_ids } },
               { terms: { status: Connectors::SyncStatus::ACTIVE_STATUSES } },
-              { range: { last_seen: { lte: "now-#{STUCK_THRESHOLD}s" } } }
+              { range: { last_seen: { lte: "now-#{IDLE_THRESHOLD}s" } } }
           ]
         }
       }

--- a/spec/core/job_cleanup_spec.rb
+++ b/spec/core/job_cleanup_spec.rb
@@ -12,14 +12,14 @@ describe Core::JobCleanUp do
   describe '.execute' do
     let(:connectors) { [] }
     let(:orphaned_jobs) { [] }
-    let(:stuck_jobs) { [] }
+    let(:idle_jobs) { [] }
     let(:job1) { double }
     let(:job2) { double }
 
     before(:each) do
       allow(Core::ConnectorSettings).to receive(:fetch_all_connectors).and_return(connectors)
       allow(Core::ConnectorJob).to receive(:orphaned_jobs).and_return(orphaned_jobs)
-      allow(Core::ConnectorJob).to receive(:stuck_jobs).and_return(stuck_jobs)
+      allow(Core::ConnectorJob).to receive(:idle_jobs).and_return(idle_jobs)
     end
 
     it 'should not clean up orphaned jobs' do
@@ -29,7 +29,7 @@ describe Core::JobCleanUp do
       described_class.execute
     end
 
-    it 'should not mark stuck jobs error' do
+    it 'should not mark idle jobs error' do
       expect_any_instance_of(Core::ConnectorJob).to_not receive(:error!)
       expect(Core::ConnectorJob).to_not receive(:fetch_by_id)
       expect(Core::ConnectorSettings).to_not receive(:fetch_by_id)
@@ -56,8 +56,8 @@ describe Core::JobCleanUp do
       end
     end
 
-    context 'with stuck jobs' do
-      let(:stuck_jobs) { [job1, job2] }
+    context 'with idle jobs' do
+      let(:idle_jobs) { [job1, job2] }
       let(:connector) { double }
       let(:connector_id) { '1' }
       let(:id1) { '1' }
@@ -74,7 +74,7 @@ describe Core::JobCleanUp do
         allow(job2).to receive(:connector).and_return(connector)
       end
 
-      it 'should mark stuck jobs error' do
+      it 'should mark idle jobs error' do
         expect(job1).to receive(:error!)
         expect(job2).to receive(:error!)
         expect(connector).to receive(:update_last_sync!).twice


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Rename stuck jobs to idle jobs (#535)](https://github.com/elastic/connectors-ruby/pull/535)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)