### PR TITLE
remove prompt=consent in favor of prompt=select_account

### DIFF
--- a/lib/connectors_sdk/share_point/authorization.rb
+++ b/lib/connectors_sdk/share_point/authorization.rb
@@ -35,7 +35,7 @@ module ConnectorsSdk
         end
 
         def additional_parameters
-          { :prompt => 'consent' }
+          { :prompt => 'select_account' }
         end
       end
     end


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/3948


This is based off of https://github.com/elastic/ent-search/pull/7352/files, but for connector packages


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)

## Related Pull Requests


* normal connectors: https://github.com/elastic/ent-search/pull/7352/files
* docs: https://github.com/elastic/enterprise-search-pubs/pull/3201

## Release Note

Fixes a bug where Sharepoint Online Connector Packages couldn't be connected by non-global-admins, even if admin consent was granted.

## For Elastic Internal Use Only
- [x] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
  - not doing this, since we aren't actually fixing old version of enterprise search, but the connector package just happens to live in this old branch
