### PR TITLE
Update to latest ubuntu image in dockerfile to avoid lots of vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     uuid-runtime curl ca-certificates git make build-essential \
     libssl-dev libreadline-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.24.2/yq_linux_amd64.tar.gz | tar -xzvf - && \
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.40.2/yq_linux_amd64.tar.gz | tar -xzvf - && \
     mv yq_linux_amd64 /usr/bin/yq
 RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
     curl -L https://github.com/sstephenson/ruby-build/archive/v20231114.tar.gz | tar -zxvf - -C /tmp/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,30 @@
-FROM ubuntu:focal
+FROM ubuntu:mantic-20231011
 
 WORKDIR /app
 COPY . /app
 
 # installing all system dependencies, yq, ruby-build and rbenv
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends uuid-runtime curl ca-certificates git make build-essential libssl-dev libreadline-dev zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -L https://github.com/mikefarah/yq/releases/download/v4.24.2/yq_linux_amd64.tar.gz | tar -xzvf - && mv yq_linux_amd64 /usr/bin/yq && \
-    git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
-    curl -L https://github.com/sstephenson/ruby-build/archive/v20220324.tar.gz | tar -zxvf - -C /tmp/ && \
-    cd /tmp/ruby-build-* && ./install.sh
+    apt-get install --yes --no-install-recommends \
+    uuid-runtime curl ca-certificates git make build-essential \
+    libssl-dev libreadline-dev zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.24.2/yq_linux_amd64.tar.gz | tar -xzvf - && \
+    mv yq_linux_amd64 /usr/bin/yq
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
+    curl -L https://github.com/sstephenson/ruby-build/archive/v20231114.tar.gz | tar -zxvf - -C /tmp/ && \
+    cd /tmp/ruby-build-* && \
+    ./install.sh
 
 # set the env
 ENV PATH /root/.rbenv/bin:/root/.rbenv/shims:$PATH
 RUN echo 'eval "$(rbenv init -)"' >> .bashrc
-RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh # or /etc/profile
+RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
 
 # run the make file to install the app
-RUN make install
+# override CFLAGS because -w (warning suppression) screws up ruby-build in newer versions
+# when compiling ruby 2.6.x, *but* we need newer ruby-build to compile older openssl
+# on newer Ubuntu releases
+RUN make install RUBY_CFLAGS=''
 
 CMD ["/bin/bash", "script/run_in_docker.sh"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ PLATFORMS
   universal-java-11
   x86-mingw32
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 6.1.7.3)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 YQ ?= "yq"
+RUBY_CFLAGS ?= -w
 .phony: test ftest lint autocorrect update_config autocorrect-unsafe install build-docker run-docker exec_app tag exec_cli
 .phony: build_utility build_service release_utility_dev release_service_dev release_utility release_service build_utility_gem build_service_gem
 
@@ -67,7 +68,7 @@ push_gem:
 	bundle _$(shell cat .bundler-version)_ exec gem push .gems/*
 
 install:
-	RUBY_CFLAGS="-w" rbenv install -s
+	RUBY_CFLAGS="$(RUBY_CFLAGS)" rbenv install -s
 	- gem install bundler -v $(shell cat .bundler-version) && rbenv rehash
 	bundle _$(shell cat .bundler-version)_ install --jobs 1
 


### PR DESCRIPTION
Bump Dockerfile to use `ubuntu:mantic-20231011` for its base image to reduce the number of vulnerable libraries/packages installed with the image.

Note: This relates to an internal developer productivity issue; I will link this issue from there.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## For Elastic Internal Use Only
- [x] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [x] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] Built gems (both `connectors_utility` and `connectors_service`) and included into Enterprise Search and tested that Enterprise Search works well with new gem versions. Instruction can be found [here](https://docs.google.com/document/d/10KJOIhe4sauDul8iWeV9Cn-_3uPWa76qG8SwYk6BCAA/edit)
