### PR TITLE
Bump elasticsearch gem to 8.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'httpclient', '~> 2.8.3'
 gem 'attr_extras', '~> 6.2.5'
 gem 'hashie', '~> 5.0.0'
 gem 'concurrent-ruby', '~> 1.1.9'
-gem 'elasticsearch', '~> 8.8.0'
+gem 'elasticsearch', '~> 8.11.0'
 
 # Dependencies for oauth
 gem 'signet', '~> 0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,13 +59,13 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
     ecs-logging (1.0.0)
-    elastic-transport (8.2.1)
+    elastic-transport (8.3.0)
       faraday (< 3)
       multi_json
-    elasticsearch (8.8.0)
-      elastic-transport (~> 8)
-      elasticsearch-api (= 8.8.0)
-    elasticsearch-api (8.8.0)
+    elasticsearch (8.11.0)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.11.0)
+    elasticsearch-api (8.11.0)
       multi_json
     et-orbi (1.2.7)
       tzinfo
@@ -220,7 +220,7 @@ DEPENDENCIES
   dry-schema (= 1.8.0)
   dry-validation (= 1.7.0)
   ecs-logging (~> 1.0.0)
-  elasticsearch (~> 8.8.0)
+  elasticsearch (~> 8.11.0)
   faraday (~> 1.10.0)
   faraday_middleware (= 1.0.0)
   forwardable (~> 1.3.2)


### PR DESCRIPTION
Part of [8.11.0 post-release tasks](https://github.com/elastic/enterprise-search-team/issues/5793).
Bumping `elasticsearch` gem's version to 8.11.0. Note that the bump is from `8.8.0`, not sure why the previous two minor versions were skipped.