### PR TITLE
Update activesupport Gem to 6.1.7.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gem 'bundler', File.read(File.join(__dir__, '.bundler-version')).strip
 
 # Dependencies for connectors
-gem 'activesupport', '~>6.1.7.3'
+gem 'activesupport', '~>6.1.7.5'
 gem 'mime-types', '= 3.1'
 gem 'tzinfo-data'
 gem 'tzinfo', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.4)
+    activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -206,7 +206,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  activesupport (~> 6.1.7.3)
+  activesupport (~> 6.1.7.5)
   attr_extras (~> 6.2.5)
   bundler (= 2.3.15)
   concurrent-ruby (~> 1.1.9)


### PR DESCRIPTION
Update the activesupport gem to ~>6.1.7.5

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
