### PR TITLE
Bump rack and activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,10 @@ source 'https://rubygems.org'
 gem 'bundler', File.read(File.join(__dir__, '.bundler-version')).strip
 
 # Dependencies for connectors
-gem 'activesupport', '~>6.0.6.1'
+gem 'activesupport', '~>6.1.7.3'
 gem 'mime-types', '= 3.1'
 gem 'tzinfo-data'
-gem 'tzinfo'
+gem 'tzinfo', '~> 2.0'
 gem 'fugit', '~> 1.5.3'
 gem 'remedy', '~> 0.3.0'
 gem 'ecs-logging', '~> 1.0.0'
@@ -34,7 +34,7 @@ group :test do
   gem 'rubocop-performance', '1.11.5'
   gem 'rspec-mocks'
   gem 'webmock'
-  gem 'rack', '>= 2.2.3.1'
+  gem 'rack', '>= 2.2.6.4'
   gem 'rack-test'
   gem 'ruby-debug-ide'
   gem 'pry-remote'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6.1)
+    activesupport (6.1.7.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -102,14 +102,14 @@ GEM
     hashdiff (1.0.1)
     hashie (5.0.0)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jwt (2.3.0)
     method_source (1.0.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.18.0)
+    minitest (5.19.0)
     mongo (2.18.1)
       bson (>= 4.14.1, < 5.0.0)
     multi_json (1.15.0)
@@ -131,7 +131,7 @@ GEM
       slop (~> 3.0)
     public_suffix (4.0.6)
     raabro (1.4.0)
-    rack (2.2.6.2)
+    rack (2.2.8)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.1.1)
@@ -186,11 +186,9 @@ GEM
     slop (3.6.0)
     spoon (0.0.6)
       ffi
-    thread_safe (0.3.6)
-    thread_safe (0.3.6-java)
     timecop (0.9.4)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.1.0)
@@ -198,7 +196,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   arm64-darwin-22
@@ -208,7 +206,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  activesupport (~> 6.0.6.1)
+  activesupport (~> 6.1.7.3)
   attr_extras (~> 6.2.5)
   bundler (= 2.3.15)
   concurrent-ruby (~> 1.1.9)
@@ -233,7 +231,7 @@ DEPENDENCIES
   mongo (~> 2.18)
   pry-nav
   pry-remote
-  rack (>= 2.2.3.1)
+  rack (>= 2.2.6.4)
   rack-test
   remedy (~> 0.3.0)
   rspec-collection_matchers (~> 1.2.0)
@@ -247,7 +245,7 @@ DEPENDENCIES
   simplecov
   simplecov-material
   timecop
-  tzinfo
+  tzinfo (~> 2.0)
   tzinfo-data
   webmock
 


### PR DESCRIPTION
Resolves dependabot alerts: https://github.com/elastic/connectors-ruby/security/dependabot