### PR TITLE
chore: delete SECURITY.md to use organization-wide policy

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,6 +1,0 @@
-# Security Policy
-
-Thanks for your interest in the security of our products. Our security policy can be found at [https://www.elastic.co/community/security](https://www.elastic.co/community/security).
-
-## Reporting a Vulnerability
-Please send security vulnerability reports to security@elastic.co.


### PR DESCRIPTION
This PR deletes the repository-specific SECURITY.md file to consolidate to a single source of truth for the security policy, which is https://github.com/elastic/.github/blob/main/SECURITY.md.