### PR TITLE
Added handling for HTTP response errors and only scanning allowed groups

### DIFF
--- a/lib/connectors_sdk/office365/custom_client.rb
+++ b/lib/connectors_sdk/office365/custom_client.rb
@@ -86,13 +86,20 @@ module ConnectorsSdk
       end
 
       def groups(fields: [])
-        request_all(:endpoint => 'groups/', :fields => fields)
+        request_all(:endpoint => 'me/transitiveMemberOf/microsoft.graph.group/', :fields => fields)
       end
 
       def group_root_site(group_id, fields: [])
+        # Continues sync if the Graph API encounters an unsuccesful request (e.g. 404)
         query_params = transform_fields_to_request_query_params(fields)
 
-        request_endpoint(:endpoint => "groups/#{group_id}/sites/root", :query_params => query_params)
+        begin
+          p "Retrieving site for #{group_id}"
+          request_endpoint(:endpoint => "groups/#{group_id}/sites/root", :query_params => query_params)
+        rescue StandardError, ClientError, Office365InvalidCursorsError => e
+          puts "An error occurred retrieving site for group ID #{group_id}: #{e}"
+          nil
+        end
       end
 
       def sites(fields: [])

--- a/spec/connectors_sdk/base/connector_spec.rb
+++ b/spec/connectors_sdk/base/connector_spec.rb
@@ -58,6 +58,7 @@ describe ConnectorsSdk::Base::Connector do
         ]
       }
 
+      mock_endpoint('me/transitiveMemberOf/microsoft.graph.group/?$select=id,createdDateTime', groups)
       mock_endpoint('sites/?$select=id,name&search=&top=10', sites)
       mock_endpoint('groups/?$select=id,createdDateTime', groups)
       mock_endpoint('groups/1234/sites/root?$select=id,name', sites)

--- a/spec/connectors_sdk/office365/custom_client_spec.rb
+++ b/spec/connectors_sdk/office365/custom_client_spec.rb
@@ -126,6 +126,8 @@ describe ConnectorsSdk::Office365::CustomClient do
     let(:recent_site_drives_body) { connectors_fixture_raw(directory + 'site_drives_for_recently_created_site.json') } # returns 2 results
 
     before(:each) do
+      stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'me/transitiveMemberOf/microsoft.graph.group/?$select=id,createdDateTime')
+        .to_return(:status => status, :body => groups_mapped_body)
       stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'groups/?$select=id,createdDateTime')
         .to_return(:status => status, :body => groups_mapped_body)
 

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -58,6 +58,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
     end
     let(:drive_ids) { share_point_site_drive_ids }
     let(:groups_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}groups/?$select=id,createdDateTime" }
+    let(:my_groups_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}me/transitiveMemberOf/microsoft.graph.group/?$select=id,createdDateTime" }
     let(:sites_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}sites/?$select=id,name&search=&top=10" }
     let(:sites_body) { connectors_fixture_raw('office365/sites.json') }
     let(:site_1_id) { 'enterprisesearch.sharepoint.com,f62543c6-b329-4e0a-96c1-c1a065f5be3f,23ed25a9-4dee-4750-afb0-acb21475a499' }
@@ -76,6 +77,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
       stub_request(:get, site_1_drive_url).to_return(:status => 200, :body => site_drive_1_body)
       stub_request(:get, site_2_drive_url).to_return(:status => 200, :body => site_drive_2_body)
       stub_request(:get, groups_url).to_return(:status => 200, :body => groups_body)
+      stub_request(:get, my_groups_url).to_return(:status => 200, :body => groups_body)
     end
 
     context 'when drive ids are all' do
@@ -314,7 +316,8 @@ describe ConnectorsSdk::SharePoint::Extractor do
   def expect_groups(groups)
     stub_request(:get, "#{graph_base_url}groups/?$select=id,createdDateTime")
       .to_return(graph_response(:value => groups))
-
+    stub_request(:get, "#{graph_base_url}me/transitiveMemberOf/microsoft.graph.group/?$select=id,createdDateTime")
+      .to_return(graph_response(:value => groups))
     groups
   end
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-ruby/issues/544

Updates to only loop through groups that the user is a member of using the following GraphAPI endpoint: https://learn.microsoft.com/en-us/graph/api/user-list-transitivememberof?view=graph-rest-1.0&tabs=http.

Also added begin...rescue to bypass and log URL request exceptions.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`) -- N/A
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

None

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->



## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
