### PR TITLE
[8.3] Add Primary Buildkite Pipeline Migration (#571)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,11 +13,3 @@ steps:
   - label: ":wrench: Linter"
     commands:
       - ".buildkite/scripts/run_command.sh linter"
-  - label: ":package: Docker"
-    commands:
-      - ".buildkite/scripts/run_command.sh docker"
-  - label: ":package: Packaging"
-    commands:
-      - ".buildkite/scripts/run_command.sh packaging"
-    artifact_paths:
-      - ".gems/*.gem"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,23 @@
+agents:
+  provider: "gcp"
+  machineType: "n1-standard-8"
+
+defaultTimeoutInMinutes: 45
+
+steps:
+  - label: ":safety_vest: Connectors Tests"
+    commands:
+      - ".buildkite/scripts/run_command.sh tests"
+    artifact_paths:
+      - "coverage/index.html"
+  - label: ":wrench: Linter"
+    commands:
+      - ".buildkite/scripts/run_command.sh linter"
+  - label: ":package: Docker"
+    commands:
+      - ".buildkite/scripts/run_command.sh docker"
+  - label: ":package: Packaging"
+    commands:
+      - ".buildkite/scripts/run_command.sh packaging"
+    artifact_paths:
+      - ".gems/*.gem"

--- a/.buildkite/scripts/run_ci_step.sh
+++ b/.buildkite/scripts/run_ci_step.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+export PATH="$PATH:/root/.rbenv/bin:/root/.rbenv/plugins/ruby-build/bin:/ci/.rbenv/shims"
+
+RUBY_VERSION=$(cat .ruby-version)
+echo "---- installing Ruby version $RUBY_VERSION"
+rbenv install $RUBY_VERSION
+rbenv global $RUBY_VERSION
+
+case $1 in
+
+  tests)
+    echo "---- running unit tests"
+    make install test
+    ;;
+
+  linter)
+    echo "---- running linter"
+    make install lint
+    ;;
+
+  packaging)
+    echo "---- running packaging"
+    git config --global --add safe.directory '*'
+    git config --global --add safe.directory /ci
+    curl -L -o yq https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_amd64
+    chmod +x yq
+    YQ=`realpath yq` make install build_service build_service_gem
+    gem install .gems/connectors_service-8.*
+    ;;
+
+  *)
+    echo "Usage: run_command {tests|linter|packaging}"
+    exit 2
+    ;;
+esac

--- a/.buildkite/scripts/run_command.sh
+++ b/.buildkite/scripts/run_command.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+COMMAND_TO_RUN=${1:-}
+
+if [[ "${COMMAND_TO_RUN:-}" == "" ]]; then
+    echo "Usage: run_command.sh {tests|linter|docker|packaging}"
+    exit 2
+fi
+
+function realpath {
+  echo "$(cd "$(dirname "$1")"; pwd)"/"$(basename "$1")";
+}
+
+SCRIPT_WORKING_DIR=$(realpath "$(dirname "$0")")
+BUILDKITE_DIR=$(realpath "$(dirname "$SCRIPT_WORKING_DIR")")
+PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
+
+if [[ "${COMMAND_TO_RUN:-}" == "docker" ]]; then
+  echo "running docker build"
+  make build-docker
+else
+  DOCKER_IMAGE="docker.elastic.co/ci-agent-images/enterprise-search/rbenv-buildkite-agent:latest"
+  SCRIPT_CMD="/ci/.buildkite/scripts/run_ci_step.sh"
+
+  docker run --interactive --rm             \
+              --sig-proxy=true --init      \
+              --user "root"                \
+              --volume "$PROJECT_ROOT:/ci" \
+              --workdir /ci                \
+              --env HOME=/ci               \
+              --env CI                     \
+              --env GIT_REVISION=${BUILDKITE_COMMIT-}        \
+              --env BUILD_ID=${BUILDKITE_BUILD_NUMBER-}      \
+              --entrypoint "${SCRIPT_CMD}" \
+              $DOCKER_IMAGE                \
+              $COMMAND_TO_RUN
+fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add Primary Buildkite Pipeline Migration (#571)](https://github.com/elastic/connectors-ruby/pull/571)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)