### PR TITLE
Allow arbitrary levels of postfix versions in .backportrc

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -8,7 +8,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.8.0$": "main",
-    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
+    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors-ruby"
 }

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -8,7 +8,7 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v8.8.0$": "main",
-    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
+    "^v(\\d+).(\\d+).\\d+$": "$1.$2"
   },
   "upstream": "elastic/connectors-ruby"
 }


### PR DESCRIPTION
With the current format we miss backports for PRs labeled with "8.7.0.0" as we hardcoded three numbers.