### PR TITLE
Remove 8.6 from backportrc

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,8 +2,7 @@
   "targetBranchChoices": [
     { "name": "main", "checked": true },
     "8.8",
-    "8.7",
-    "8.6"
+    "8.7"
   ],
   "fork": false,
   "targetPRLabels": ["backport"],


### PR DESCRIPTION
Small thing - there are no more 8.6.* releases left, so no point to have it in backportrc.