### PR TITLE
Upgrade activesupport to fix dependabot alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gem 'bundler', File.read(File.join(__dir__, '.bundler-version')).strip
 
 # Dependencies for connectors
-gem 'activesupport', '~>6.1.7.3'
+gem 'activesupport', '~>6.1.7.5'
 gem 'mime-types', '= 3.1'
 gem 'tzinfo-data'
 gem 'tzinfo', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.4)
+    activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -94,7 +94,6 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    ffi (1.15.5-java)
     forwardable (1.3.2)
     fugit (1.5.3)
       et-orbi (~> 1, >= 1.2.7)
@@ -120,10 +119,6 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry (0.14.1-java)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      spoon (~> 0.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
     pry-remote (0.1.8)
@@ -184,8 +179,6 @@ GEM
       simplecov (>= 0.16.0)
     simplecov_json_formatter (0.1.4)
     slop (3.6.0)
-    spoon (0.0.6)
-      ffi
     timecop (0.9.4)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -206,7 +199,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  activesupport (~> 6.1.7.3)
+  activesupport (~> 6.1.7.5)
   attr_extras (~> 6.2.5)
   bundler (= 2.3.15)
   concurrent-ruby (~> 1.1.9)


### PR DESCRIPTION
To fix dependabot alert https://github.com/elastic/connectors-ruby/security/dependabot/23

## Checklists

#### Pre-Review Checklist
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
