### PR TITLE
Make connector_utilities compatible with Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gem 'bundler', File.read(File.join(__dir__, '.bundler-version')).strip
 
 # Dependencies for connectors
-gem 'activesupport', '~>6.0.6'
+gem 'activesupport', '~>6.0.6.1'
 gem 'mime-types', '= 3.1'
 gem 'tzinfo-data'
 gem 'tzinfo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  activesupport (~> 6.0.6)
+  activesupport (~> 6.0.6.1)
   attr_extras (~> 6.2.5)
   bundler (= 2.3.15)
   concurrent-ruby (~> 1.1.9)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4069

This PR just bump `activesupport` version to 6.0.6 to align it with ent-search dependencies

## Checklists

#### Pre-Review Checklist
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* https://github.com/elastic/ent-search/pull/7402
* https://github.com/elastic/ent-search/pull/7393
