### PR TITLE
[CI] [Buildkite] Add Proper Team in Catalog Info File

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,7 +22,7 @@ spec:
       repository: elastic/connectors-ruby
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        # your-team:
-        #  access_level: MANAGE_BUILD_AND_READ
+        enterprise-search:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Adds the missing team name in the `catalog-info.yaml` file for Buildkite / Backstage.

