### PR TITLE
Update the ubuntu base image to noble-20241118.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:mantic-20231011
+FROM ubuntu:noble-20241118.1
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
The original base image was EOLed on Jul 2024, causing the Docker build in CI failed (because EOLed repositories are moved to `old-releases.ubuntu.com`)

https://github.com/elastic/connectors-ruby/blob/255cf4ce4133e30ead41a58c2be9bed734451850/Dockerfile#L1

This PR updates the base image to the latest `noble-20241118.1`.